### PR TITLE
fix(tui): let queued steer own first Esc on streaming turn

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -18,6 +18,8 @@
 
 ### Fixed
 
+- The first Esc on a streaming turn with a queued steering message again consumes that steer and auto-continues instead of aborting the turn and dumping the queue back into the composer. The busy-indicator recovery branch counted the same drainable queue as cancellable work and, because a streaming turn always has that indicator mounted, it short-circuited before the steer-on-interrupt branch could run. Stale busy-indicator recovery, pending-submission cancellation, and the loud second-Esc abort are unchanged.
+
 - Interactive `/login`, `/logout`, and account inventory commands now keep the TUI alive when the credential database reports `SQLITE_CORRUPT` or `SQLITE_NOTADB`. They show a bounded, payload-free recovery message and never auto-repair or delete the database. (#5070)
 - `session.last_assistant` now reads the public transcript projection, skips trailing tool-only, thinking-only, empty, and whitespace-only assistant rows, and returns the most recent readable assistant text or an empty string when none exists. (#5078)
 - Chat-daemon same-generation successor attachments now wait for predecessor provider retirement before admitting frames. Retired attachment frames remain fenced, successor frames resume after retirement, queue waiters settle during takeover and shutdown, and cross-generation replacement remains isolated. (#5120)

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -420,6 +420,24 @@ export class InputController {
 			if (this.ctx.cancelPendingSubmission()) {
 				return true;
 			}
+			// A queued steer on a live stream is owned by the steering branch below,
+			// which silently consumes it and auto-continues. This branch counts the same
+			// queue as cancellable work, and a streaming turn always has the indicator
+			// mounted, so without this hand-off it short-circuited first and turned the
+			// documented steer-on-interrupt into a loud abort that dumped the steer back
+			// into the composer. `cancelPendingSubmission()` above still wins: a
+			// submission that has not started yet is cancelled before the stream owns
+			// the key, and one that has started returns false there by design.
+			if (
+				options.streaming === true &&
+				this.ctx.session.isStreaming &&
+				this.ctx.session.hasQueuedSteering &&
+				!this.#steerConsumePending
+			) {
+				this.#steerConsumePending = true;
+				void this.#abortInteractive({ silent: true });
+				return true;
+			}
 			// Only count queues this handler can actually drain. The aggregate
 			// `queuedMessageCount` also counts hidden next-turn context, which
 			// `restoreQueuedMessagesToEditor()` never returns and which survives turn

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -420,6 +420,14 @@ export class InputController {
 			if (this.ctx.cancelPendingSubmission()) {
 				return true;
 			}
+			if (options.processes && this.ctx.session.isBashRunning) {
+				this.ctx.session.abortBash();
+				return true;
+			}
+			if (options.processes && this.ctx.session.isEvalRunning) {
+				this.ctx.session.abortEval();
+				return true;
+			}
 			// A queued steer on a live stream is owned by the steering branch below,
 			// which silently consumes it and auto-continues. This branch counts the same
 			// queue as cancellable work, and a streaming turn always has the indicator
@@ -432,6 +440,8 @@ export class InputController {
 				options.streaming === true &&
 				this.ctx.session.isStreaming &&
 				this.ctx.session.hasQueuedSteering &&
+				!this.ctx.session.isBashRunning &&
+				!this.ctx.session.isEvalRunning &&
 				!this.#steerConsumePending
 			) {
 				this.#steerConsumePending = true;

--- a/packages/coding-agent/test/input-controller-escape.test.ts
+++ b/packages/coding-agent/test/input-controller-escape.test.ts
@@ -951,6 +951,102 @@ describe("InputController escape behavior", () => {
 		expect(spies.clearQueue).not.toHaveBeenCalled();
 	});
 
+	it("consumes a queued steer on the first Esc while the streaming busy indicator is mounted", () => {
+		const { ctx, editor, spies } = createContext();
+		(ctx.session as { isStreaming: boolean; hasQueuedSteering: boolean }).isStreaming = true;
+		(ctx.session as { hasQueuedSteering: boolean }).hasQueuedSteering = true;
+		// Every streaming turn mounts the activity indicator, so the busy branch is
+		// live for the exact case steer-on-interrupt is meant to handle.
+		ctx.loadingAnimation = {} as InteractiveModeContext["loadingAnimation"];
+		(ctx.session as { drainableQueuedMessageCount: number }).drainableQueuedMessageCount = 1;
+		spies.clearQueue.mockReturnValue({ steering: ["do this instead"], followUp: [] });
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		editor.onEscape?.();
+
+		expect(spies.abort).toHaveBeenCalledTimes(1);
+		expect(spies.abort).toHaveBeenCalledWith(expect.objectContaining({ cause: "user_interrupt", silent: true }));
+		expect(spies.clearQueue).not.toHaveBeenCalled();
+		expect(editor.getText()).toBe("");
+	});
+
+	it("consumes a queued steer while the started submission for that turn is still pending", () => {
+		const { ctx, editor, spies } = createContext();
+		(ctx.session as { isStreaming: boolean; hasQueuedSteering: boolean }).isStreaming = true;
+		(ctx.session as { hasQueuedSteering: boolean }).hasQueuedSteering = true;
+		ctx.loadingAnimation = {} as InteractiveModeContext["loadingAnimation"];
+		(ctx.session as { drainableQueuedMessageCount: number }).drainableQueuedMessageCount = 1;
+		// The submission that started this turn is only finished in the turn-level
+		// `finally`, so it stays pending for the whole stream. It has already started,
+		// so `cancelPendingSubmission()` declines it.
+		spies.hasPendingSubmission.mockReturnValue(true);
+		spies.cancelPendingSubmission.mockReturnValue(false);
+		spies.clearQueue.mockReturnValue({ steering: ["do this instead"], followUp: [] });
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		editor.onEscape?.();
+
+		expect(spies.abort).toHaveBeenCalledTimes(1);
+		expect(spies.abort).toHaveBeenCalledWith(expect.objectContaining({ cause: "user_interrupt", silent: true }));
+		expect(spies.clearQueue).not.toHaveBeenCalled();
+		expect(editor.getText()).toBe("");
+	});
+
+	it("still cancels an unstarted submission before a queued steer claims the key", () => {
+		const { ctx, editor, spies } = createContext();
+		(ctx.session as { isStreaming: boolean; hasQueuedSteering: boolean }).isStreaming = true;
+		(ctx.session as { hasQueuedSteering: boolean }).hasQueuedSteering = true;
+		ctx.loadingAnimation = {} as InteractiveModeContext["loadingAnimation"];
+		spies.hasPendingSubmission.mockReturnValue(true);
+		spies.cancelPendingSubmission.mockReturnValue(true);
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		editor.onEscape?.();
+
+		expect(spies.cancelPendingSubmission).toHaveBeenCalledTimes(1);
+		expect(spies.abort).not.toHaveBeenCalled();
+	});
+
+	it("still aborts loudly on the second Esc when the busy indicator is mounted", () => {
+		const { ctx, editor, spies } = createContext();
+		(ctx.session as { isStreaming: boolean; hasQueuedSteering: boolean }).isStreaming = true;
+		(ctx.session as { hasQueuedSteering: boolean }).hasQueuedSteering = true;
+		ctx.loadingAnimation = {} as InteractiveModeContext["loadingAnimation"];
+		(ctx.session as { drainableQueuedMessageCount: number }).drainableQueuedMessageCount = 1;
+		spies.clearQueue.mockReturnValue({ steering: ["do this instead"], followUp: [] });
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		editor.onEscape?.();
+		editor.onEscape?.();
+
+		expect(spies.abort).toHaveBeenCalledTimes(2);
+		expect(spies.abort.mock.calls[0]?.[0]).toMatchObject({ silent: true });
+		expect(spies.abort.mock.calls[1]?.[0]?.silent).toBeUndefined();
+		expect(spies.clearQueue).toHaveBeenCalledTimes(1);
+		expect(editor.getText()).toBe("do this instead");
+	});
+
+	it("consumes a queued steer on the first Ctrl+C while the streaming busy indicator is mounted", () => {
+		const { ctx, inputListeners, spies } = createContext();
+		(ctx.session as { isStreaming: boolean; hasQueuedSteering: boolean }).isStreaming = true;
+		(ctx.session as { hasQueuedSteering: boolean }).hasQueuedSteering = true;
+		ctx.loadingAnimation = {} as InteractiveModeContext["loadingAnimation"];
+		(ctx.session as { drainableQueuedMessageCount: number }).drainableQueuedMessageCount = 1;
+		spies.clearQueue.mockReturnValue({ steering: ["do this instead"], followUp: [] });
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+
+		expect(inputListeners[0]?.("\x03")).toEqual({ consume: true });
+		expect(spies.abort).toHaveBeenCalledTimes(1);
+		expect(spies.abort).toHaveBeenCalledWith(expect.objectContaining({ cause: "user_interrupt", silent: true }));
+		expect(spies.clearQueue).not.toHaveBeenCalled();
+	});
+
 	it("does a real abort on the second Esc while a steer consume is still pending", () => {
 		const { ctx, editor, spies } = createContext();
 		(ctx.session as { isStreaming: boolean; hasQueuedSteering: boolean }).isStreaming = true;

--- a/packages/coding-agent/test/input-controller-escape.test.ts
+++ b/packages/coding-agent/test/input-controller-escape.test.ts
@@ -1030,6 +1030,36 @@ describe("InputController escape behavior", () => {
 		expect(editor.getText()).toBe("do this instead");
 	});
 
+	it("preserves bash precedence over queued-steer consumption with the busy indicator mounted", () => {
+		const { ctx, editor, spies } = createContext();
+		(ctx.session as { isStreaming: boolean; hasQueuedSteering: boolean; isBashRunning: boolean }).isStreaming = true;
+		(ctx.session as { hasQueuedSteering: boolean; isBashRunning: boolean }).hasQueuedSteering = true;
+		(ctx.session as { isBashRunning: boolean }).isBashRunning = true;
+		ctx.loadingAnimation = {} as InteractiveModeContext["loadingAnimation"];
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		editor.onEscape?.();
+
+		expect(spies.abortBash).toHaveBeenCalledTimes(1);
+		expect(spies.abort).not.toHaveBeenCalled();
+	});
+
+	it("preserves python precedence over queued-steer consumption with the busy indicator mounted", () => {
+		const { ctx, editor, spies } = createContext();
+		(ctx.session as { isStreaming: boolean; hasQueuedSteering: boolean; isEvalRunning: boolean }).isStreaming = true;
+		(ctx.session as { hasQueuedSteering: boolean; isEvalRunning: boolean }).hasQueuedSteering = true;
+		(ctx.session as { isEvalRunning: boolean }).isEvalRunning = true;
+		ctx.loadingAnimation = {} as InteractiveModeContext["loadingAnimation"];
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		editor.onEscape?.();
+
+		expect(spies.abortEval).toHaveBeenCalledTimes(1);
+		expect(spies.abort).not.toHaveBeenCalled();
+	});
+
 	it("consumes a queued steer on the first Ctrl+C while the streaming busy indicator is mounted", () => {
 		const { ctx, inputListeners, spies } = createContext();
 		(ctx.session as { isStreaming: boolean; hasQueuedSteering: boolean }).isStreaming = true;


### PR DESCRIPTION
Maintainer recovery successor for #5152.

Preserves attribution to @yazzang-homelab via the cherry-picked fix and includes the narrow process-precedence repair found by adversarial review. Rebased onto current origin/dev after #5151 merged and #5144 closed.

- [x] `low-risk` — focused TUI behavior fix with targeted regression tests

## GJC verdict

gajae.pr-review-verdict.v1 merge-self-approved sha256:ed2371d5bdf2bcf401356fd38b00b2a30d6bf5a2ac88e340483a8626a8d669b7 reviewer:human reviewer-id:Yeachan-Heo evidence:https://github.com/Yeachan-Heo/gajae-code/actions

Exact base: `41222d31b2955778cdb480a14ddadffc6102100f`
Exact head: `a8ea7dd8dc32b71e7e446c3df3612612b1f03801`

Focused escape and steer-interrupt tests pass 105 tests; CLI smoke passes. Repository typecheck has unrelated pre-existing session-state-sidecar errors.

Contract evidence refreshed against the current exact head.