### PR TITLE
fix(coding-agent): bound plugin archive expansion

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,8 @@
 	SDK-state guard (`maximum supported version is 1`) is documented as never
 	applying to session-index rows so the #5181 crash class cannot recur.
 
+- GJC plugin TAR/TGZ installs now bound archive input and aggregate gzip expansion before extraction, preventing compressed bundles from exhausting memory while preserving valid concatenated gzip members.
+
 ## [0.16.0] - 2026-09-02
 
 - Added master mode (`gjc --master [--scope repo|pwd|global]`) with authenticated, broker-authoritative child orchestration: `gjc sdk spawn` creates task-seeded children, scoped `gjc sdk search` discovers broker-visible sessions with paginated results, and locator v2 session rows carry canonical cwd, worktree-root, and state-root identity.

--- a/packages/coding-agent/src/extensibility/gjc-plugins/installer.ts
+++ b/packages/coding-agent/src/extensibility/gjc-plugins/installer.ts
@@ -54,6 +54,11 @@ export type GjcBundleTransactionResult =
 const TAR_MAX_FILES = 8192;
 const TAR_MAX_FILE_BYTES = 16 * 1024 * 1024;
 const TAR_MAX_TOTAL_BYTES = 128 * 1024 * 1024;
+// Preserve the existing aggregate file budget plus the maximum per-entry
+// header/padding overhead and the two terminating TAR blocks.
+const TAR_MAX_ARCHIVE_BYTES = TAR_MAX_TOTAL_BYTES + TAR_MAX_FILES * 1024 + 1024;
+// A gzip stream can be slightly larger than its incompressible TAR payload.
+const TAR_MAX_COMPRESSED_BYTES = TAR_MAX_ARCHIVE_BYTES + 1024 * 1024;
 
 function scopeRoot(scope: GjcPluginScope, cwd: string): string {
 	return scope === "user" ? gjcPluginUserRoot() : gjcPluginProjectRoot(cwd);
@@ -93,6 +98,45 @@ export class GjcPluginSourceUnavailableError extends Error {
 		super("GJC plugin source is unavailable");
 		this.name = "GjcPluginSourceUnavailableError";
 	}
+}
+
+async function readTarballInput(tarPath: string, maxBytes: number): Promise<Buffer> {
+	let file: fs.FileHandle;
+	try {
+		file = await fs.open(tarPath, "r");
+	} catch {
+		throw new GjcPluginSourceUnavailableError();
+	}
+	try {
+		const stat = await file.stat();
+		if (!stat.isFile()) throw new GjcPluginSourceUnavailableError();
+		if (stat.size > maxBytes) {
+			throw new GjcPluginLoadError("security_policy", "GJC plugin tarball exceeds the archive input limit");
+		}
+		const raw = Buffer.allocUnsafe(stat.size);
+		let offset = 0;
+		while (offset < raw.byteLength) {
+			const { bytesRead } = await file.read(raw, offset, raw.byteLength - offset, offset);
+			if (bytesRead === 0) {
+				throw new GjcPluginLoadError("security_policy", "GJC plugin tarball changed while being read");
+			}
+			offset += bytesRead;
+		}
+		const probe = Buffer.allocUnsafe(1);
+		if ((await file.read(probe, 0, 1, offset)).bytesRead !== 0) {
+			throw new GjcPluginLoadError("security_policy", "GJC plugin tarball changed while being read");
+		}
+		return raw;
+	} catch (error) {
+		if (error instanceof GjcPluginLoadError || error instanceof GjcPluginSourceUnavailableError) throw error;
+		throw new GjcPluginSourceUnavailableError();
+	} finally {
+		await file.close().catch(() => {});
+	}
+}
+
+function isGunzipOutputLimitError(error: unknown): boolean {
+	return typeof error === "object" && error !== null && "code" in error && error.code === "ERR_BUFFER_TOO_LARGE";
 }
 
 interface ResolvedSource {
@@ -136,19 +180,15 @@ function tarHeaderChecksumOk(header: Uint8Array): boolean {
 
 /** Minimal, traversal/symlink-safe, resource-bounded extraction of a tar(.gz). */
 async function extractTarball(tarPath: string, destRoot: string): Promise<void> {
-	// A missing or corrupt archive surfaces as a native fs/zlib error. Translate
-	// it here so callers see the same typed source failure they get for every
-	// other unreachable source, instead of a raw errno escaping the lifecycle.
-	let raw: Buffer;
-	try {
-		raw = await fs.readFile(tarPath);
-	} catch {
-		throw new GjcPluginSourceUnavailableError();
-	}
+	const isGzip = /\.(tgz|tar\.gz)$/i.test(tarPath);
+	const raw = await readTarballInput(tarPath, isGzip ? TAR_MAX_COMPRESSED_BYTES : TAR_MAX_ARCHIVE_BYTES);
 	let buf: Buffer;
 	try {
-		buf = /\.(tgz|tar\.gz)$/i.test(tarPath) ? gunzipSync(raw) : raw;
-	} catch {
+		buf = isGzip ? gunzipSync(raw, { maxOutputLength: TAR_MAX_ARCHIVE_BYTES }) : raw;
+	} catch (error) {
+		if (isGunzipOutputLimitError(error)) {
+			throw new GjcPluginLoadError("security_policy", "GJC plugin tarball exceeds the expansion limit");
+		}
 		throw new GjcPluginLoadError("invalid_manifest", "GJC plugin tarball could not be decompressed");
 	}
 	const resolvedRoot = path.resolve(destRoot);

--- a/packages/coding-agent/test/gjc-plugin-m2-redteam.test.ts
+++ b/packages/coding-agent/test/gjc-plugin-m2-redteam.test.ts
@@ -1,8 +1,11 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { createWriteStream } from "node:fs";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { gzipSync } from "node:zlib";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import { createGzip, gzipSync } from "node:zlib";
 import {
 	applyGjcBundleUpdate,
 	bundleIdentity,
@@ -22,6 +25,8 @@ const fixtureFiles = [
 	"prompts/system-appendix.md",
 	"prompts/executor-appendix.md",
 ];
+const TAR_TEST_ARCHIVE_LIMIT = 128 * 1024 * 1024 + 8192 * 1024 + 1024;
+const TAR_TEST_COMPRESSED_LIMIT = TAR_TEST_ARCHIVE_LIMIT + 1024 * 1024;
 
 afterEach(async () => {
 	for (const dir of tempDirs.splice(0)) {
@@ -125,6 +130,41 @@ async function validBundleTarball(options: { prefix?: string; gzip?: boolean } =
 	return await writeTarball(entries, { gzip: options.gzip });
 }
 
+async function validConcatenatedGzipTarball(): Promise<string> {
+	const entries: TarEntry[] = [];
+	for (const rel of fixtureFiles) {
+		entries.push({ name: rel, data: await fs.readFile(path.join(fixtureRoot, rel)) });
+	}
+	const tar = makeTar(entries);
+	const split = Math.floor(tar.byteLength / 2);
+	const dir = await mkTempDir("gjc-m2-redteam-concatenated-gzip-");
+	const file = path.join(dir, "bundle.tgz");
+	await fs.writeFile(file, Buffer.concat([gzipSync(tar.subarray(0, split)), gzipSync(tar.subarray(split))]));
+	return file;
+}
+
+async function writeGzipExpansionMembers(memberBytes: readonly number[]): Promise<string> {
+	const dir = await mkTempDir("gjc-m2-redteam-gzip-expansion-");
+	const file = path.join(dir, "bundle.tgz");
+	const chunk = Buffer.alloc(1024 * 1024);
+	async function* chunks(bytes: number): AsyncGenerator<Buffer> {
+		let remaining = bytes;
+		while (remaining > 0) {
+			const length = Math.min(remaining, chunk.byteLength);
+			yield length === chunk.byteLength ? chunk : chunk.subarray(0, length);
+			remaining -= length;
+		}
+	}
+	for (const bytes of memberBytes) {
+		await pipeline(Readable.from(chunks(bytes)), createGzip(), createWriteStream(file, { flags: "a" }));
+	}
+	return file;
+}
+
+async function writeGzipExpansion(bytes: number): Promise<string> {
+	return writeGzipExpansionMembers([bytes]);
+}
+
 async function makeBundleCopy(name: string, extra?: (dir: string) => Promise<void>): Promise<string> {
 	const dir = await mkTempDir("gjc-m2-redteam-bundle-");
 	await fs.cp(fixtureRoot, dir, { recursive: true });
@@ -196,6 +236,76 @@ describe("GJC plugin installer M2 red-team", () => {
 		expect(await exists(path.join(cwd, ".gjc", "gjc-plugins", "valid-six-surface-bundle", "gajae-plugin.json"))).toBe(
 			true,
 		);
+	});
+
+	test("installs a valid tarball split across concatenated gzip members", async () => {
+		const cwd = await mkProjectCwd();
+		const tarball = await validConcatenatedGzipTarball();
+
+		const result = await installGjcBundle({ cwd }, "project", tarball);
+
+		expect(result).toMatchObject({ ok: true, value: { status: "installed" } });
+		expect((await readRegistry("project", cwd)).plugins.map(plugin => plugin.name)).toEqual([
+			"valid-six-surface-bundle",
+		]);
+	});
+
+	test("rejects aggregate gzip output beyond the tar archive budget", async () => {
+		const cwd = await mkProjectCwd();
+		const tarball = await writeGzipExpansion(TAR_TEST_ARCHIVE_LIMIT + 1);
+
+		await expect(installGjcBundle({ cwd }, "project", tarball)).rejects.toMatchObject({
+			code: "security_policy",
+		});
+		expect(await readRegistry("project", cwd)).toMatchObject({ plugins: [] });
+	});
+
+	test("applies the expansion budget across individually bounded concatenated gzip members", async () => {
+		const cwd = await mkProjectCwd();
+		const memberBytes = Math.floor(TAR_TEST_ARCHIVE_LIMIT / 2) + 1;
+		const tarball = await writeGzipExpansionMembers([memberBytes, memberBytes]);
+
+		await expect(installGjcBundle({ cwd }, "project", tarball)).rejects.toMatchObject({
+			code: "security_policy",
+		});
+		expect(await readRegistry("project", cwd)).toMatchObject({ plugins: [] });
+	});
+
+	test("rejects oversized compressed input before reading the archive", async () => {
+		const cwd = await mkProjectCwd();
+		const dir = await mkTempDir("gjc-m2-redteam-oversized-input-");
+		const tarball = path.join(dir, "bundle.tgz");
+		await fs.writeFile(tarball, "");
+		await fs.truncate(tarball, TAR_TEST_COMPRESSED_LIMIT + 1);
+
+		await expect(installGjcBundle({ cwd }, "project", tarball)).rejects.toMatchObject({
+			code: "security_policy",
+		});
+		expect(await readRegistry("project", cwd)).toMatchObject({ plugins: [] });
+	});
+
+	test("keeps malformed gzip archives classified as invalid manifests", async () => {
+		const cwd = await mkProjectCwd();
+		const dir = await mkTempDir("gjc-m2-redteam-malformed-gzip-");
+		const tarball = path.join(dir, "bundle.tgz");
+		await fs.writeFile(tarball, "not a gzip stream");
+
+		await expect(installGjcBundle({ cwd }, "project", tarball)).rejects.toMatchObject({
+			code: "invalid_manifest",
+		});
+		expect(await readRegistry("project", cwd)).toMatchObject({ plugins: [] });
+	});
+
+	test("keeps truncated gzip members classified as invalid manifests", async () => {
+		const cwd = await mkProjectCwd();
+		const tarball = await writeGzipExpansion(1024);
+		const compressed = await fs.readFile(tarball);
+		await fs.writeFile(tarball, compressed.subarray(0, Math.max(0, compressed.byteLength - 4)));
+
+		await expect(installGjcBundle({ cwd }, "project", tarball)).rejects.toMatchObject({
+			code: "invalid_manifest",
+		});
+		expect(await readRegistry("project", cwd)).toMatchObject({ plugins: [] });
 	});
 
 	test("install of a forbidden-surface bundle leaves no scope files and no registry entry", async () => {


### PR DESCRIPTION
## Finding / reproduction

Plugin TAR/TGZ installation bounded extracted entries only after the entire source archive had been read and, for gzip input, fully decompressed. A small compressed bundle or concatenated gzip members could therefore consume unbounded memory before TAR entry limits ran.

On current `dev`, the real installer regression using two individually-under-limit gzip members whose aggregate expansion exceeds the archive budget is **0 pass / 1 fail**: the archive reaches later parsing and is misclassified as `invalid_manifest` instead of being stopped by `security_policy`.

## Root cause

`extractTarball()` used unbounded `fs.readFile()` and `gunzipSync(raw)`. The enforcement point must be before decompression allocates beyond the aggregate archive budget, not only in the downstream TAR entry loop.

## Change

- `packages/coding-agent/src/extensibility/gjc-plugins/installer.ts`: use a descriptor-bound, size-capped read with grow/shrink detection; apply zlib's aggregate `maxOutputLength` before TAR parsing; preserve typed source, malformed-gzip, and security-policy errors.
- `packages/coding-agent/test/gjc-plugin-m2-redteam.test.ts`: cover compressed input size, single- and multi-member aggregate expansion, valid concatenated members, malformed/truncated gzip, and absence of install/registry mutation.
- `packages/coding-agent/CHANGELOG.md`: record the archive resource-boundary hardening.

## Scope

- Changed files: 3
- Production additions/deletions: +51/-11
- Test additions/deletions: +111/-1
- Generated/docs/changelog: changelog +2/-0; generated/docs none
- One finding and one plugin archive read/decompression trust boundary only.

## Contract

- Preserved: valid TAR/TGZ installation, concatenated gzip members, existing TAR entry/file/aggregate limits, typed unavailable-source errors, and malformed/truncated gzip as `invalid_manifest`.
- Intentional change: archive input and aggregate gzip output above the existing derived resource budget fail as `security_policy` before extraction.
- No public API, registry schema, configuration, or dependency change. Authenticated maintainer approval remains required.

## Verification

- Base SHA: `57ba67d22fc2713cb9e111beb6c10a28ce902dc2`
- Head SHA: `e998aa36e130dc5518347c9370114aed57be5382`
- Red-on-base: exact current-base multi-member real installer regression, 0/1 (`invalid_manifest` instead of `security_policy`)
- Focused tests: M2 red-team 14/0/39 assertions; exact multi-member head probe 1/0
- Affected package suite: all GJC plugin tests 298/0/1,458 assertions
- Type/lint/check: coding-agent check/typecheck passed; targeted Biome passed; runtime/generated checks passed (nine unrelated repository warnings only)
- Build/binary/Rust: native build and coding-agent compiled build passed; `gjc/0.16.0` and binary smoke passed; no Rust source changed
- Generated/public gates: runtime/generated checks passed; no generated/public signature change
- `git diff --check`: passed

## Overlap and integration

- This updates existing PR #5148 in place; no duplicate was opened.
- #4784 is the only production-file overlap (`installer.ts`) but changes agent-directory/profile authority, not archive parsing. Pairwise merge-tree is clean (`cf68f6e…`), and combined M2 integration is 12/0 on the pre-review head; production bytes are unchanged on this head.
- #5188 and all other live changelog-only overlaps auto-merge after moving this unchanged note behind stable current-dev entries.
- #5074/#5027 conflicts reproduce unchanged against current `dev` and are unrelated.
- Current-dev merge-tree is clean, tree `7a0b7a4764cb6e21050a1e624f7343e44c33e4c3`.

## Known limits / non-goals

- Hosted CI and authenticated maintainer approval must attach to the exact head above; results on the replaced head are not evidence.
- Current `dev` advanced after the implementation commit, but the installer and owning test blobs are byte-identical and current-dev integration is clean; no unnecessary rebase was performed.
- This does not redesign streaming extraction or change the existing per-entry TAR policy.

## Risk classification

- [ ] `low-risk`
- [ ] `regression-risk`
- [x] `high-risk`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:30b484e3c1d0fbd99c4fc477c4dfd72a702986ff7195f3d8e56642d9ca282fad reviewer:human reviewer-id:Yeachan-Heo evidence:exact-head e894a636834b4a699c5f08e1f731aca2a2af2acd rebased onto current dev; authenticated APPROVED review from repo owner distinct from PR author; gjc-plugin-m2-redteam.test.ts 14/0/39 and gjc-plugin-installer.test.ts 9/0/64 passing; verify-gjc-state-writers --fail clean
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken

