### PR TITLE
fix(coding-agent): separate foreign-workspace runtime markers from unreadable ones

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- A runtime-state marker recorded against a different workspace path now reports that mismatch instead of claiming the file is unreadable, and a terminal, not-live marker that travelled into the current workspace with its session directory is adopted rather than refused. Live, non-terminal, and out-of-workspace markers are still refused untouched.
+
 - Headless SDK substrate close now reports success when exact teardown observes the recorded process gone even if cleanup unlinks the durable proof first; live or identity-ambiguous substrates still report `substrate_mismatch`. (#5130)
 
 - Windows session-state locks now drain late terminal reconciliation writes before disposal returns and safely reclaim valid dead transition claims during resume. (#5102)

--- a/packages/coding-agent/src/gjc-runtime/session-state-sidecar.ts
+++ b/packages/coding-agent/src/gjc-runtime/session-state-sidecar.ts
@@ -1012,6 +1012,65 @@ class PreviousRuntimeStateReadError extends Error {
 	}
 }
 
+/**
+ * A readable, well-formed marker recorded against a different workspace path.
+ *
+ * Separate from {@link PreviousRuntimeStateReadError} because the two demand different
+ * operator responses: an unreadable marker points at file damage, while a foreign marker
+ * points at the same session directory being reachable from two checkouts.
+ */
+class ForeignRuntimeStateError extends Error {
+	readonly recordedCwd: string;
+	readonly currentCwd: string;
+	constructor(previous: Record<string, unknown>, input: RuntimeStateIdentity) {
+		const recorded = typeof previous.cwd === "string" ? previous.cwd : "<unknown>";
+		super(
+			`Existing runtime state marker belongs to a different workspace; refusing to overwrite. ` +
+				`recorded cwd ${recorded}, current cwd ${input.cwd}. ` +
+				`A live or in-flight marker is never adopted; delete it only if no session is running there.`,
+		);
+		this.name = "ForeignRuntimeStateError";
+		this.recordedCwd = recorded;
+		this.currentCwd = input.cwd;
+	}
+}
+
+/**
+ * A foreign marker is adoptable only when every one of these holds:
+ *
+ * - it already reached a terminal state and is explicitly not live, so no owner can still
+ *   be writing to it (`live` must be `false` rather than merely absent: an older or
+ *   truncated marker that omits the field says nothing about whether its owner runs);
+ * - the marker file itself lives inside the current workspace, which is what distinguishes
+ *   a session directory that travelled here with its repository from one that still
+ *   belongs to a different workspace on this machine.
+ *
+ * The second condition is the load-bearing one. Terminal-and-not-live alone would let a
+ * finished `C:\...` session be adopted by a `D:\...` workspace, and those are unrelated
+ * working trees that must never inherit each other's runtime identity.
+ */
+function isAdoptableForeignRuntimeState(
+	previous: Record<string, unknown>,
+	input: RuntimeStateIdentity,
+	stateFile: string | null,
+): boolean {
+	if (previous.live !== false) return false;
+	if (previous.state !== "completed" && previous.state !== "errored") return false;
+	if (!stateFile) return false;
+	return pathIsInside(stateFile, input.cwd, input.platform);
+}
+
+/** True when `candidate` resolves to `root` itself or something beneath it. */
+function pathIsInside(candidate: string, root: string, platform: NodeJS.Platform = process.platform): boolean {
+	if (sameResolvedPath(candidate, root, platform)) return true;
+	const normalizedRoot = normalizePathForComparison(root, platform);
+	const normalizedCandidate = normalizePathForComparison(candidate, platform);
+	if (!normalizedRoot || !normalizedCandidate) return false;
+	const separator = platform === "win32" ? "\\" : "/";
+	const prefix = normalizedRoot.endsWith(separator) ? normalizedRoot : `${normalizedRoot}${separator}`;
+	return normalizedCandidate.startsWith(prefix);
+}
+
 class RuntimeToolActivityRefusedError extends Error {
 	constructor(reason: string) {
 		super(`Refusing to overwrite the coordinator tool-activity snapshot: ${reason}.`);
@@ -1224,7 +1283,11 @@ function shouldPreserveTerminalPayload(previous: RuntimeStateSidecarPayload, inp
 	);
 }
 
-function assertPreviousRuntimeStateIdentity(previous: Record<string, unknown>, input: RuntimeStateIdentity): void {
+function assertPreviousRuntimeStateIdentity(
+	previous: Record<string, unknown>,
+	input: RuntimeStateIdentity,
+	stateFile: string | null = null,
+): void {
 	if (Object.keys(previous).length === 0) return;
 	if (previous.session_id !== input.sessionId) throw new PreviousRuntimeStateReadError();
 	// Signed coordinator mode never trusts an unsigned predecessor. The sole exception
@@ -1261,17 +1324,26 @@ function assertPreviousRuntimeStateIdentity(previous: Record<string, unknown>, i
 	if (coordinatorSeed) return;
 	// If the previous payload has runtime identity fields, verify them fully.
 	if (typeof previous.cwd === "string" && typeof previous.workdir === "string") {
-		if (
-			!sameResolvedPath(previous.cwd, input.cwd, input.platform) ||
-			!sameResolvedPath(previous.workdir, input.cwd, input.platform) ||
-			(previous.session_file !== input.sessionFile &&
-				!(
-					typeof previous.session_file === "string" &&
+		const pathsMatch =
+			sameResolvedPath(previous.cwd, input.cwd, input.platform) &&
+			sameResolvedPath(previous.workdir, input.cwd, input.platform) &&
+			(previous.session_file === input.sessionFile ||
+				(typeof previous.session_file === "string" &&
 					typeof input.sessionFile === "string" &&
-					sameResolvedPath(previous.session_file, input.sessionFile, input.platform)
-				))
-		)
-			throw new PreviousRuntimeStateReadError();
+					sameResolvedPath(previous.session_file, input.sessionFile, input.platform)));
+		if (!pathsMatch) {
+			// A marker whose recorded workspace differs from the current one is readable and
+			// well-formed; it simply belongs to another checkout. Reporting that as a read
+			// failure sends operators hunting for file corruption that does not exist.
+			//
+			// A session directory committed to version control reaches a second machine this
+			// way, so the mismatch is ordinary rather than exceptional. When the recorded
+			// marker is already terminal and not live, nothing can still be writing to it and
+			// adopting it is safe; anything else still refuses, because a live or in-flight
+			// marker from another workspace may have a running owner behind it.
+			if (!isAdoptableForeignRuntimeState(previous, input, stateFile))
+				throw new ForeignRuntimeStateError(previous, input);
+		}
 	}
 }
 
@@ -1723,7 +1795,7 @@ async function persistCoordinatorRuntimeToolActivity(
 						assertNoRuntimeStateRescopeJournal(context, identity);
 						const previous = await readPreviousPayloadForEvent(stateFile);
 						if (Object.keys(previous).length === 0) return;
-						assertPreviousRuntimeStateIdentity(previous, identity);
+						assertPreviousRuntimeStateIdentity(previous, identity, stateFile);
 						// A tool event that lands after the session settled must never
 						// resurrect it into a live-looking state.
 						if (previous.state === "completed" || previous.state === "errored") return;
@@ -1804,7 +1876,7 @@ export async function persistCoordinatorRuntimeStateFromEvent(
 						const nowMs = Date.now();
 						const now = new Date(nowMs).toISOString();
 						const previous = await readPreviousPayloadForEvent(stateFile);
-						assertPreviousRuntimeStateIdentity(previous, identity);
+						assertPreviousRuntimeStateIdentity(previous, identity, stateFile);
 						const finalResponse = finalResponseForEvent(event);
 						const terminalReceipt =
 							state === "completed" || state === "errored"
@@ -1879,7 +1951,7 @@ export async function persistCoordinatorWorkerIntegrationOutcome(
 						assertNoRuntimeStateRescopeJournal(context, identity);
 						const previous = await readPreviousPayloadForEvent(stateFile);
 						if (Object.keys(previous).length === 0) return;
-						assertPreviousRuntimeStateIdentity(previous, identity);
+						assertPreviousRuntimeStateIdentity(previous, identity, stateFile);
 						const now = new Date().toISOString();
 						const terminalPersistenceFailed =
 							outcome.kind === "terminal_persistence" && outcome.status !== "completed";
@@ -2732,7 +2804,7 @@ export async function persistCoordinatorRuntimeStateFromPostmortem(
 					await withStateFileLock(stateFile, async () => {
 						assertNoRuntimeStateRescopeJournal(context, identity);
 						const previous = readPreviousPayload(stateFile);
-						assertPreviousRuntimeStateIdentity(previous, identity);
+						assertPreviousRuntimeStateIdentity(previous, identity, stateFile);
 						if (shouldPreserveTerminalPayload(previous as RuntimeStateSidecarPayload, identity)) return;
 						// The immutable owner verdict remains in its lifecycle artifact; never replace a
 						// complete agent terminal payload merely to mirror that verdict here.

--- a/packages/coding-agent/test/session-state-sidecar.test.ts
+++ b/packages/coding-agent/test/session-state-sidecar.test.ts
@@ -1280,7 +1280,7 @@ describe("coordinator runtime state sidecar", () => {
 				cwd: "D:\\Users\\Operator\\Repo",
 				sessionFile: "D:\\Users\\Operator\\Repo\\.gjc\\session.jsonl",
 			}),
-		).rejects.toThrow("invalid or unreadable");
+		).rejects.toThrow("belongs to a different workspace");
 		expect(await Bun.file(stateFile).text()).toBe(beforeRejectedWrite);
 	});
 	it("rejects case-different POSIX runtime-state identities", async () => {
@@ -1306,8 +1306,139 @@ describe("coordinator runtime state sidecar", () => {
 					sessionFile: path.join(root, "WORKSPACE", "session.jsonl"),
 				},
 			),
-		).rejects.toThrow("invalid or unreadable");
+		).rejects.toThrow("belongs to a different workspace");
 		expect(await Bun.file(stateFile).text()).toBe(beforeRejectedWrite);
+	});
+
+	it("adopts a terminal foreign-workspace marker that travelled inside the current workspace", async () => {
+		// A session directory committed to version control reaches a second machine with a
+		// marker whose recorded cwd is the other platform's path. The marker is readable and
+		// terminal, and it now lives inside this workspace, so resuming here must not be
+		// refused as if the file were corrupt.
+		const root = await tempRoot();
+		const sessionId = "travelled-session";
+		const runtimeDir = path.join(root, ".gjc", `_session-${sessionId}`, "runtime");
+		await fs.mkdir(runtimeDir, { recursive: true });
+		const stateFile = path.join(runtimeDir, "runtime-state.json");
+		await Bun.write(
+			stateFile,
+			JSON.stringify({
+				schema_version: 1,
+				session_id: sessionId,
+				state: "completed",
+				live: false,
+				cwd: "D:\\Users\\Operator\\Repo",
+				workdir: "D:\\Users\\Operator\\Repo",
+				session_file: null,
+			}),
+		);
+		process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV] = stateFile;
+
+		await persistCoordinatorRuntimeStateFromEvent(
+			{ type: "turn_start" },
+			{ sessionId, cwd: root, sessionFile: null },
+		);
+
+		expect(JSON.parse(await Bun.file(stateFile).text())).toMatchObject({
+			session_id: sessionId,
+			cwd: root,
+			workdir: root,
+		});
+	});
+
+	it("refuses a foreign-workspace marker that is live, non-terminal, or outside this workspace", async () => {
+		const sessionId = "foreign-session";
+		const foreign = "D:\\Users\\Operator\\Repo";
+
+		// Live or non-terminal markers may still have a running owner behind them. A live
+		// marker is refused as a foreign workspace; a non-terminal one is refused earlier, by
+		// the pre-existing non-terminal guard, so both messages are accepted here.
+		for (const marker of [
+			{ state: "running", live: true },
+			{ state: "completed" }, // `live` absent says nothing about the owner
+			{ state: "running", live: false },
+		]) {
+			const root = await tempRoot();
+			const runtimeDir = path.join(root, ".gjc", `_session-${sessionId}`, "runtime");
+			await fs.mkdir(runtimeDir, { recursive: true });
+			const stateFile = path.join(runtimeDir, "runtime-state.json");
+			await Bun.write(
+				stateFile,
+				JSON.stringify({
+					schema_version: 1,
+					session_id: sessionId,
+					cwd: foreign,
+					workdir: foreign,
+					session_file: null,
+					...marker,
+				}),
+			);
+			process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV] = stateFile;
+			const before = await Bun.file(stateFile).text();
+
+			await expect(
+				persistCoordinatorRuntimeStateFromEvent(
+					{ type: "turn_start" },
+					{ sessionId, cwd: root, sessionFile: null },
+				),
+			).rejects.toThrow(/belongs to a different workspace|invalid or unreadable/);
+			expect(await Bun.file(stateFile).text()).toBe(before);
+		}
+
+		// A terminal marker stored outside this workspace belongs to a different checkout on
+		// the same machine, so being terminal is not enough to adopt it.
+		const root = await tempRoot();
+		const elsewhere = await tempRoot();
+		const stateFile = path.join(elsewhere, "runtime-state.json");
+		await Bun.write(
+			stateFile,
+			JSON.stringify({
+				schema_version: 1,
+				session_id: sessionId,
+				state: "completed",
+				live: false,
+				cwd: elsewhere,
+				workdir: elsewhere,
+				session_file: null,
+			}),
+		);
+		process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV] = stateFile;
+		const before = await Bun.file(stateFile).text();
+
+		await expect(
+			persistCoordinatorRuntimeStateFromEvent({ type: "turn_start" }, { sessionId, cwd: root, sessionFile: null }),
+		).rejects.toThrow("belongs to a different workspace");
+		expect(await Bun.file(stateFile).text()).toBe(before);
+	});
+
+	it("names both workspaces so the mismatch is not mistaken for file corruption", async () => {
+		const root = await tempRoot();
+		const sessionId = "diagnostic-session";
+		const stateFile = path.join(root, "runtime-state.json");
+		await Bun.write(
+			stateFile,
+			JSON.stringify({
+				schema_version: 1,
+				session_id: sessionId,
+				state: "running",
+				live: true,
+				cwd: "D:\\Users\\Operator\\Repo",
+				workdir: "D:\\Users\\Operator\\Repo",
+				session_file: null,
+			}),
+		);
+		process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV] = stateFile;
+
+		const failure = await persistCoordinatorRuntimeStateFromEvent(
+			{ type: "turn_start" },
+			{ sessionId, cwd: root, sessionFile: null },
+		).catch((error: unknown) => error as Error);
+
+		expect(failure).toBeInstanceOf(Error);
+		expect(failure.name).toBe("ForeignRuntimeStateError");
+		expect(failure.message).toContain("D:\\Users\\Operator\\Repo");
+		expect(failure.message).toContain(root);
+		expect(failure.message).not.toContain("invalid or unreadable");
 	});
 
 	it("rejects non-terminal and mismatched runtime markers", async () => {
@@ -1702,7 +1833,7 @@ describe("coordinator runtime state sidecar", () => {
 					cwd: root,
 					sessionFile: path.join(root, "session.jsonl"),
 				}),
-			).rejects.toThrow("invalid or unreadable");
+			).rejects.toThrow("belongs to a different workspace");
 			expect(await Bun.file(stateFile).text()).toBe(before);
 		}
 	});


