### PR TITLE
fix(ai): escape OAuth callback script data

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - Cursor sessions now report prompt tokens instead of zero. `ConversationTokenDetails.used_tokens` counts the whole conversation, but the checkpoint handler assigned it to `usage.output` and returned early whenever token deltas had been seen — which is the normal streaming path — so `usage.input`, `usage.cacheRead`, and `usage.cacheWrite` were left at their zero initializers for every cursor request. `calculatePromptTokens` therefore fell through to its output-only fallback, so the context indicator tracked the last response's output size rather than the conversation, and automatic compaction never observed a full context. Conversation usage is now recorded through the stream and split into prompt and output tokens when the stream finalizes.
 
+- OAuth callback responses now serialize provider-controlled result fields as safe JSON script data, preventing callback values from terminating the embedded state element while preserving exact JSON values and callback behavior.
 
 ## [0.16.0] - 2026-09-02
 

--- a/packages/ai/src/utils/oauth/callback-server.ts
+++ b/packages/ai/src/utils/oauth/callback-server.ts
@@ -19,6 +19,13 @@ const DEFAULT_TIMEOUT = 300_000;
 const DEFAULT_HOSTNAME = "localhost";
 const CALLBACK_PATH = "/callback";
 
+function serializeScriptData(value: unknown): string {
+	return JSON.stringify(value)
+		.replaceAll("<", "\\u003c")
+		.replaceAll("\u2028", "\\u2028")
+		.replaceAll("\u2029", "\\u2029");
+}
+
 export type CallbackResult = { code: string; state: string };
 
 export interface OAuthCallbackFlowOptions {
@@ -259,7 +266,7 @@ export abstract class OAuthCallbackFlow {
 		});
 
 		return new Response(
-			(templateHtml as unknown as string).replaceAll("__OAUTH_STATE__", JSON.stringify(resultState)),
+			(templateHtml as unknown as string).replaceAll("__OAUTH_STATE__", () => serializeScriptData(resultState)),
 			{
 				status: resultState.ok ? 200 : 500,
 				headers: { "Content-Type": "text/html" },

--- a/packages/ai/test/callback-server-script-data.test.ts
+++ b/packages/ai/test/callback-server-script-data.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from "bun:test";
+import { parseHTML } from "linkedom";
+import { OAuthCallbackFlow, type OAuthCallbackFlowOptions } from "../src/utils/oauth/callback-server";
+import templateHtml from "../src/utils/oauth/oauth.html" with { type: "text" };
+import type { OAuthCredentials } from "../src/utils/oauth/types";
+
+const EXPECTED_STATE = "expected-state";
+const TEMPLATE_HTML = templateHtml as unknown as string;
+
+class TestCallbackFlow extends OAuthCallbackFlow {
+	constructor(port: number, options: Partial<OAuthCallbackFlowOptions> = {}) {
+		const flowOptions: OAuthCallbackFlowOptions = {
+			preferredPort: port,
+			callbackHostname: "127.0.0.1",
+			callbackBindHostname: "127.0.0.1",
+			...options,
+		};
+		const authUrl = Promise.withResolvers<string>();
+		super({ onAuth: ({ url }) => authUrl.resolve(url) }, flowOptions);
+		this.authUrl = authUrl.promise;
+	}
+
+	readonly authUrl: Promise<string>;
+
+	override generateState(): string {
+		return EXPECTED_STATE;
+	}
+
+	async generateAuthUrl(_state: string, redirectUri: string): Promise<{ url: string }> {
+		return { url: redirectUri };
+	}
+
+	async exchangeToken(code: string): Promise<OAuthCredentials> {
+		return { access: `access-${code}`, refresh: "refresh-token", expires: 1 };
+	}
+}
+
+async function availablePort(): Promise<number> {
+	const server = Bun.serve({ hostname: "127.0.0.1", port: 0, fetch: () => new Response() });
+	const port = server.port;
+	server.stop(true);
+	if (port === undefined) throw new Error("Bun did not assign a loopback port");
+	return port;
+}
+
+function readServerState(html: string): Record<string, unknown> {
+	const document = parseHTML(html).document;
+	const serverStates = document.querySelectorAll('script#server-state[type="application/json"]');
+	expect(serverStates).toHaveLength(1);
+	expect(document.querySelectorAll("script")).toHaveLength(TEMPLATE_HTML.match(/<script(?:\s|>)/g)?.length ?? 0);
+	expect(html.match(/<script(?:\s|>)/g)).toHaveLength(TEMPLATE_HTML.match(/<script(?:\s|>)/g)?.length ?? 0);
+	expect(html.match(/<\/script>/g)).toHaveLength(TEMPLATE_HTML.match(/<\/script>/g)?.length ?? 0);
+	expect(document.querySelector("[data-marker='GJC_SCRIPT_DATA_MARKER']")).toBeNull();
+	return JSON.parse(serverStates[0]?.textContent ?? "") as Record<string, unknown>;
+}
+
+async function runCallback(
+	params: URLSearchParams,
+	options: Partial<OAuthCallbackFlowOptions> = {},
+): Promise<{ response: Response; html: string; outcome: OAuthCredentials | Error }> {
+	const flow = new TestCallbackFlow(await availablePort(), options);
+	const login = flow.login().catch((error: unknown) => (error instanceof Error ? error : new Error(String(error))));
+	const callbackUrl = new URL(await flow.authUrl);
+	callbackUrl.search = params.toString();
+	const response = await fetch(callbackUrl);
+	const html = await response.text();
+	const outcome = await login;
+	return { response, html, outcome };
+}
+
+describe("OAuthCallbackFlow callback script data", () => {
+	it.each([
+		"</script>",
+		"</SCRIPT>",
+		"</ScRiPt>",
+	])("keeps the %s terminator inside exact error JSON data", async terminator => {
+		const injected = `${terminator}<script data-marker=GJC_SCRIPT_DATA_MARKER>GJC_INJECTED_SCRIPT_NODE</script>`;
+		const { response, html, outcome } = await runCallback(
+			new URLSearchParams({ error: "access_denied", error_description: injected }),
+		);
+
+		expect(response.status).toBe(500);
+		expect(response.headers.get("content-type")).toBe("text/html");
+		expect(html).not.toContain("<script data-marker=GJC_SCRIPT_DATA_MARKER>");
+		expect(html).toContain(`${terminator.replace("<", "\\u003c")}\\u003cscript data-marker=GJC_SCRIPT_DATA_MARKER>`);
+		expect(readServerState(html)).toEqual({ ok: false, error: `Authorization failed: ${injected}` });
+		expect(outcome).toBeInstanceOf(Error);
+		expect((outcome as Error).message).toBe(`Authorization failed: ${injected}`);
+	});
+
+	it("escapes JavaScript line separators without changing provider-controlled values", async () => {
+		const injected = "before\u2028middle\u2029after";
+		const { response, html, outcome } = await runCallback(
+			new URLSearchParams({ error: "access_denied", error_description: injected }),
+		);
+
+		expect(response.status).toBe(500);
+		expect(response.headers.get("content-type")).toBe("text/html");
+		expect(html).not.toContain("\u2028");
+		expect(html).not.toContain("\u2029");
+		expect(html).toContain("before\\u2028middle\\u2029after");
+		expect(readServerState(html)).toEqual({ ok: false, error: `Authorization failed: ${injected}` });
+		expect(outcome).toBeInstanceOf(Error);
+		expect((outcome as Error).message).toBe(`Authorization failed: ${injected}`);
+	});
+
+	it.each([
+		["matched substring", "$&"],
+		["literal dollar", "$$"],
+		["prefix", "$`"],
+		["suffix", "$'"],
+	])("keeps replacement metasequence %s as exact JSON data", async (_name, metasequence) => {
+		const injected = `${metasequence}</ScRiPt><script data-marker=GJC_SCRIPT_DATA_MARKER>GJC_INJECTED_SCRIPT_NODE</script>`;
+		const { response, html, outcome } = await runCallback(
+			new URLSearchParams({ error: "access_denied", error_description: injected }),
+		);
+
+		expect(response.status).toBe(500);
+		expect(response.headers.get("content-type")).toBe("text/html");
+		expect(html).not.toContain("<script data-marker=GJC_SCRIPT_DATA_MARKER>");
+		expect(readServerState(html)).toEqual({ ok: false, error: `Authorization failed: ${injected}` });
+		expect(outcome).toBeInstanceOf(Error);
+		expect((outcome as Error).message).toBe(`Authorization failed: ${injected}`);
+	});
+
+	it.each([
+		{
+			name: "ordinary provider error",
+			params: new URLSearchParams({ error: "access_denied", error_description: "The user denied access" }),
+			state: { ok: false, error: "Authorization failed: The user denied access" },
+			message: "Authorization failed: The user denied access",
+		},
+		{
+			name: "missing authorization code",
+			params: new URLSearchParams({ state: EXPECTED_STATE }),
+			state: { ok: false, error: "Missing authorization code" },
+			message: "Missing authorization code",
+		},
+		{
+			name: "empty authorization code",
+			params: new URLSearchParams({ code: "", state: EXPECTED_STATE }),
+			state: { ok: false, error: "Missing authorization code" },
+			message: "Missing authorization code",
+		},
+		{
+			name: "state mismatch",
+			params: new URLSearchParams({ code: "auth-code", state: "wrong-state" }),
+			state: { ok: false, error: "State mismatch - possible CSRF attack" },
+			message: "State mismatch - possible CSRF attack",
+		},
+	])("preserves the $name response contract", async ({ params, state, message }) => {
+		const { response, html, outcome } = await runCallback(params);
+
+		expect(response.status).toBe(500);
+		expect(readServerState(html)).toEqual(state);
+		expect(outcome).toBeInstanceOf(Error);
+		expect((outcome as Error).message).toBe(message);
+	});
+
+	it("preserves issuer validation precedence and generic failure text", async () => {
+		const { response, html, outcome } = await runCallback(
+			new URLSearchParams({
+				code: "auth-code",
+				state: EXPECTED_STATE,
+				iss: "https://attacker.example",
+				error: "access_denied",
+				error_description: "provider-controlled detail",
+			}),
+			{ expectedIssuer: "https://issuer.example" },
+		);
+
+		expect(response.status).toBe(500);
+		expect(readServerState(html)).toEqual({ ok: false, error: "Authorization response issuer mismatch" });
+		expect(outcome).toBeInstanceOf(Error);
+		expect((outcome as Error).message).toBe("Authorization response issuer mismatch");
+	});
+
+	it("preserves the required issuer failure when iss is missing", async () => {
+		const { response, html, outcome } = await runCallback(
+			new URLSearchParams({ code: "auth-code", state: EXPECTED_STATE }),
+			{ expectedIssuer: "https://issuer.example", issuerResponseIssSupported: true },
+		);
+
+		expect(response.status).toBe(500);
+		expect(readServerState(html)).toEqual({
+			ok: false,
+			error: "Authorization response missing required issuer (iss)",
+		});
+		expect(outcome).toBeInstanceOf(Error);
+		expect((outcome as Error).message).toBe("Authorization response missing required issuer (iss)");
+	});
+
+	it("preserves successful callback status, JSON, and token exchange", async () => {
+		const code = "auth</ScRiPt>code";
+		const { response, html, outcome } = await runCallback(new URLSearchParams({ code, state: EXPECTED_STATE }));
+
+		expect(response.status).toBe(200);
+		expect(html).not.toContain(code);
+		expect(readServerState(html)).toEqual({ ok: true, code, state: EXPECTED_STATE });
+		expect(outcome).toEqual({ access: `access-${code}`, refresh: "refresh-token", expires: 1 });
+	});
+});


### PR DESCRIPTION
## Finding / reproduction

Provider-controlled OAuth callback values were inserted into an HTML `<script type="application/json">` block. On current `dev`, a mixed-case `</script>` terminator creates an attacker-controlled script node, and JavaScript replacement metasequences (`$&`, `$$`, ``$` ``, `$'`) alter the serialized value.

The current-base real-loopback regression produced **6 pass / 6 fail**. Impact is limited to the OAuth callback response's HTML/script-data serialization boundary.

## Root cause

`JSON.stringify()` is valid JSON but does not escape HTML raw-text terminators. The same serialized string was passed as a string replacement value, so `String.replaceAll` applied replacement-string semantics before the browser parsed the response.

The runtime enforcement point is the final callback HTML response construction in `OAuthCallbackFlow.createResponse()`.

## Change

- `packages/ai/src/utils/oauth/callback-server.ts`: serialize JSON with literal `<` escaped as `\u003c`, and insert it through a function replacer so provider data is never interpreted as replacement syntax.
- `packages/ai/test/callback-server-script-data.test.ts`: exercise the real loopback listener and parse the final HTML for hostile error/success values, malformed callback paths, issuer/CSRF ordering, and exact value round-trips.
- `packages/ai/CHANGELOG.md`: record this user-visible callback hardening in the current Unreleased section.

## Scope

- Changed files: 3
- Production additions/deletions: +5/-1
- Test additions/deletions: +182/-0
- Generated/docs/changelog: changelog +2/-0; generated/docs none
- This PR addresses one finding and one final HTML/script-data trust boundary only.

## Contract

- Preserved: callback status codes, result JSON values, token exchange, error text, issuer validation, CSRF/state checks, and public APIs.
- Intentional change: literal `<` is represented as its JSON-equivalent `\u003c` in the embedded script-data bytes; parsed values are unchanged.
- Maintainer approval is still required because this is security-sensitive; no capability or storage-format change is proposed.

## Verification

- Base SHA: `4bab035cd50a4e93cd0a8edde70415431902911d`
- Head SHA: `09ce790b40ede96bc3f99c090711d384d9441990`
- Red-on-base: real loopback copied regression, 6 pass / 6 fail
- Focused tests: callback script-data + adjacent manual callback, 14 pass / 0 fail / 123 assertions
- Affected package suite: full AI attempt reached 2,229 pass / 15 fail / 125 skip before an unrelated hang; all 15 failures are `issue-1934-bedrock-auth` and reproduce 0/15 on the exact base
- Type/lint/check: `bun --cwd=packages/ai run check` passed; targeted Biome passed (two unrelated repository infos only in a different file)
- Build/binary/Rust: native build passed; coding-agent compiled binary build passed; `gjc/0.16.0` and `--smoke-test` passed; no Rust source changed
- Generated/public gates: no generated/public surface changed
- `git diff --check`: passed

## Overlap and integration

- Same finding: this updates existing PR #5149 in place; no duplicate PR was opened.
- Open authored PR #5186 shares only `packages/ai/CHANGELOG.md`; production/test boundaries are independent.
- Pairwise merge-tree with #5186: clean, tree `d0b24aa93f3925d610b00a10e40ff47f28877293`.
- Current-base merge-tree: clean, tree `ff9e567d7357816b186015effbecbeac40ca57ce`.
- Other live AI changelog overlaps auto-merge. Conflicts observed in #5074 also reproduce against current `dev` without this PR and are unrelated.

## Known limits / non-goals

- The full AI package suite did not terminate locally; the observed Bedrock failures are exact-base-equivalent and unrelated to the OAuth callback files.
- Hosted CI and authenticated maintainer approval must attach to the exact head above; checks on the replaced head are not evidence for this head.
- This does not redesign the callback page or alter provider OAuth flows.

## Risk classification

- [ ] `low-risk`
- [ ] `regression-risk`
- [x] `high-risk`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:64b3c3b1fec45bc7672775c066fb6ea27ed88531f0efb597a972cbe543d7e703 reviewer:human reviewer-id:Yeachan-Heo evidence:bun test packages/ai/test/callback-server-script-data.test.ts (15 pass, 0 fail, 156 assertions); independent exact-head source review
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken


