### PR TITLE
fix(coordinator): recover released transition tombstones

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Coordinator session-state locks now reclaim an empty, identity-qualified released transition tombstone on POSIX after a short release grace period. Live, foreign, malformed, non-empty, or identity-changed claims remain fail-closed, while persistent macOS/File Provider debris no longer burns the full transition timeout on every state write. (#5159)
+
 - A runtime-state marker recorded against a different workspace path now reports that mismatch instead of claiming the file is unreadable, and a terminal, not-live marker that travelled into the current workspace with its session directory is adopted rather than refused. Live, non-terminal, and out-of-workspace markers are still refused untouched.
 - An unavailable provider-qualified `modelRoles.default` selection now reports the requested model instead of silently starting on another provider's baseline. This keeps signed-registry omissions and failed catalog admission actionable rather than routing requests to an unrelated retired model. (#5144)
 

--- a/packages/coding-agent/src/gjc-runtime/session-state-lock.ts
+++ b/packages/coding-agent/src/gjc-runtime/session-state-lock.ts
@@ -39,6 +39,7 @@ const LOCK_ACQUIRE_RETRY_MS = 5;
 const LOCK_ACQUIRE_MAX_RETRY_MS = 100;
 const LOCK_ACQUIRE_TIMEOUT_MS = 2_000;
 const LOCK_STALE_MS = 30_000;
+const RELEASED_TRANSITION_GRACE_MS = 1_000;
 
 interface LockRetryBudget {
 	startedAt: number;
@@ -1336,7 +1337,10 @@ async function acquireOwnerLock(
  *
  * Stale-owner reclaim still uses the native identity-bound detach protocol because no live
  * owner or transition claim can vouch for that pathname. A mismatch here likewise leaves a
- * successor strictly alone.
+ * successor strictly alone. A released tombstone is reclaimable on every platform when its
+ * owner host is this installation and the transition directory is proven empty and unchanged:
+ * the tombstone is the release marker, while the directory generation binds that marker to
+ * the exact claim that release failed to remove.
  */
 async function releaseOwnerLock(file: string, held: LockOwnerSnapshot): Promise<void> {
 	let owner: unknown;
@@ -1572,7 +1576,6 @@ async function reclaimStaleTransitionClaim(transitionDir: string, quarantineName
 		return;
 	}
 	if (!stat.isDirectory()) throw new SessionStateLockUnavailableError();
-	if (process.platform !== "win32") return;
 	const ownerSnapshot = await captureRegularLockOwner(`${transitionDir}.owner`);
 	if (!ownerSnapshot) return;
 	let owner: unknown;
@@ -1582,9 +1585,19 @@ async function reclaimStaleTransitionClaim(transitionDir: string, quarantineName
 		return;
 	}
 	if (!validLockOwner(owner)) return;
-	// Released tombstones intentionally remain fail-closed: they carry no live
-	// process proof and are not generation-bound to the sibling directory.
-	if (owner.released === true || (await lockOwnerIsAlive(owner))) return;
+	if (owner.released === true) {
+		// A released record is safe only when it is qualified by this installation.
+		// Never let a shared-volume tombstone, an absent identity, or a legacy foreign
+		// identity authorize removal of a claim this process cannot own.
+		if (owner.owner_host_id === undefined) return;
+		const currentHost = await currentOwnerHostId();
+		const legacyHost = await currentLegacyOwnerHostId();
+		if (owner.owner_host_id !== currentHost && owner.owner_host_id !== legacyHost) return;
+		if (Date.now() - Number(stat.mtimeNs / 1_000_000n) < RELEASED_TRANSITION_GRACE_MS) return;
+	} else {
+		if (process.platform !== "win32") return;
+		if (await lockOwnerIsAlive(owner)) return;
+	}
 	const generation = transitionGenerationFromStat(stat);
 	const nativePath = await canonicalOwnedTransitionPath(transitionDir).catch(() => null);
 	if (!nativePath) return;
@@ -1601,6 +1614,7 @@ async function reclaimStaleTransitionClaim(transitionDir: string, quarantineName
 		root.ctimeNs !== String(generation.ctimeNs)
 	)
 		return;
+	if (captured.snapshot.entries.length !== 1) return;
 	const removed = nativeSessionStateLock().exactRemoveDirectoryTree(nativePath, captured.snapshot);
 	if (removed.ok || removed.code === "not_found") {
 		const ownerRemoval = exactUnlinkOwnerRecord(`${transitionDir}.owner`, ownerSnapshot, quarantineName);

--- a/packages/coding-agent/test/fixtures/session-state-lock-debris-probe.ts
+++ b/packages/coding-agent/test/fixtures/session-state-lock-debris-probe.ts
@@ -106,6 +106,23 @@ switch (scenario) {
 		);
 		break;
 	}
+	case "released-transition-tombstone": {
+		const transitionDir = `${lockFile}.transition`;
+		await fs.mkdir(transitionDir, { mode: 0o700 });
+		await fs.writeFile(
+			`${transitionDir}.owner`,
+			JSON.stringify({
+				pid: 1,
+				start_time: "unknown",
+				token: "released-transition-tombstone",
+				owner_host_id: "probe-local-host",
+				released: true,
+			}),
+			{ mode: 0o600 },
+		);
+		await age(transitionDir);
+		break;
+	}
 
 	case "race-replacement": {
 		await fs.writeFile(

--- a/packages/coding-agent/test/session-state-lock-debris-subprocess.test.ts
+++ b/packages/coding-agent/test/session-state-lock-debris-subprocess.test.ts
@@ -95,6 +95,14 @@ describe("session-state lock debris subprocess contract", () => {
 		expect(result.wallMs).toBeLessThan(4_000);
 	});
 
+	it("reclaims an empty released transition tombstone on POSIX", async () => {
+		const result = await runProbe("released-transition-tombstone");
+		expect(result.entered).toBe(true);
+		expect(result.error).toBeNull();
+		expect(result.attempts).toBeLessThanOrEqual(2);
+		expect(result.wallMs).toBeLessThan(3_000);
+	});
+
 	it.skipIf(process.platform !== "win32")("reclaims a dead Windows transition claim", async () => {
 		const result = await runProbe("stale-dead-transition", true);
 		expect(result.entered).toBe(true);


### PR DESCRIPTION
## Risk classification

- [x] \low-risk\u0000
- [ ] \regression-risk\u0000
- [ ] \high-risk\u0000

## GJC verdict

gajae.pr-review-verdict.v1 merge-self-approved sha256:f85b65890eb71fa57c32f8d06aedb7f8af45f3a93202afab33c67a0116a85d23 reviewer:architect reviewer-id:Yeachan-Heo evidence:https://github.com/Yeachan-Heo/gajae-code/actions

## Summary
- reclaim empty, locally-qualified released transition tombstones on POSIX after a short grace period
- consume production native cleanup_pending detach receipts without deterministic .removing collisions
- preserve fail-closed handling for live, foreign, malformed, non-empty, and identity-changed claims
- add deterministic native and fallback regressions

Closes #5159