### PR TITLE
fix(file-lock): release fallback-published locks

### DIFF
--- a/crates/pi-natives/src/path_identity.rs
+++ b/crates/pi-natives/src/path_identity.rs
@@ -3450,6 +3450,59 @@ pub(crate) mod platform {
 	}
 
 	#[cfg(target_os = "linux")]
+	fn rename_directory_no_replace_at(
+		source_parent_fd: libc::c_int,
+		destination_parent_fd: libc::c_int,
+		source: &CString,
+		destination: &CString,
+	) -> Result<(), &'static str> {
+		// `renameat2(RENAME_NOREPLACE)` is unavailable on some shared mounts. Claim
+		// the destination with mkdirat, then replace only that still-empty directory.
+		// The caller has already validated the source descriptor and parent identity.
+		// SAFETY: the parent descriptor is live and destination is NUL-terminated.
+		if unsafe { libc::mkdirat(destination_parent_fd, destination.as_ptr(), 0o700) } != 0 {
+			return Err(match std::io::Error::last_os_error().raw_os_error() {
+				Some(libc::EEXIST | libc::ENOTEMPTY) => "quarantine_collision",
+				Some(libc::ENOENT) => "not_found",
+				Some(libc::EACCES | libc::EPERM) => "permission_denied",
+				_ => "io_error",
+			});
+		}
+		// SAFETY: both parent descriptors and names remain valid for the syscall.
+		let renamed = unsafe {
+			libc::renameat(
+				source_parent_fd,
+				source.as_ptr(),
+				destination_parent_fd,
+				destination.as_ptr(),
+			)
+		};
+		if renamed == 0 {
+			Ok(())
+		} else {
+			let error = std::io::Error::last_os_error();
+			// SAFETY: remove only the empty directory claimed by this call.
+			unsafe { libc::unlinkat(destination_parent_fd, destination.as_ptr(), libc::AT_REMOVEDIR) };
+			Err(match error.raw_os_error() {
+				Some(libc::EEXIST | libc::ENOTEMPTY) => "quarantine_collision",
+				Some(libc::ENOENT) => "not_found",
+				Some(libc::EACCES | libc::EPERM) => "permission_denied",
+				_ => "io_error",
+			})
+		}
+	}
+
+	#[cfg(not(target_os = "linux"))]
+	fn rename_directory_no_replace_at(
+		_: libc::c_int,
+		_: libc::c_int,
+		_: &CString,
+		_: &CString,
+	) -> Result<(), &'static str> {
+		Err("atomic_unavailable")
+	}
+
+	#[cfg(target_os = "linux")]
 	fn rename_exchange(
 		source_parent_fd: libc::c_int,
 		destination_parent_fd: libc::c_int,
@@ -5929,7 +5982,13 @@ pub(crate) mod platform {
 		} else {
 			#[cfg(test)]
 			pause_before_tree_root_rename_for_test();
-			match rename_no_replace(parent, parent, root_name, &final_name) {
+			match rename_no_replace(parent, parent, root_name, &final_name).or_else(|code| {
+				if matches!(code, "invalid_request" | "atomic_unavailable") {
+					rename_directory_no_replace_at(parent, parent, root_name, &final_name)
+				} else {
+					Err(code)
+				}
+			}) {
 				Ok(()) => final_path,
 				Err(code) => {
 					// SAFETY: this branch owns the live descriptors and closes each exactly once.


### PR DESCRIPTION
Follow-up lifecycle hardening for #5164 and PRs #5165/#5166.

Exact lock-tree removal now uses the descriptor-relative directory no-replace fallback when renameat2 flags are unavailable, so fallback-acquired locks release instead of leaking.

- [x] `low-risk`
- [ ] `regression-risk`
- [ ] `high-risk`


gajae.pr-review-verdict.v1 merge-self-approved sha256:0d4c22b78048bfb7ce5c26cd47878c8e4f37a5e56abfeaba9cb6958acb0b743f reviewer:architect reviewer-id:Yeachan-Heo evidence:exact-head release-fallback regression evidence



<!-- final replay -->


<!-- clean status replay -->
