### PR TITLE
fix(coordinator): recover raced projection scans

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Fresh interactive onboarding now asks for an interface language before showing guidance, supports English, Korean, Simplified Chinese, and Japanese, persists the choice through `ui.language`, and uses a documented English fallback for noninteractive, invalid, cancelled, or unwritable startup.
+- Coordinator projection consumers now retry a bounded number of fresh authoritative scans when concurrent session churn races a candidate. Cap exhaustion, owner disappearance, unsupported authority, and parse failures remain fail-closed, while settled concurrent SDK sessions no longer permanently starve the session reaper or coordinator mutations. (#5168)
 
 - Coordinator session-state locks now reclaim an empty, identity-qualified released transition tombstone on POSIX after a short release grace period. Live, foreign, malformed, non-empty, or identity-changed claims remain fail-closed, while persistent macOS/File Provider debris no longer burns the full transition timeout on every state write. (#5159)
 

--- a/packages/coding-agent/src/coordinator-mcp/projection-scan.ts
+++ b/packages/coding-agent/src/coordinator-mcp/projection-scan.ts
@@ -36,6 +36,8 @@ function projectionPlatform(): NodeJS.Platform {
 
 /** Post-filter parse-candidate cap. Exhaustion returns an explicit incomplete result. */
 export const COORDINATOR_JSON_SCAN_CAP = 10_000;
+/** Number of fresh authoritative attempts allowed for a scan that observed churn. */
+export const COORDINATOR_JSON_SCAN_RETRY_ATTEMPTS = 3;
 
 export interface ProjectionScanStat {
 	size: number | bigint;
@@ -568,4 +570,23 @@ export async function listCoordinatorJsonFiles(
 	} finally {
 		await authority?.close().catch(() => undefined);
 	}
+}
+
+/**
+ * Retry only scans invalidated by observed directory/file churn. A candidate cap,
+ * unsupported authority, parse error, or any other failure remains fail-closed.
+ * Each attempt acquires a new authority, so no partial result crosses attempts.
+ */
+export async function listCoordinatorJsonFilesWithRetry(
+	dir: string,
+	io: ProjectionScanFs = defaultFs,
+	cap: number = COORDINATOR_JSON_SCAN_CAP,
+	maxAttempts: number = COORDINATOR_JSON_SCAN_RETRY_ATTEMPTS,
+): Promise<ProjectionScanResult> {
+	const attempts = Math.max(1, Math.floor(maxAttempts));
+	let scan = await listCoordinatorJsonFiles(dir, io, cap);
+	for (let attempt = 1; attempt < attempts && scan.incomplete && scan.raced > 0; attempt++) {
+		scan = await listCoordinatorJsonFiles(dir, io, cap);
+	}
+	return scan;
 }

--- a/packages/coding-agent/src/coordinator-mcp/server.ts
+++ b/packages/coding-agent/src/coordinator-mcp/server.ts
@@ -83,7 +83,7 @@ import {
 	requireCoordinatorMutation,
 	safeOpenCoordinatorArtifact,
 } from "./policy";
-import { listCoordinatorJsonFiles } from "./projection-scan";
+import { listCoordinatorJsonFilesWithRetry } from "./projection-scan";
 import {
 	answerBindingMatches,
 	buildCoordinatorAskAnswerSchema,
@@ -1498,7 +1498,7 @@ function publicSdkAcknowledgement(result: RuntimePromptAcknowledgement): Record<
 }
 
 async function listJsonFiles(dir: string): Promise<unknown[]> {
-	const scan = await listCoordinatorJsonFiles(dir);
+	const scan = await listCoordinatorJsonFilesWithRetry(dir);
 	if (scan.capped) throw new Error("coordinator_projection_scan_incomplete");
 	if (scan.skippedEmpty > 0 || scan.skippedDebris > 0) {
 		logger.warn("Coordinator projection scan skipped debris", {

--- a/packages/coding-agent/test/empty-delete-receipt-latch.test.ts
+++ b/packages/coding-agent/test/empty-delete-receipt-latch.test.ts
@@ -9,6 +9,7 @@ import { writeCoordinatorAtomic } from "../src/coordinator-mcp/durability";
 import {
 	COORDINATOR_JSON_SCAN_CAP,
 	listCoordinatorJsonFiles,
+	listCoordinatorJsonFilesWithRetry,
 	type ProjectionScanDirectory,
 	ProjectionScanTestHooks,
 } from "../src/coordinator-mcp/projection-scan";
@@ -95,6 +96,78 @@ describe("empty .gjc-delete-* latch", () => {
 		expect(scan.raced).toBe(1);
 		expect(scan.incomplete).toBe(true);
 		expect(scan.capped).toBe(true);
+	});
+
+	it("Test 1 recovery: six concurrent projection writers settle within bounded retries", async () => {
+		const dir = await tempRoot("gjc-scan-retry-");
+		for (let index = 0; index < 6; index++)
+			await fs.writeFile(
+				path.join(dir, `session-${index}.json`),
+				JSON.stringify({ session_id: `session-${index}` }),
+			);
+		let attempts = 0;
+		const scan = await listCoordinatorJsonFilesWithRetry(
+			dir,
+			{
+				readdir: async target => fs.readdir(target),
+				lstat: async file => {
+					if (path.basename(file) === "session-0.json" && attempts < 2) {
+						attempts += 1;
+						const error = new Error("concurrent writer replaced candidate") as NodeJS.ErrnoException;
+						error.code = "ELOOP";
+						throw error;
+					}
+					return fs.lstat(file);
+				},
+				readFile: (file, encoding) => fs.readFile(file, encoding),
+			},
+			10,
+			3,
+		);
+		expect(attempts).toBe(2);
+		expect(scan.values).toHaveLength(6);
+		expect(scan.incomplete).toBe(false);
+		expect(scan.raced).toBe(0);
+	});
+
+	it("Test 1 recovery: owner disappearance never becomes an authoritative empty result", async () => {
+		const stat = {
+			size: 0,
+			dev: 1n,
+			ino: 2n,
+			isDirectory: () => true,
+			isFile: () => false,
+			isSymbolicLink: () => false,
+		};
+		const error = new Error("owner disappeared") as NodeJS.ErrnoException;
+		error.code = "ENOENT";
+		let opens = 0;
+		const scan = await listCoordinatorJsonFilesWithRetry(
+			"/owner-disappeared",
+			{
+				readdir: async () => [],
+				lstat: async () => stat,
+				readFile: async () => "{}",
+				openDirectory: async () => {
+					opens += 1;
+					return {
+						stat,
+						readdir: async () => {
+							throw error;
+						},
+						lstat: async () => stat,
+						readFile: async () => "{}",
+						close: async () => {},
+					};
+				},
+			},
+			COORDINATOR_JSON_SCAN_CAP,
+			3,
+		);
+		expect(opens).toBe(3);
+		expect(scan.values).toEqual([]);
+		expect(scan.incomplete).toBe(true);
+		expect(scan.raced).toBe(1);
 	});
 
 	it.skipIf(process.platform !== "linux")(


### PR DESCRIPTION
Closes #5168

## Risk classification
- [x] `low-risk`
- [ ] `regression-risk`
- [ ] `high-risk`

## Summary
- retry only projection scans invalidated by observed concurrent file/root churn
- acquire a fresh authority for every retry; preserve fail-closed cap, owner disappearance, unsupported-authority, and parse behavior
- cover six concurrent projection records, bounded recovery, and owner disappearance

## Validation
- `bun test packages/coding-agent/test/empty-delete-receipt-latch.test.ts`
- `bun test packages/coding-agent/test/coordinator-mcp/session-reaper.test.ts`
- `bun test packages/coding-agent/test/coordinator-mcp-server.test.ts`
- `bun --cwd=packages/coding-agent run check`

Signed commit: `a911cf9467c6305d5e4172782b8daf180b0cb586`

gajae.pr-review-verdict.v1 merge-self-approved sha256:489acba3a14ce2991eea1b30f94f8268d2133af4c9c177f52608a409da8c5591 reviewer:architect reviewer-id:Yeachan-Heo evidence:Exact-head bounded retry preserves authoritative scan and fail-closed mutation admission; signed maintainer self-review comment binds the low-risk classification.
<!-- exact-contract-refresh-2 -->