### PR TITLE
fix(ai): correct cursor kimi-k3 context window to 1M (measured 1,026,459 tokens accepted)

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- Cursor's `kimi-k3-low`, `kimi-k3-high`, and `kimi-k3-max` now declare their real 1,048,576-token context window instead of 200,000. The bundled value was understated by 5.2x, so context management compacted these models at roughly a fifth of their usable window. The same underlying model already declares 1,048,576 elsewhere in this catalog (`openrouter/moonshotai/kimi-k3`, `kilo/moonshotai/kimi-k3`, and `opencode-go/kimi-k3` in `provider-models/openai-compat.ts`), so the cursor entries were the inconsistent ones. Measured against the live `cursor-agent` transport, which reports `usage.inputTokens` per request: 1,026,459 input tokens were accepted and answered correctly, while 1,161,948 tokens were silently summarized down to 20,552 and lost the answer. Output `maxTokens` is unchanged at 64,000, which this change did not measure.
+
 - OpenCode Go's bundled catalog now contains all 33 models advertised by its live provider list, including the seven newly published models. Canonical endpoint metadata supplies their transport, multimodal input, limits, pricing, and reasoning capabilities, while generated output remains deterministic and preserves fail-closed selection when a live catalog is unavailable (#5144).
 
 - SQLite corruption detection is now shared by credential and capability-cache surfaces, so callers can recognize `SQLITE_CORRUPT` and `SQLITE_NOTADB` without inspecting provider-specific error details.

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -10900,7 +10900,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 200000,
+			"contextWindow": 1048576,
 			"maxTokens": 64000
 		},
 		"kimi-k3-low": {
@@ -10919,7 +10919,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 200000,
+			"contextWindow": 1048576,
 			"maxTokens": 64000
 		},
 		"kimi-k3-max": {
@@ -10938,7 +10938,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 200000,
+			"contextWindow": 1048576,
 			"maxTokens": 64000
 		}
 	},


### PR DESCRIPTION
## What

Corrects the bundled `contextWindow` for cursor's `kimi-k3-low`, `kimi-k3-high`, and `kimi-k3-max` from `200000` to `1048576`.

Three numbers in `packages/ai/src/models.json`. No code change.

## Why

Cursor's `GetUsableModels` sends no numeric context metadata, so `resolveCursorLiveContextWindow` (`packages/ai/src/utils/discovery/cursor.ts`) infers a million-token window only from a display name containing `1M`, and otherwise falls back to the bundled catalog value. Cursor names these models `Kimi K3 Low` / `Kimi K3 High` / `Kimi K3` with no `1M` marker, so they always landed on the understated fallback.

The resolver already returns `Math.max(named, fallback)` and its doc comment says *"Never shrink a larger bundled fallback such as Gemini's 1048576-token window."* Correcting the bundled number is therefore the fix path the existing design intends, which is why no code changes.

**The catalog was already internally inconsistent.** The same underlying model declares `1048576` in three other places in this repo:

| entry | contextWindow |
|---|---|
| `openrouter/moonshotai/kimi-k3` | 1048576 |
| `kilo/moonshotai/kimi-k3` | 1048576 |
| `opencode-go/kimi-k3` (`provider-models/openai-compat.ts:2702`) | `1_048_576` |
| `cursor/kimi-k3-*` | **200000** |

**Impact:** context management compacted these models at roughly a fifth of their usable window, discarding ~80% of available context.

## Testing

Measured against the live `cursor-agent` transport, using `usage.inputTokens` as reported by the cursor API itself (not a local estimate). Needle-in-a-haystack with the marker placed mid-payload.

| model | reported `inputTokens` | result |
|---|---|---|
| `kimi-k3-max` | **1,026,459** | correct needle |
| `kimi-k3-max` | 340,648 | correct needle |
| `kimi-k3-high` | 340,649 | correct needle |
| `kimi-k3-low` | 340,649 | correct needle |
| `kimi-k3-max` | **1,161,948** | **silently summarized to 20,552; needle lost, answer hallucinated** |

Two findings worth flagging:

1. All three tiers accept far more than 200000, so the bundled value was understated for the whole family.
2. Past the ceiling cursor does **not** return an error — it silently summarizes and loses content. So an over-stated value would degrade quality invisibly. That is why this PR uses the measured-bracket value rather than rounding up. The two runs bracket the limit to (1.03M, 1.16M), and 1048576 is the only round value inside it, matching what the same model reports on openrouter.

Confound control: runs executed in an empty working directory with the payload piped from stdin outside that directory, and the complete `--output-format stream-json` transcript contains zero tool-call events, so the model could not have read the needle off disk.

Focused tests on this checkout:

```
bun test packages/ai/test/cursor-discovery-context-window.test.ts \
         packages/ai/test/model-manager-context-cap.test.ts \
         packages/ai/test/generate-models.test.ts
# 19 pass, 0 fail
```

No test asserts `200000` for these entries; `cursor-discovery-context-window.test.ts` exercises the resolver with injected references and is unaffected.

Output `maxTokens` is left at `64000` — this change did not measure output capacity, and over-stating it would cause API errors.

## Risk classification

- [ ] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [x] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

Classified as `regression-risk` rather than `low-risk` on purpose: it raises a shared-catalog limit for every cursor kimi-k3 user, and my measurements come from one cursor account. If cursor's window varies by plan, a lower-tier account would hit the silent-summarization path instead of a clean error. A reviewer with a different cursor plan re-running the 1,026,459-token case would close that gap.

## GJC verdict

```text
gajae.pr-review-verdict.v1 needs-human sha256:b43c258ce1f2f6138bd0630c086603a04fc209f192039121d3bc9cb477e55464 reviewer:human reviewer-id:none evidence:external-contributor-cannot-self-approve
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken

> `bun check` unchecked: not run to completion on this checkout. The change is three integer literals in a data file; focused tests listed above pass and JSON validity is verified. Full CI on the exact head is authoritative.
