### PR TITLE
fix(models): sync OpenCode Go catalog parity

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- OpenCode Go's bundled catalog now contains all 33 models advertised by its live provider list, including the seven newly published models. Canonical endpoint metadata supplies their transport, multimodal input, limits, pricing, and reasoning capabilities, while generated output remains deterministic and preserves fail-closed selection when a live catalog is unavailable (#5144).
+
 - SQLite corruption detection is now shared by credential and capability-cache surfaces, so callers can recognize `SQLITE_CORRUPT` and `SQLITE_NOTADB` without inspecting provider-specific error details.
 
 - OpenAI Codex WebSockets are now opt-in on Windows. Bun 1.4.0 can segfault in its Windows TLS WebSocket handshake, so the automatic model preference uses SSE on Windows while the explicit WebSocket setting remains available for operators who have a newer safe runtime.

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -66259,6 +66259,179 @@
 				"minLevel": "minimal",
 				"maxLevel": "xhigh"
 			}
+		},
+		"deepseek-v4-flash-vision-exp": {
+			"id": "deepseek-v4-flash-vision-exp",
+			"name": "DeepSeek V4 Flash Vision Exp",
+			"api": "openai-completions",
+			"provider": "opencode-go",
+			"baseUrl": "https://opencode.ai/zen/go/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.22,
+				"output": 0.66,
+				"cacheRead": 0.007,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 384000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"glm-5.3-flash": {
+			"id": "glm-5.3-flash",
+			"name": "GLM-5.3-Flash (2x usage)",
+			"api": "openai-completions",
+			"provider": "opencode-go",
+			"baseUrl": "https://opencode.ai/zen/go/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.075,
+				"output": 0.25,
+				"cacheRead": 0.015,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"grok-4.6": {
+			"id": "grok-4.6",
+			"name": "Grok 4.6",
+			"api": "openai-responses",
+			"provider": "opencode-go",
+			"baseUrl": "https://opencode.ai/zen/go/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.5,
+				"cacheWrite": 0
+			},
+			"contextWindow": 500000,
+			"maxTokens": 500000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"hy4-preview": {
+			"id": "hy4-preview",
+			"name": "Hy4 preview",
+			"api": "openai-completions",
+			"provider": "opencode-go",
+			"baseUrl": "https://opencode.ai/zen/go/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.834,
+				"output": 2.501,
+				"cacheRead": 0.042,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1024000,
+			"maxTokens": 64000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"longcat-2.0": {
+			"id": "longcat-2.0",
+			"name": "LongCat-2.0",
+			"api": "openai-completions",
+			"provider": "opencode-go",
+			"baseUrl": "https://opencode.ai/zen/go/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.3,
+				"output": 1.2,
+				"cacheRead": 0.006,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"muse-spark-1.2-contributor": {
+			"id": "muse-spark-1.2-contributor",
+			"name": "Muse Spark 1.2 Contributor",
+			"api": "openai-responses",
+			"provider": "opencode-go",
+			"baseUrl": "https://opencode.ai/zen/go/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.1,
+				"output": 0.2,
+				"cacheRead": 0.002,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"qwen3.8-flash": {
+			"id": "qwen3.8-flash",
+			"name": "Qwen3.8 Flash",
+			"api": "anthropic-messages",
+			"provider": "opencode-go",
+			"baseUrl": "https://opencode.ai/zen/go",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.15,
+				"output": 0.47,
+				"cacheRead": 0.016,
+				"cacheWrite": 0.2
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
 		}
 	},
 	"opencode-zen": {

--- a/packages/ai/src/provider-models/openai-compat.ts
+++ b/packages/ai/src/provider-models/openai-compat.ts
@@ -2357,11 +2357,15 @@ const OPENCODE_GO_BASE_PATH = "https://opencode.ai/zen/go";
 const OPENCODE_ZEN_API_RESOLUTION = createOpenCodeApiResolution("https://opencode.ai/zen");
 const OPENCODE_GO_CHAT_COMPLETIONS_MODEL_IDS = [
 	"deepseek-v4-flash",
+	"deepseek-v4-flash-vision-exp",
 	"deepseek-v4-pro",
 	"glm-5.1",
 	"glm-5.2",
+	"glm-5.3-flash",
 	"kimi-k2.6",
 	"kimi-k2.7-code",
+	"hy4-preview",
+	"longcat-2.0",
 	"mimo-v2.5",
 	"mimo-v2.5-pro",
 ] as const;
@@ -2372,6 +2376,7 @@ const OPENCODE_GO_MESSAGES_MODEL_IDS = [
 	"qwen3.6-plus",
 	"qwen3.7-max",
 	"qwen3.7-plus",
+	"qwen3.8-flash",
 ] as const;
 const OPENCODE_GO_API_OVERRIDES: Readonly<Record<string, Api>> = {
 	...Object.fromEntries(OPENCODE_GO_CHAT_COMPLETIONS_MODEL_IDS.map(id => [id, "openai-completions"])),
@@ -2795,6 +2800,62 @@ const OPENCODE_GO_OFFICIAL_MODELS: Readonly<Record<string, OpenCodeGoOfficialMod
 		input: ["text"],
 		reasoning: true,
 		cost: { input: 0.066, output: 0.26, cacheRead: 0.029, cacheWrite: 0 },
+	},
+	"deepseek-v4-flash-vision-exp": {
+		name: "DeepSeek V4 Flash Vision Exp",
+		contextWindow: 1_000_000,
+		maxTokens: 384_000,
+		input: ["text", "image"],
+		reasoning: true,
+		cost: { input: 0.22, output: 0.66, cacheRead: 0.007, cacheWrite: 0 },
+	},
+	"glm-5.3-flash": {
+		name: "GLM-5.3-Flash (2x usage)",
+		contextWindow: 1_000_000,
+		maxTokens: 131_072,
+		input: ["text", "image"],
+		reasoning: true,
+		cost: { input: 0.075, output: 0.25, cacheRead: 0.015, cacheWrite: 0 },
+	},
+	"grok-4.6": {
+		name: "Grok 4.6",
+		contextWindow: 500_000,
+		maxTokens: 500_000,
+		input: ["text", "image"],
+		reasoning: true,
+		cost: { input: 2, output: 6, cacheRead: 0.5, cacheWrite: 0 },
+	},
+	"hy4-preview": {
+		name: "Hy4 preview",
+		contextWindow: 1_024_000,
+		maxTokens: 64_000,
+		input: ["text"],
+		reasoning: true,
+		cost: { input: 0.834, output: 2.501, cacheRead: 0.042, cacheWrite: 0 },
+	},
+	"longcat-2.0": {
+		name: "LongCat-2.0",
+		contextWindow: 1_000_000,
+		maxTokens: 131_072,
+		input: ["text"],
+		reasoning: true,
+		cost: { input: 0.3, output: 1.2, cacheRead: 0.006, cacheWrite: 0 },
+	},
+	"muse-spark-1.2-contributor": {
+		name: "Muse Spark 1.2 Contributor",
+		contextWindow: 1_048_576,
+		maxTokens: 131_072,
+		input: ["text", "image"],
+		reasoning: true,
+		cost: { input: 0.1, output: 0.2, cacheRead: 0.002, cacheWrite: 0 },
+	},
+	"qwen3.8-flash": {
+		name: "Qwen3.8 Flash",
+		contextWindow: 1_000_000,
+		maxTokens: 131_072,
+		input: ["text", "image"],
+		reasoning: true,
+		cost: { input: 0.15, output: 0.47, cacheRead: 0.016, cacheWrite: 0.2 },
 	},
 };
 

--- a/packages/ai/test/opencode-go-catalog-parity.test.ts
+++ b/packages/ai/test/opencode-go-catalog-parity.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test";
+import models from "../src/models.json" with { type: "json" };
+
+const LIVE_OPENCODE_GO_MODEL_IDS = [
+	"minimax-m3",
+	"minimax-m2.7",
+	"minimax-m2.5",
+	"kimi-k3",
+	"kimi-k2.7-code",
+	"kimi-k2.6",
+	"longcat-2.0",
+	"kimi-k2.5",
+	"glm-5.2",
+	"glm-5.3-flash",
+	"glm-5.3",
+	"glm-5.1",
+	"glm-5",
+	"deepseek-v4-pro",
+	"deepseek-v4-flash",
+	"deepseek-v4-flash-vision-exp",
+	"qwen3.7-max",
+	"qwen3.8-max",
+	"qwen3.8-flash",
+	"qwen3.7-plus",
+	"qwen3.6-plus",
+	"qwen3.5-plus",
+	"mimo-v2-pro",
+	"mimo-v2-omni",
+	"mimo-v2.5-pro",
+	"mimo-v2.5",
+	"hy4-preview",
+	"hy3",
+	"hy3-preview",
+	"gpt-5.6-luna",
+	"grok-4.5",
+	"grok-4.6",
+	"muse-spark-1.2-contributor",
+] as const;
+
+const catalog = models["opencode-go"];
+
+describe("OpenCode Go catalog parity", () => {
+	test("represents every id in the live provider fixture", () => {
+		expect(Object.keys(catalog).sort()).toEqual([...LIVE_OPENCODE_GO_MODEL_IDS].sort());
+	});
+
+	test.each([
+		[
+			"deepseek-v4-flash-vision-exp",
+			"openai-completions",
+			"https://opencode.ai/zen/go/v1",
+			["text", "image"],
+			1_000_000,
+			384_000,
+		],
+		["glm-5.3-flash", "openai-completions", "https://opencode.ai/zen/go/v1", ["text", "image"], 1_000_000, 131_072],
+		["grok-4.6", "openai-responses", "https://opencode.ai/zen/go/v1", ["text", "image"], 500_000, 500_000],
+		["hy4-preview", "openai-completions", "https://opencode.ai/zen/go/v1", ["text"], 1_024_000, 64_000],
+		["longcat-2.0", "openai-completions", "https://opencode.ai/zen/go/v1", ["text"], 1_000_000, 131_072],
+		[
+			"muse-spark-1.2-contributor",
+			"openai-responses",
+			"https://opencode.ai/zen/go/v1",
+			["text", "image"],
+			1_048_576,
+			131_072,
+		],
+		["qwen3.8-flash", "anthropic-messages", "https://opencode.ai/zen/go", ["text", "image"], 1_000_000, 131_072],
+	] as const)("keeps authoritative metadata for %s", (id, api, baseUrl, input, contextWindow, maxTokens) => {
+		const model = catalog[id];
+		expect(model).toMatchObject({
+			id,
+			api,
+			provider: "opencode-go",
+			baseUrl,
+			reasoning: true,
+			input,
+			contextWindow,
+			maxTokens,
+		});
+		expect(model.cost).toEqual(
+			expect.objectContaining({
+				input: expect.any(Number),
+				output: expect.any(Number),
+				cacheRead: expect.any(Number),
+			}),
+		);
+	});
+});


### PR DESCRIPTION
## Summary
- add the seven live OpenCode Go models missing from the bundled 26-entry catalog
- preserve provider endpoint routing and authoritative limits, costs, and input capabilities
- add parity coverage for all 33 live IDs and the seven new metadata rows

## Evidence
- live `https://opencode.ai/zen/go/v1/models` returned all 33 IDs, including `grok-4.6`
- OpenCode Go docs define endpoint transport; models.dev `opencode-go` rows provide catalog metadata
- reporter metadata was treated as untrusted and reconciled against those sources

## Verification
- `bun test packages/ai/test/opencode-go-catalog-parity.test.ts packages/ai/test/generate-models.test.ts packages/ai/test/issue-887-repro.test.ts packages/coding-agent/test/model-registry-runtime-provider.test.ts`
- `bun --cwd=packages/ai run check`
- native addon rebuilt for runtime registry tests

Closes #5144

## Risk classification
- [x] `low-risk` — bounded provider catalog metadata and generated registry parity; no selection fallback logic changed
- [ ] `regression-risk`
- [ ] `high-risk`

gajae.pr-review-verdict.v1 merge-self-approved sha256:c7b948737b32f0252f89828b4aa020f947b2f9fdb1c2a198195b1dc1389c57ac reviewer:architect reviewer-id:Yeachan-Heo evidence:Exact-head catalog review verified all 33 live OpenCode Go IDs, seven authoritative transport and capability rows, deterministic generated output, runtime stale-cache coverage, and preserved fail-closed unavailable selection.