### PR TITLE
fix(file-lock): reject malformed runtime paths

### DIFF
--- a/packages/coding-agent/src/config/file-lock.ts
+++ b/packages/coding-agent/src/config/file-lock.ts
@@ -1174,6 +1174,10 @@ async function lockHolderDescription(lockPath: string): Promise<string> {
 }
 
 async function acquireLock(filePath: string, options: FileLockOptions = {}): Promise<() => Promise<void>> {
+	const requestedFilePath: unknown = filePath;
+	if (typeof requestedFilePath !== "string" || requestedFilePath.length === 0 || !path.isAbsolute(requestedFilePath))
+		throw new TypeError("filePath must be a non-empty absolute path");
+	if (requestedFilePath.includes("\0")) throw new TypeError("filePath must not contain NUL bytes");
 	if (options.ownerHostId !== undefined && !options.ownerHostId) throw new Error("ownerHostId must be non-empty");
 	if (options.previousOwnerHostIds?.some(hostId => !hostId))
 		throw new Error("previousOwnerHostIds must contain only non-empty identities");

--- a/packages/coding-agent/test/file-lock-gc-toctou.test.ts
+++ b/packages/coding-agent/test/file-lock-gc-toctou.test.ts
@@ -170,6 +170,18 @@ describe("withFileLock stale owner liveness (#652)", () => {
 		expect(fallbackCalls).toBe(1);
 	});
 
+	test("rejects malformed runtime lock operands before publication", async () => {
+		let entered = false;
+		for (const operand of ["", null, 42, "../escape"] as unknown[]) {
+			await expect(
+				withFileLock(operand as string, async () => {
+					entered = true;
+				}),
+			).rejects.toThrow("filePath must be a non-empty absolute path");
+		}
+		expect(entered).toBe(false);
+	});
+
 	test("does not replace a legacy empty lock directory when publication is unsupported", async () => {
 		const root = await makeTemp();
 		const file = path.join(root, "legacy-empty", "publication.json");


### PR DESCRIPTION
Follow-up hardening for #5164 and PR #5165.

The merged publication fallback is safe for valid paths; this follow-up rejects malformed runtime operands before any filesystem access, including empty, relative, NUL-bearing, null, and numeric values.

Verification: `bun test packages/coding-agent/test/file-lock-gc-toctou.test.ts`; `bun --cwd=packages/coding-agent run check:types`; `bunx biome check packages/coding-agent/src/config/file-lock.ts packages/coding-agent/test/file-lock-gc-toctou.test.ts`.

- [x] `low-risk`
- [ ] `regression-risk`
- [ ] `high-risk`


gajae.pr-review-verdict.v1 merge-self-approved sha256:50f4952126070af2eb7f48309c661747326d3186ccae53c982b376d88f70a95e reviewer:architect reviewer-id:Yeachan-Heo evidence:exact-head malformed-operand regression evidence



<!-- final contract replay -->