### PR DESCRIPTION
## What

Distinguish readable foreign-workspace runtime markers from invalid or unreadable markers, and adopt only terminal, explicitly non-live markers that travelled inside the current workspace.

## Why

Fixes #5145. The exact contributor change from PR #5146 is salvaged onto current dev with attribution preserved.

## Testing

- `bun test packages/coding-agent/test/session-state-sidecar.test.ts` (159 pass)
- `bun test packages/coding-agent/test/gjc-runtime/` (1310 pass)
- Independent baseline and post-fix marker scenarios: dead travelled adopted; live, unknown-owner, and external markers refused untouched.
- `bun run check:ts` reaches the existing 2 unrelated check:tools formatting errors.

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk`
- [ ] `high-risk`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:60e503014200d0e583392569d6db38659c6df2f2471003aa9bdcf090bbc308da reviewer:human reviewer-id:Yeachan-Heo evidence:maintainer exact-head owner risk record
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes (existing unrelated check:tools formatting errors)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head
- [x] Risk classification above matches the actual review path taken

Lore-id: 5145a1b2
Constraint: a live or in-flight foreign marker must never be adopted
Constraint: live absent is not live false
Rejected: adopt any terminal foreign marker
Rejected: reuse unreadable error for workspace mismatch
Confidence: high
Scope-risk: narrow
Reversibility: easy
Tested: exact contributor diff salvaged and lifecycle regressions pass




 