### PR TITLE
fix(tui): let a queued steer own the first Esc on a streaming turn

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 ### Fixed
 
+- The first Esc on a streaming turn with a queued steering message again consumes that steer and auto-continues instead of aborting the turn and dumping the queue back into the composer. The busy-indicator recovery branch counted the same drainable queue as cancellable work and, because a streaming turn always has that indicator mounted, it short-circuited before the steer-on-interrupt branch could run. Stale busy-indicator recovery, pending-submission cancellation, and the loud second-Esc abort are unchanged.
+
 - Interactive `/login`, `/logout`, and account inventory commands now keep the TUI alive when the credential database reports `SQLITE_CORRUPT` or `SQLITE_NOTADB`. They show a bounded, payload-free recovery message and never auto-repair or delete the database. (#5070)
 - `session.last_assistant` now reads the public transcript projection, skips trailing tool-only, thinking-only, empty, and whitespace-only assistant rows, and returns the most recent readable assistant text or an empty string when none exists. (#5078)
 - Chat-daemon same-generation successor attachments now wait for predecessor provider retirement before admitting frames. Retired attachment frames remain fenced, successor frames resume after retirement, queue waiters settle during takeover and shutdown, and cross-generation replacement remains isolated. (#5120)

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -420,6 +420,24 @@ export class InputController {
 			if (this.ctx.cancelPendingSubmission()) {
 				return true;
 			}
+			// A queued steer on a live stream is owned by the steering branch below,
+			// which silently consumes it and auto-continues. This branch counts the same
+			// queue as cancellable work, and a streaming turn always has the indicator
+			// mounted, so without this hand-off it short-circuited first and turned the
+			// documented steer-on-interrupt into a loud abort that dumped the steer back
+			// into the composer. `cancelPendingSubmission()` above still wins: a
+			// submission that has not started yet is cancelled before the stream owns
+			// the key, and one that has started returns false there by design.
+			if (
+				options.streaming === true &&
+				this.ctx.session.isStreaming &&
+				this.ctx.session.hasQueuedSteering &&
+				!this.#steerConsumePending
+			) {
+				this.#steerConsumePending = true;
+				void this.#abortInteractive({ silent: true });
+				return true;
+			}
 			// Only count queues this handler can actually drain. The aggregate
 			// `queuedMessageCount` also counts hidden next-turn context, which
 			// `restoreQueuedMessagesToEditor()` never returns and which survives turn

--- a/packages/coding-agent/test/input-controller-escape.test.ts
+++ b/packages/coding-agent/test/input-controller-escape.test.ts
@@ -951,6 +951,102 @@ describe("InputController escape behavior", () => {
 		expect(spies.clearQueue).not.toHaveBeenCalled();
 	});
 
+	it("consumes a queued steer on the first Esc while the streaming busy indicator is mounted", () => {
+		const { ctx, editor, spies } = createContext();
+		(ctx.session as { isStreaming: boolean; hasQueuedSteering: boolean }).isStreaming = true;
+		(ctx.session as { hasQueuedSteering: boolean }).hasQueuedSteering = true;
+		// Every streaming turn mounts the activity indicator, so the busy branch is
+		// live for the exact case steer-on-interrupt is meant to handle.
+		ctx.loadingAnimation = {} as InteractiveModeContext["loadingAnimation"];
+		(ctx.session as { drainableQueuedMessageCount: number }).drainableQueuedMessageCount = 1;
+		spies.clearQueue.mockReturnValue({ steering: ["do this instead"], followUp: [] });
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		editor.onEscape?.();
+
+		expect(spies.abort).toHaveBeenCalledTimes(1);
+		expect(spies.abort).toHaveBeenCalledWith(expect.objectContaining({ cause: "user_interrupt", silent: true }));
+		expect(spies.clearQueue).not.toHaveBeenCalled();
+		expect(editor.getText()).toBe("");
+	});
+
+	it("consumes a queued steer while the started submission for that turn is still pending", () => {
+		const { ctx, editor, spies } = createContext();
+		(ctx.session as { isStreaming: boolean; hasQueuedSteering: boolean }).isStreaming = true;
+		(ctx.session as { hasQueuedSteering: boolean }).hasQueuedSteering = true;
+		ctx.loadingAnimation = {} as InteractiveModeContext["loadingAnimation"];
+		(ctx.session as { drainableQueuedMessageCount: number }).drainableQueuedMessageCount = 1;
+		// The submission that started this turn is only finished in the turn-level
+		// `finally`, so it stays pending for the whole stream. It has already started,
+		// so `cancelPendingSubmission()` declines it.
+		spies.hasPendingSubmission.mockReturnValue(true);
+		spies.cancelPendingSubmission.mockReturnValue(false);
+		spies.clearQueue.mockReturnValue({ steering: ["do this instead"], followUp: [] });
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		editor.onEscape?.();
+
+		expect(spies.abort).toHaveBeenCalledTimes(1);
+		expect(spies.abort).toHaveBeenCalledWith(expect.objectContaining({ cause: "user_interrupt", silent: true }));
+		expect(spies.clearQueue).not.toHaveBeenCalled();
+		expect(editor.getText()).toBe("");
+	});
+
+	it("still cancels an unstarted submission before a queued steer claims the key", () => {
+		const { ctx, editor, spies } = createContext();
+		(ctx.session as { isStreaming: boolean; hasQueuedSteering: boolean }).isStreaming = true;
+		(ctx.session as { hasQueuedSteering: boolean }).hasQueuedSteering = true;
+		ctx.loadingAnimation = {} as InteractiveModeContext["loadingAnimation"];
+		spies.hasPendingSubmission.mockReturnValue(true);
+		spies.cancelPendingSubmission.mockReturnValue(true);
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		editor.onEscape?.();
+
+		expect(spies.cancelPendingSubmission).toHaveBeenCalledTimes(1);
+		expect(spies.abort).not.toHaveBeenCalled();
+	});
+
+	it("still aborts loudly on the second Esc when the busy indicator is mounted", () => {
+		const { ctx, editor, spies } = createContext();
+		(ctx.session as { isStreaming: boolean; hasQueuedSteering: boolean }).isStreaming = true;
+		(ctx.session as { hasQueuedSteering: boolean }).hasQueuedSteering = true;
+		ctx.loadingAnimation = {} as InteractiveModeContext["loadingAnimation"];
+		(ctx.session as { drainableQueuedMessageCount: number }).drainableQueuedMessageCount = 1;
+		spies.clearQueue.mockReturnValue({ steering: ["do this instead"], followUp: [] });
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		editor.onEscape?.();
+		editor.onEscape?.();
+
+		expect(spies.abort).toHaveBeenCalledTimes(2);
+		expect(spies.abort.mock.calls[0]?.[0]).toMatchObject({ silent: true });
+		expect(spies.abort.mock.calls[1]?.[0]?.silent).toBeUndefined();
+		expect(spies.clearQueue).toHaveBeenCalledTimes(1);
+		expect(editor.getText()).toBe("do this instead");
+	});
+
+	it("consumes a queued steer on the first Ctrl+C while the streaming busy indicator is mounted", () => {
+		const { ctx, inputListeners, spies } = createContext();
+		(ctx.session as { isStreaming: boolean; hasQueuedSteering: boolean }).isStreaming = true;
+		(ctx.session as { hasQueuedSteering: boolean }).hasQueuedSteering = true;
+		ctx.loadingAnimation = {} as InteractiveModeContext["loadingAnimation"];
+		(ctx.session as { drainableQueuedMessageCount: number }).drainableQueuedMessageCount = 1;
+		spies.clearQueue.mockReturnValue({ steering: ["do this instead"], followUp: [] });
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+
+		expect(inputListeners[0]?.("\x03")).toEqual({ consume: true });
+		expect(spies.abort).toHaveBeenCalledTimes(1);
+		expect(spies.abort).toHaveBeenCalledWith(expect.objectContaining({ cause: "user_interrupt", silent: true }));
+		expect(spies.clearQueue).not.toHaveBeenCalled();
+	});
+
 	it("does a real abort on the second Esc while a steer consume is still pending", () => {
 		const { ctx, editor, spies } = createContext();
 		(ctx.session as { isStreaming: boolean; hasQueuedSteering: boolean }).isStreaming = true;


### PR DESCRIPTION
## What

Restore the documented steer-on-interrupt path in the interactive TUI.

A streaming turn always has the activity indicator mounted, and the busy-indicator recovery branch in `#handleCancellableWorkEscape` counts the drainable steering queue as cancellable work. It therefore short-circuited before the steering branch could run, so the first Esc on a turn with a queued steering message aborted the turn loudly and dumped the steer back into the composer instead of consuming it and auto-continuing.

The hand-off now happens inside the busy branch, immediately after `cancelPendingSubmission()` has had its say. That ordering matters: the submission that starts a turn is only finished in the turn-level `finally` in `main.ts`, so it stays pending for the whole stream, while `cancelPendingSubmission()` declines a submission that has already started (`interactive-mode.ts`). An unstarted submission is therefore still cancelled first, and only then does a queued steer claim the key.

Unchanged: stale busy-indicator recovery (#4741), pending-submission cancellation, the loud second-Esc abort, and every path with no queued steer.

## Why

`busyPromptMode` defaults to `steer`, so a prompt submitted while the agent works is queued as a steering message. `dev` already implements and documents the intended behaviour — `input-controller.ts` carries the comment "First Esc with a queued steer: silently consume it and auto-continue via steer-on-interrupt instead of stalling on 'Operation aborted'", `agent-session.ts` schedules the continue for `user_interrupt` aborts, and three existing tests assert it. Only the interactive entry point was unreachable.

`git log -S "hasCancellableWork" -- packages/coding-agent/src/modes/controllers/input-controller.ts` points at `b063296e8` (#4750, the #4741 stale busy-indicator fix), which introduced the busy branch above the pre-existing steering branch.

Reproduced on `dev` by adding only `ctx.loadingAnimation = {}` to the existing harness for the three steer tests: the first Esc called `abort` without `silent`, called `clearQueue` once, and left the queued text in the editor, where those tests assert `silent: true` and no `clearQueue`. The three existing tests never set `loadingAnimation`, so they did not cover the shape a real streaming turn always has.

## Testing

Local, on head `35e4c9ec98ae10224a30df44fc96bbb59e461e81` with base `131d593de1f4b816fb060b0605bb1434d512eaa8`:

- `bun test packages/coding-agent/test/input-controller-escape.test.ts` — 97 pass / 0 fail
- `bun test packages/coding-agent/test/input-controller-escape.test.ts packages/coding-agent/test/cancel-and-submit.test.ts packages/coding-agent/test/agent-session-terminal-abort-chain.test.ts` — 163 pass / 0 fail
- `bun test packages/coding-agent/test/agent-session-steer-interrupt.test.ts` — 6 pass / 0 fail
- Reverting only `input-controller.ts` to its `dev` content turns all four new tests red, including `consumes a queued steer while the started submission for that turn is still pending`, which is the case an earlier iteration of this fix silently failed.

Two notes so the numbers are not read as more than they are:

- `bun check` reports 2 errors on this branch, in `sdk/host/session-runtime.test.ts` (import sort) and a formatter diff. Both reproduce identically on unmodified `dev` here, and `biome check` on the two files this PR touches is clean. I did not touch them.
- Running `agent-session-steer-interrupt.test.ts` in the same invocation as four other suites fails 4 tests on timeouts, but that also reproduces on unmodified `dev` (with more errors, not fewer). It passes standalone.

## Risk classification

- [ ] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [x] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

Classified `regression-risk` because it reorders Esc handling that #4750 landed to fix a lockout. The specific thing worth a reviewer's attention is the window where `AgentSession.isStreaming` is still true through `#livePromptsInFlight()` while the agent loop has stopped: the new branch fires there and consumes the steer with a silent abort. My reading is that this is delivery rather than a stall, because that abort carries `cause: "user_interrupt"` and `agent-session.ts` schedules a continue for exactly that case, with `#canAutoContinueForSteer()` covering the unwind window by design. I would like that confirmed rather than taken on my word.

## GJC verdict

```text
gajae.pr-review-verdict.v1 needs-human sha256:7d3a73d68db70f5cb7b5362026752e221f8f64f2b3b9351ddd815cd020141665 reviewer:human reviewer-id:none evidence:local bun test packages/coding-agent/test/input-controller-escape.test.ts (97 pass / 0 fail); reverting input-controller.ts to dev turns the four new tests red
```

No independent human has reviewed this. Writing `needs-human` and stopping, per the template.

---

- [x] Target branch is `dev`
- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken

`bun check` is left unchecked deliberately: it fails on this branch, and identically on unmodified `dev`, in files this PR does not touch. Details in Testing above.
