### PR TITLE
fix(ralplan): bind skill invocation seeds to worktree

### DIFF
--- a/packages/coding-agent/src/hooks/skill-state.ts
+++ b/packages/coding-agent/src/hooks/skill-state.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 import { logger } from "@gajae-code/utils";
 import { resolveSkillScopeTrust, type SkillDiscoverySettings } from "../config/skill-settings-defaults";
 import { detectDeepInterviewPlaintextAskLeak } from "../deep-interview/plaintext-gate-guard";
+import { captureRepositoryBinding, publicRepositoryBinding } from "../gjc-runtime/repository-binding";
 import { activeSnapshotPath, modeStatePath as sessionModeStatePath } from "../gjc-runtime/session-layout";
 import { resolveGjcSessionForRead } from "../gjc-runtime/session-resolution";
 import { ModeStateSchema, SkillActiveStateSchema } from "../gjc-runtime/state-schema";
@@ -421,6 +422,10 @@ async function seedSkillActivationState(
 		active_skills: [entry],
 		...(input.activeSubskills ? { active_subskills: input.activeSubskills } : {}),
 	};
+	const repositoryBinding =
+		skill === "ralplan"
+			? publicRepositoryBinding(await captureRepositoryBinding(input.cwd, { displayPath: input.cwd }))
+			: undefined;
 	const modeState: ModeState = {
 		active: true,
 		version: WORKFLOW_STATE_VERSION,
@@ -431,6 +436,7 @@ async function seedSkillActivationState(
 		session_id: resolvedSessionId,
 		...(input.threadId ? { thread_id: input.threadId } : {}),
 		...(input.turnId ? { turn_id: input.turnId } : {}),
+		...(repositoryBinding ? { repository_binding: repositoryBinding } : {}),
 	};
 	if (skill === "deep-interview") {
 		modeState.threshold = DEFAULT_DEEP_INTERVIEW_AMBIGUITY_THRESHOLD;

--- a/packages/coding-agent/test/gjc-skill-state-hooks.test.ts
+++ b/packages/coding-agent/test/gjc-skill-state-hooks.test.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import * as activeStateModule from "@gajae-code/coding-agent/skill-state/active-state";
 import { logger } from "@gajae-code/utils";
 import { DEFAULT_DISABLED_EXTENSIONS, DEFAULT_SKILL_DISCOVERY_SETTINGS } from "../src/config/skill-settings-defaults";
+import { runNativeRalplanCommand } from "../src/gjc-runtime/ralplan-runtime";
 import {
 	activeEntryPath,
 	activeSnapshotPath,
@@ -94,6 +95,21 @@ describe("GJC native skill-state hooks", () => {
 	async function cwd(): Promise<string> {
 		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-skill-hooks-"));
 		return tempDir;
+	}
+
+	async function initGitRepo(root: string): Promise<void> {
+		const run = async (args: string[]) => {
+			const process = Bun.spawn(["git", ...args], { cwd: root, stdout: "pipe", stderr: "pipe" });
+			const status = await process.exited;
+			if (status !== 0)
+				throw new Error(`git ${args.join(" ")} failed: ${await new Response(process.stderr).text()}`);
+		};
+		await run(["init"]);
+		await run(["config", "user.email", "test@example.com"]);
+		await run(["config", "user.name", "Test"]);
+		await fs.writeFile(path.join(root, "README.md"), "test\n");
+		await run(["add", "README.md"]);
+		await run(["commit", "-m", "init"]);
 	}
 
 	async function writePersistedSessionFile(
@@ -1997,6 +2013,82 @@ disabledExtensions:
 		expect(persistedMode.current_phase).toBe("requirements");
 		expect(persistedEntry.phase).toBe("requirements");
 		expect(rebuiltSnapshot.phase).toBe("requirements");
+	});
+
+	it("seeds ralplan repository binding for the first explicit-target role write", async () => {
+		const root = await cwd();
+		await initGitRepo(root);
+		const sessionId = "session-ralplan-first-use-binding";
+		const activation = await ensureWorkflowSkillActivationSeed({ cwd: root, skill: "ralplan", sessionId });
+		expect(activation.seeded).toBe(true);
+
+		const state = JSON.parse(await fs.readFile(modeStatePath(root, sessionId, "ralplan"), "utf8")) as Record<
+			string,
+			unknown
+		>;
+		expect(state.repository_binding).toMatchObject({ schema: "gjc.repository_binding.v1", worktreeRoot: root });
+
+		const result = await runNativeRalplanCommand(
+			[
+				"--write",
+				"--worktree-root",
+				root,
+				"--session-id",
+				sessionId,
+				"--run-id",
+				"first-use-run",
+				"--stage",
+				"planner",
+				"--stage_n",
+				"1",
+				"--artifact",
+				"# planner\n",
+				"--json",
+			],
+			root,
+		);
+		expect(result.status).toBe(0);
+	});
+
+	it("rejects malformed ralplan hook bindings before an explicit-target role write", async () => {
+		const root = await cwd();
+		await initGitRepo(root);
+		const sessionId = "session-ralplan-malformed-binding";
+		await ensureWorkflowSkillActivationSeed({ cwd: root, skill: "ralplan", sessionId });
+		const statePath = modeStatePath(root, sessionId, "ralplan");
+		const state = JSON.parse(await fs.readFile(statePath, "utf8")) as Record<string, unknown>;
+		const revision = state.state_revision;
+		if (typeof revision !== "number") throw new Error("Expected seeded state revision");
+		await writeGuardedWorkflowEnvelopeAtomic(
+			statePath,
+			{ ...state, repository_binding: { schema: "gjc.repository_binding.v1", worktreeRoot: "" } },
+			{
+				cwd: root,
+				policy: "source",
+				expectedRevision: revision,
+				receipt: { cwd: root, skill: "ralplan", owner: "gjc-runtime", command: "test", sessionId },
+			},
+		);
+
+		const result = await runNativeRalplanCommand(
+			[
+				"--write",
+				"--worktree-root",
+				root,
+				"--session-id",
+				sessionId,
+				"--stage",
+				"planner",
+				"--stage_n",
+				"1",
+				"--artifact",
+				"# planner\n",
+				"--json",
+			],
+			root,
+		);
+		expect(result.status).toBe(2);
+		expect(result.stderr).toMatch(/repository binding rejected|requires worktreeRoot/i);
 	});
 	it("rollback restores upstream pipeline entries superseded by a later seed", async () => {
 		const root = await cwd();


### PR DESCRIPTION
## Summary
- stamp ralplan `gjc-skill-invocation` seeds with the canonical repository binding captured from invocation cwd
- allow the first explicit `--worktree-root` planner write to succeed
- add deterministic first-use and malformed-binding regressions; existing foreign-binding coverage remains enforced

Fixes #5156

## Verification
- `bun test packages/coding-agent/test/gjc-skill-state-hooks.test.ts packages/coding-agent/test/gjc-runtime/repository-binding.test.ts packages/coding-agent/test/gjc-runtime/ralplan-worktree-root.test.ts`
- `bun --cwd=packages/coding-agent run check:types` reaches unrelated existing errors in `test/model-resolver.test.ts` and `test/session-state-sidecar.test.ts`

Base: `dev@41222d31b2955778cdb480a14ddadffc6102100f`
Head: `6bb8e6e3d3`

## Risk classification
- [x] `low-risk`
- [ ] `regression-risk`
- [ ] `high-risk`

## Exact-head review evidence
gajae.pr-review-verdict.v1 merge-self-approved sha256:ac22128b4b8b9add3f1b000dc1e03cdf825c76972683bc664f4aa0698e725359 reviewer:architect reviewer-id:Yeachan-Heo evidence:Exact-head review of the two-file ralplan hook seed fix; first-use explicit-target write passes, malformed binding rejects, and existing foreign-binding rejection remains covered.