### PR TITLE
fix(models): fail closed on unavailable configured defaults

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - A runtime-state marker recorded against a different workspace path now reports that mismatch instead of claiming the file is unreadable, and a terminal, not-live marker that travelled into the current workspace with its session directory is adopted rather than refused. Live, non-terminal, and out-of-workspace markers are still refused untouched.
+- An unavailable provider-qualified `modelRoles.default` selection now reports the requested model instead of silently starting on another provider's baseline. This keeps signed-registry omissions and failed catalog admission actionable rather than routing requests to an unrelated retired model. (#5144)
 
 - Headless SDK substrate close now reports success when exact teardown observes the recorded process gone even if cleanup unlinks the durable proof first; live or identity-ambiguous substrates still report `substrate_mismatch`. (#5130)
 

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -1580,6 +1580,11 @@ export async function findInitialModel(options: {
 			thinkingLevel = resolveThinkingLevelForModel(found, defaultThinkingSelector);
 			return { model, thinkingLevel, fallbackMessage: undefined };
 		}
+		return {
+			model: undefined,
+			thinkingLevel: undefined,
+			fallbackMessage: `Model ${defaultProvider}/${defaultModelId} not found`,
+		};
 	}
 
 	// 4. Try first available model with valid API key

--- a/packages/coding-agent/src/sdk/session.ts
+++ b/packages/coding-agent/src/sdk/session.ts
@@ -67,6 +67,7 @@ import {
 	resolveModelRoleValue,
 	type ScopedModelSelection,
 } from "../config/model-resolver";
+import { normalizeModelSelectorValue } from "../config/model-selector-value";
 import { loadPromptTemplates as loadPromptTemplatesInternal, type PromptTemplate } from "../config/prompt-templates";
 import { Settings, type SkillsSettings } from "../config/settings";
 import { resolveEagerTaskDelegation } from "../config/task-delegation";
@@ -1832,8 +1833,12 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				credentialSessionId,
 			}),
 		);
+		const configuredDefaultPatterns = normalizeModelSelectorValue(settings.getModelRole("default"));
 		let model = options.model;
 		let modelFallbackMessage: string | undefined;
+		if (!hasExplicitModel && configuredDefaultPatterns.length > 0 && !defaultRoleSpec.model) {
+			modelFallbackMessage = `Model ${configuredDefaultPatterns.join(" -> ")} not found`;
+		}
 		const resumeModelBehavior = settings.get("session.resumeModelBehavior");
 		const persistedDefaultChain = existingSession.configuredModelChains.default;
 		const defaultModelEntries =
@@ -3542,7 +3547,12 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		// Fall back to first available model with a valid API key, honoring the
 		// path-scoped `enabledModels` allow-list when configured. Skip when the
 		// user explicitly requested a model via --model that wasn't found.
-		if (!model && !options.modelPattern && !startupCredentialModelRejected) {
+		if (
+			!model &&
+			!options.modelPattern &&
+			!startupCredentialModelRejected &&
+			configuredDefaultPatterns.length === 0
+		) {
 			// Re-resolve the allowed set: extension factories above may have
 			// registered providers/models that weren't visible at startup.
 			const allowedFallbackCandidates = await resolveAllowedModels(modelRegistry, settings, modelMatchPreferences);

--- a/packages/coding-agent/test/model-onboarding-guidance.test.ts
+++ b/packages/coding-agent/test/model-onboarding-guidance.test.ts
@@ -145,6 +145,20 @@ describe("model onboarding guidance", () => {
 		}
 	}, 30000);
 
+	it("does not replace an unavailable signed-registry default with another provider baseline", async () => {
+		const agentDir = await createTempDir();
+		const settings = Settings.isolated({
+			modelRoles: { default: "opencode-go/glm-5.3-flash" },
+		});
+		const { session, modelFallbackMessage } = await createAgentSession(createSessionOptions(agentDir, { settings }));
+		try {
+			expect(session.model).toBeUndefined();
+			expect(modelFallbackMessage).toBe("Model opencode-go/glm-5.3-flash not found");
+		} finally {
+			await session.dispose();
+		}
+	}, 30000);
+
 	it("uses shared provider onboarding text for AgentSession no-model and no-credential errors", async () => {
 		const noModelDir = await createTempDir();
 		const noModelSettings = Settings.isolated({ enabledModels: ["provider-without-models"] });

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -1120,6 +1120,20 @@ describe("OpenAI Codex default resolution", () => {
 		expect(result.model).toBeUndefined();
 		expect(result.fallbackMessage).toBe("Model opencode-go/glm-5.3-flash not found");
 	});
+
+	test("keeps an available OpenCode Go catalog model as the configured default", async () => {
+		const model = { ...codexDefaultModels[0]!, provider: "opencode-go" as const, id: "deepseek-v4-flash" };
+		const result = await findInitialModel({
+			defaultProvider: model.provider,
+			defaultModelId: model.id,
+			scopedModels: [],
+			isContinuing: false,
+			modelRegistry: { getAvailable: () => [model], getApiKey: async () => "test-key" },
+		});
+
+		expect(result.model).toBe(model);
+		expect(result.fallbackMessage).toBeUndefined();
+	});
 });
 
 test("restores only an exact available provider/model candidate", async () => {

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -1107,6 +1107,19 @@ describe("OpenAI Codex default resolution", () => {
 			"Could not restore model openai-codex/missing-gpt (model no longer exists). Using openai-codex/gpt-5.5.",
 		);
 	});
+
+	test("does not replace an unavailable configured default with another provider's baseline", async () => {
+		const result = await findInitialModel({
+			defaultProvider: "opencode-go",
+			defaultModelId: "glm-5.3-flash",
+			scopedModels: [],
+			isContinuing: false,
+			modelRegistry: codexDefaultRegistry,
+		});
+
+		expect(result.model).toBeUndefined();
+		expect(result.fallbackMessage).toBe("Model opencode-go/glm-5.3-flash not found");
+	});
 });
 
 test("restores only an exact available provider/model candidate", async () => {


### PR DESCRIPTION
## Summary
- preserve an unavailable provider-qualified default as an actionable model-not-found diagnostic
- prevent startup from selecting an unrelated provider baseline after signed-registry/catalog admission misses
- add resolver and SDK onboarding regressions for `opencode-go/glm-5.3-flash`

Fixes #5144.

## Evidence
- Issue #5144 verified against signed registry revision 1 (`sourceRevision=65d0d2f...`): `glm-5.3-flash`, `deepseek-v4-flash-vision-exp`, and `qwen3.8-flash` are absent while current supported OpenCode Go entries are present.
- The old path allowed an unresolved saved/default selection to enter the generic provider-default sweep.
- Targeted tests: `model-resolver`, `model-onboarding-guidance`, `model-profile-activation`, `model-preset-registry`, `model-registry`, AI model-manager/cache/context/catalog suites.
- Coding-agent typecheck and changed-file Biome check pass.

## Risk classification
- [x] `low-risk`
- [ ] `regression-risk`
- [ ] `high-risk`

gajae.pr-review-verdict.v1 merge-self-approved sha256:8c684e2b20d934a2f8c16402e4363af3fc73f8358a1db78ec95b2dc3aa83cbbe reviewer:architect reviewer-id:Yeachan-Heo evidence:exact current-dev head review and targeted signed-registry fallback validation passed