### PR TITLE
fix(coordinator): finish released tombstone cleanup

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/session-state-lock.ts
+++ b/packages/coding-agent/src/gjc-runtime/session-state-lock.ts
@@ -1593,7 +1593,7 @@ async function reclaimStaleTransitionClaim(transitionDir: string, quarantineName
 		const currentHost = await currentOwnerHostId();
 		const legacyHost = await currentLegacyOwnerHostId();
 		if (owner.owner_host_id !== currentHost && owner.owner_host_id !== legacyHost) return;
-		if (Date.now() - Number(stat.mtimeNs / 1_000_000n) < RELEASED_TRANSITION_GRACE_MS) return;
+		if (Date.now() - Number(ownerSnapshot.mtimeNs / 1_000_000n) < RELEASED_TRANSITION_GRACE_MS) return;
 	} else {
 		if (process.platform !== "win32") return;
 		if (await lockOwnerIsAlive(owner)) return;
@@ -1629,6 +1629,12 @@ async function reclaimStaleTransitionClaim(transitionDir: string, quarantineName
 		removed.retainedUnknownPath === undefined &&
 		removed.retainedPlaceholderPath === undefined
 	) {
+		// The captured claim is proven empty, so the native detach receipt leaves an
+		// empty directory at detachedPath. Remove that exact directory directly: calling
+		// the detach primitive again would deterministically create a second `.removing`
+		// collision on POSIX. rmdir never follows a directory's contents and refuses if a
+		// successor populated the detached path.
+		await removeTransitionDir(removed.detachedPath);
 		const ownerRemoval = exactUnlinkOwnerRecord(`${transitionDir}.owner`, ownerSnapshot, quarantineName);
 		if (ownerRemoval !== "removed" && ownerRemoval !== "absent") return;
 		return;

--- a/packages/coding-agent/test/session-state-lock-debris-subprocess.test.ts
+++ b/packages/coding-agent/test/session-state-lock-debris-subprocess.test.ts
@@ -103,6 +103,13 @@ describe("session-state lock debris subprocess contract", () => {
 		expect(result.wallMs).toBeLessThan(3_000);
 	});
 
+	it.skipIf(process.platform === "win32")("reclaims released tombstone with production native cleanup", async () => {
+		const result = await runProbe("released-transition-tombstone", true);
+		expect(result.entered).toBe(true);
+		expect(result.error).toBeNull();
+		expect(result.wallMs).toBeLessThan(3_000);
+	});
+
 	it.skipIf(process.platform !== "win32")("reclaims a dead Windows transition claim", async () => {
 		const result = await runProbe("stale-dead-transition", true);
 		expect(result.entered).toBe(true);


### PR DESCRIPTION
## Risk classification

- [x] `low-risk`
- [ ] `regression-risk`
- [ ] `high-risk`

## GJC verdict

gajae.pr-review-verdict.v1 merge-self-approved sha256:dbafbb32382c05f2cc4e653e2fd1eb82631dfce69dce5760cf5ddae62267af42 reviewer:architect reviewer-id:Yeachan-Heo evidence:https://github.com/Yeachan-Heo/gajae-code/actions

## Summary
- consume production native cleanup_pending detach receipts without deterministic .removing collisions
- measure release grace from the owner tombstone mtime
- add deterministic native regression coverage

Closes #5159