### PR TITLE
fix(ai): correct Cursor Kimi K3 context window

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- Cursor's `kimi-k3-low`, `kimi-k3-high`, and `kimi-k3-max` now declare their real 1,048,576-token context window instead of 200,000. The bundled value was understated by 5.2x, so context management compacted these models at roughly a fifth of their usable window. The same underlying model already declares 1,048,576 elsewhere in this catalog (`openrouter/moonshotai/kimi-k3`, `kilo/moonshotai/kimi-k3`, and `opencode-go/kimi-k3` in `provider-models/openai-compat.ts`), so the cursor entries were the inconsistent ones. Measured against the live `cursor-agent` transport, which reports `usage.inputTokens` per request: 1,026,459 input tokens were accepted and answered correctly, while 1,161,948 tokens were silently summarized down to 20,552 and lost the answer. Output `maxTokens` is unchanged at 64,000, which this change did not measure.
+
 - OpenCode Go's bundled catalog now contains all 33 models advertised by its live provider list, including the seven newly published models. Canonical endpoint metadata supplies their transport, multimodal input, limits, pricing, and reasoning capabilities, while generated output remains deterministic and preserves fail-closed selection when a live catalog is unavailable (#5144).
 
 - SQLite corruption detection is now shared by credential and capability-cache surfaces, so callers can recognize `SQLITE_CORRUPT` and `SQLITE_NOTADB` without inspecting provider-specific error details.

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Cursor's `kimi-k3-low`, `kimi-k3-high`, and `kimi-k3-max` now declare their real 1,048,576-token context window instead of 200,000. The bundled value was understated by 5.2x, so context management compacted these models at roughly a fifth of their usable window. The same underlying model already declares 1,048,576 elsewhere in this catalog (`openrouter/moonshotai/kimi-k3`, `kilo/moonshotai/kimi-k3`, and `opencode-go/kimi-k3` in `provider-models/openai-compat.ts`), so the cursor entries were the inconsistent ones. Measured against the live `cursor-agent` transport, which reports `usage.inputTokens` per request: 1,026,459 input tokens were accepted and answered correctly, while 1,161,948 tokens were silently summarized down to 20,552 and lost the answer. Output `maxTokens` is unchanged at 64,000, which this change did not measure.
 
+- The Cursor Kimi K3 context correction is now enforced by the deterministic model-generation policy, so a future catalog regeneration cannot reintroduce the stale 200,000-token fallback.
+
 - OpenCode Go's bundled catalog now contains all 33 models advertised by its live provider list, including the seven newly published models. Canonical endpoint metadata supplies their transport, multimodal input, limits, pricing, and reasoning capabilities, while generated output remains deterministic and preserves fail-closed selection when a live catalog is unavailable (#5144).
 
 - SQLite corruption detection is now shared by credential and capability-cache surfaces, so callers can recognize `SQLITE_CORRUPT` and `SQLITE_NOTADB` without inspecting provider-specific error details.

--- a/packages/ai/src/model-thinking.ts
+++ b/packages/ai/src/model-thinking.ts
@@ -278,6 +278,14 @@ export function applyGeneratedModelPolicies(models: ApiModel<Api>[]): void {
 		if (source.provider === "omlx") {
 			source.reasoning = true;
 		}
+		if (
+			source.provider === "cursor" &&
+			(source.id === "kimi-k3-low" || source.id === "kimi-k3-high" || source.id === "kimi-k3-max")
+		) {
+			// Cursor's GetUsableModels metadata omits numeric context limits for
+			// this family. Keep the measured 1M fallback across regeneration.
+			source.contextWindow = 1_048_576;
+		}
 		const model = refreshModelThinking(source);
 		applyGeneratedModelPolicy(model);
 		models[index] = model;

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -10900,7 +10900,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 200000,
+			"contextWindow": 1048576,
 			"maxTokens": 64000
 		},
 		"kimi-k3-low": {
@@ -10919,7 +10919,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 200000,
+			"contextWindow": 1048576,
 			"maxTokens": 64000
 		},
 		"kimi-k3-max": {
@@ -10938,7 +10938,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 200000,
+			"contextWindow": 1048576,
 			"maxTokens": 64000
 		}
 	},

--- a/packages/ai/test/model-thinking.test.ts
+++ b/packages/ai/test/model-thinking.test.ts
@@ -374,6 +374,20 @@ describe("generated model policies", () => {
 		});
 	});
 
+	it("pins the measured Cursor Kimi K3 context window across regeneration", () => {
+		const models = [
+			createModel({ id: "kimi-k3-low", api: "cursor-agent", provider: "cursor" }),
+			createModel({ id: "kimi-k3-high", api: "cursor-agent", provider: "cursor" }),
+			createModel({ id: "kimi-k3-max", api: "cursor-agent", provider: "cursor" }),
+			createModel({ id: "kimi-k3-low", api: "openai-completions", provider: "openrouter" }),
+		];
+
+		applyGeneratedModelPolicies(models);
+
+		expect(models.slice(0, 3).map(model => model.contextWindow)).toEqual([1_048_576, 1_048_576, 1_048_576]);
+		expect(models[3]?.contextWindow).toBe(200_000);
+	});
+
 	it("removes unsupported reasoning controls only from Groq compound systems", () => {
 		const models = [
 			createModel({ id: "groq/compound", api: "openai-completions", provider: "groq" }),

--- a/packages/ai/test/model-thinking.test.ts
+++ b/packages/ai/test/model-thinking.test.ts
@@ -376,16 +376,27 @@ describe("generated model policies", () => {
 
 	it("pins the measured Cursor Kimi K3 context window across regeneration", () => {
 		const models = [
-			createModel({ id: "kimi-k3-low", api: "cursor-agent", provider: "cursor" }),
-			createModel({ id: "kimi-k3-high", api: "cursor-agent", provider: "cursor" }),
-			createModel({ id: "kimi-k3-max", api: "cursor-agent", provider: "cursor" }),
+			createModel({ id: "kimi-k3-low", api: "cursor-agent", provider: "cursor", reasoning: false }),
+			createModel({ id: "kimi-k3-high", api: "cursor-agent", provider: "cursor", reasoning: false }),
+			createModel({ id: "kimi-k3-max", api: "cursor-agent", provider: "cursor", reasoning: false }),
+			createModel({ id: "kimi-k3", api: "cursor-agent", provider: "cursor", reasoning: false }),
 			createModel({ id: "kimi-k3-low", api: "openai-completions", provider: "openrouter" }),
 		];
+		for (const model of models.slice(0, 3)) {
+			model.contextWindow = 200_000;
+			model.maxTokens = 64_000;
+		}
 
 		applyGeneratedModelPolicies(models);
 
 		expect(models.slice(0, 3).map(model => model.contextWindow)).toEqual([1_048_576, 1_048_576, 1_048_576]);
+		expect(models.slice(0, 3).map(model => model.maxTokens)).toEqual([64_000, 64_000, 64_000]);
 		expect(models[3]?.contextWindow).toBe(200_000);
+		expect(models[4]?.contextWindow).toBe(200_000);
+
+		models[0]!.contextWindow = 2_000_000;
+		applyGeneratedModelPolicies(models);
+		expect(models[0]?.contextWindow).toBe(1_048_576);
 	});
 
 	it("removes unsupported reasoning controls only from Groq compound systems", () => {


### PR DESCRIPTION
## Summary

Replays contributor PR #5170 onto current `dev` and preserves its attribution, correcting Cursor Kimi K3 Low/High/Max bundled context windows from 200,000 to 1,048,576 tokens.

Also adds the deterministic generation policy and regression test requested by exact-head review, so future catalog regeneration cannot reintroduce the stale fallback.

## Evidence

- Exact contributor head: `1c6981b4eb16f0756cf0188678584373f686f498`
- Current base: `b4c49f6c53a70bdbaf3ffd97667f699f55c71db1`
- Live transport evidence in #5170: 1,026,459 accepted with correct needle; 1,161,948 silently summarized to 20,552 with needle lost.
- Same model family is already 1,048,576 in OpenRouter, Kilo, and OpenCode Go catalog entries.
- `maxTokens` remains 64,000 because output capacity was not measured.

## Verification

- 56 focused AI tests pass across Cursor discovery, model manager, model generation, and generated model policy suites.
- `bun --cwd=packages/ai run check` passes with only pre-existing informational diagnostics.
- Regeneration exercised; the policy re-emits all three Cursor rows at 1,048,576.


## GJC verdict

gajae.pr-review-verdict.v1 merge-approved sha256:b38971977a51dbf1330aae5d9abbde80beef53dc4741bc8bca0d7d1d769bf078 reviewer:human reviewer-id:probepark evidence:https://github.com/Yeachan-Heo/gajae-code/pull/5171 exact-head APPROVED review and focused CI



## Risk classification

- [ ] `low-risk`
- [x] `regression-risk`
- [ ] `high-risk`




<!-- exact-head-contract-refresh -->
