### PR TITLE
fix(sdk): reject empty notification tokens

### DIFF
--- a/crates/gjc-sdk/src/server.rs
+++ b/crates/gjc-sdk/src/server.rs
@@ -1588,8 +1588,15 @@ impl Drop for ServerHandle {
 /// reflects the real (possibly ephemeral) port.
 ///
 /// # Errors
-/// Returns the bind error if the loopback socket cannot be acquired.
+/// Returns [`std::io::ErrorKind::InvalidInput`] when the session token is
+/// empty, or the bind error if the loopback socket cannot be acquired.
 pub async fn start(config: ServerConfig) -> std::io::Result<ServerHandle> {
+	if config.token.is_empty() {
+		return Err(std::io::Error::new(
+			std::io::ErrorKind::InvalidInput,
+			"notification server token must not be empty",
+		));
+	}
 	let listener = TcpListener::bind(SocketAddr::new(config.host, config.port)).await?;
 	let addr = listener.local_addr()?;
 	let (tx, _rx) = broadcast::channel(256);
@@ -2948,6 +2955,78 @@ mod tests {
 		assert_ne!(handle.addr().port(), 0);
 		assert!(handle.addr().ip().is_loopback());
 		handle.stop();
+	}
+
+	#[tokio::test]
+	async fn start_rejects_empty_token_before_endpoint_publication() {
+		let root = std::env::temp_dir().join(format!(
+			"gjc-empty-token-{}-{}",
+			std::process::id(),
+			std::time::SystemTime::now()
+				.duration_since(std::time::UNIX_EPOCH)
+				.unwrap()
+				.as_nanos()
+		));
+		std::fs::create_dir_all(&root).unwrap();
+		let mut config = ServerConfig::new("empty-token", "");
+		config.state_root = Some(root.clone());
+		let occupied = TcpListener::bind(SocketAddr::new(config.host, 0))
+			.await
+			.unwrap();
+		config.port = occupied.local_addr().unwrap().port();
+
+		let error = match start(config).await {
+			Ok(handle) => {
+				handle.stop_and_wait().await;
+				panic!("empty token unexpectedly started a server");
+			},
+			Err(error) => error,
+		};
+		assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+		assert_eq!(error.to_string(), "notification server token must not be empty");
+		assert!(
+			!crate::discovery::endpoint_path(&root, "empty-token").exists(),
+			"rejected startup must not publish endpoint discovery"
+		);
+		drop(occupied);
+		std::fs::remove_dir_all(&root).ok();
+	}
+
+	#[tokio::test]
+	async fn nonempty_opaque_and_whitespace_tokens_remain_valid_startup_inputs() {
+		let opaque = "opaque._~-token";
+		let opaque_handle = start(ServerConfig::new("opaque", opaque)).await.unwrap();
+		let mut ws = connect(&opaque_handle, opaque).await;
+		assert!(matches!(next_server_msg(&mut ws).await, ServerMessage::Hello(_)));
+		ws.close(None).await.unwrap();
+		opaque_handle.stop_and_wait().await;
+
+		let whitespace = " \t ";
+		// The query parser intentionally does not percent-decode because production
+		// tokens are URL-safe. Exercise its no-trim contract directly so startup
+		// continues to preserve every nonempty opaque value.
+		assert!(
+			token_from_query(Some("token= \t "))
+				.is_some_and(|candidate| tokens_match(candidate.as_str(), whitespace))
+		);
+		let whitespace_handle = start(ServerConfig::new("whitespace", whitespace))
+			.await
+			.unwrap();
+		assert_ne!(whitespace_handle.addr().port(), 0);
+		whitespace_handle.stop_and_wait().await;
+	}
+
+	#[tokio::test]
+	async fn nonempty_token_rejects_missing_empty_and_wrong_query_credentials() {
+		let handle = start(ServerConfig::new("s", "secret")).await.unwrap();
+		for path in ["/", "/?token=", "/?token=wrong"] {
+			let url = format!("ws://{}{}", handle.addr(), path);
+			assert!(connect_async(url).await.is_err(), "credential {path:?} was accepted");
+		}
+		let mut ws = connect(&handle, "secret").await;
+		assert!(matches!(next_server_msg(&mut ws).await, ServerMessage::Hello(_)));
+		ws.close(None).await.unwrap();
+		handle.stop_and_wait().await;
 	}
 
 	#[tokio::test]

--- a/packages/coding-agent/test/sdk-napi-empty-token.test.ts
+++ b/packages/coding-agent/test/sdk-napi-empty-token.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { NotificationServer } from "../../natives/native/index.js";
+
+async function open(endpoint: string, token: string): Promise<WebSocket> {
+	const ws = new WebSocket(`${endpoint}/?token=${token}`);
+	const { promise, resolve, reject } = Promise.withResolvers<void>();
+	ws.addEventListener("open", () => resolve(), { once: true });
+	ws.addEventListener("error", () => reject(new Error("websocket connection failed")), { once: true });
+	await promise;
+	return ws;
+}
+
+test("compiled NotificationServer rejects an empty token without publishing an endpoint", async () => {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-sdk-empty-token-"));
+	const rejectedSessionId = `empty-${process.pid}-${Date.now()}`;
+	const rejectedEndpoint = path.join(root, "sdk", `${rejectedSessionId}.json`);
+	const rejected = new NotificationServer(rejectedSessionId, "", root, true);
+	const ordinarySessionId = `ordinary-${process.pid}-${Date.now()}`;
+	const ordinaryToken = "ordinary-opaque-token";
+	const ordinary = new NotificationServer(ordinarySessionId, ordinaryToken, root, true);
+	let ws: WebSocket | undefined;
+
+	try {
+		await expect(rejected.start()).rejects.toThrow("bind failed: notification server token must not be empty");
+		await expect(fs.stat(rejectedEndpoint)).rejects.toMatchObject({ code: "ENOENT" });
+
+		const endpoint = await ordinary.start();
+		ws = await open(endpoint.url, ordinaryToken);
+		expect(endpoint.sessionId).toBe(ordinarySessionId);
+		expect(endpoint.port).toBeGreaterThan(0);
+	} finally {
+		ws?.close();
+		await rejected.stopAndWait();
+		await ordinary.stopAndWait();
+		await fs.rm(root, { recursive: true, force: true });
+	}
+});

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Notification server startup now rejects an empty session token before binding or publishing endpoint discovery, while preserving every nonempty opaque token.
+
 ## [0.16.0] - 2026-09-02
 
 - Added exact-identity detached cleanup export for safely removing stale claim files without following replacement paths or retaining the JavaScript lifecycle; cleanup dispatch uses a bounded native worker queue and reports queue admission so callers can retry saturation.


### PR DESCRIPTION
## Finding / reproduction

The SDK notification server accepted an exactly empty configured token. Because authentication compares the supplied and expected token values, an empty query credential could satisfy an empty shared secret.

On current `dev`, the compiled N-API regression starts instead of rejecting (**0 pass / 1 fail**). The affected boundary is notification-server startup before socket binding and endpoint publication.

## Root cause

The authoritative Rust `start()` path validated address and filesystem state but did not reject a zero-length shared secret before `TcpListener::bind`. Later WebSocket authentication correctly compared credentials, but equality is not an authentication invariant when the configured secret is empty.

## Change

- `crates/gjc-sdk/src/server.rs`: reject exactly empty notification tokens with `InvalidInput` before bind, endpoint serialization/publication, state construction, or accept-task spawn; add Rust boundary coverage for validation precedence and nonempty opaque-token compatibility.
- `packages/coding-agent/test/sdk-napi-empty-token.test.ts`: exercise the compiled N-API server, assert rejection/no endpoint publication, and prove ordinary nonempty-token connectivity and cleanup.
- `packages/natives/CHANGELOG.md`: record this user-visible validation in the current Unreleased section.

## Scope

- Changed files: 3
- Production additions/deletions: +80/-1 (includes colocated Rust unit coverage)
- Test additions/deletions: +40/-0
- Generated/docs/changelog: changelog +4/-0; generated/docs none
- One finding and one startup/authentication trust boundary only.

## Contract

- Preserved: every nonempty opaque token, including whitespace-only values; public API signatures; N-API error wrapping; endpoint format; bind/listen/connect/stop behavior.
- Intentional change: exactly empty tokens now fail before any listener or endpoint record can exist.
- No storage-format or capability change. Authenticated maintainer approval remains required for this security-sensitive patch.

## Verification

- Base SHA: `e8ef1bb91ba0f4db4f5ac6b07aa6c59e62591723`
- Head SHA: `e359341fb62871bd51a042f40b1475d641bc72b1`
- Red-on-base: compiled N-API regression, 0 pass / 1 fail (startup unexpectedly resolved)
- Focused tests: compiled N-API 1/0/4 assertions; focused Rust boundary tests passed
- Affected package suite: `cargo test -p gjc-sdk` 159/0; natives 147/0 with 69 platform skips
- Type/lint/check: natives check passed; coding-agent check/typecheck passed; targeted Biome passed; `cargo clippy -p gjc-sdk --lib -- -D warnings` passed
- Build/binary/Rust: native addon build passed; coding-agent compiled build passed; `gjc/0.16.0` and `--smoke-test` passed
- Generated/public gates: signatures unchanged, so native declarations were not regenerated
- `git diff --check`: passed

## Overlap and integration

- This updates existing PR #5147 in place; no duplicate was opened.
- #4784 shares only `packages/natives/CHANGELOG.md`; pairwise merge-tree is clean (`313c9e8c…`).
- #5074 also shares only the changelog. Its unrelated natives/coding-agent conflicts reproduce against current `dev`; this candidate does not cause or worsen them.
- Current-base merge-tree is clean, tree `45d00cd68aa8d6fbe42f4cbfdd1d5dc9662164ce`.

## Known limits / non-goals

- The repository-pinned nightly Rust toolchain is unavailable on this host. Homebrew stable rustfmt cannot honor the repo's nightly-only vendored ignore rules, and stable all-target Clippy exposes existing test-only debt. The production library Clippy gate passed; hosted Rust CI must cover the canonical toolchain.
- Current-base Dev CI is not used as proof for this PR. Fresh hosted checks and authenticated maintainer approval must attach to the exact head above.
- Session-ID publication/storage containment is a separate owner-gated finding and is not mixed into this patch.

## Risk classification

- [ ] `low-risk`
- [ ] `regression-risk`
- [x] `high-risk`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:9b391645810e979bde12152d49f484b5e53f135b49b360157777f50624a4e227 reviewer:human reviewer-id:Yeachan-Heo evidence:https://github.com/Yeachan-Heo/gajae-code/pull/5147#pullrequestreview-5091775979 exact-head approval; targeted Rust and compiled-NAPI verification passed
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken
