### PR TITLE
fix(ai): report cursor prompt tokens instead of zero (context indicator frozen, compaction never fires)

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- Cursor sessions now report prompt tokens instead of zero. `ConversationTokenDetails.used_tokens` counts the whole conversation, but the checkpoint handler assigned it to `usage.output` and returned early whenever token deltas had been seen — which is the normal streaming path — so `usage.input`, `usage.cacheRead`, and `usage.cacheWrite` were left at their zero initializers for every cursor request. `calculatePromptTokens` therefore fell through to its output-only fallback, so the context indicator tracked the last response's output size rather than the conversation, and automatic compaction never observed a full context. Conversation usage is now recorded through the stream and split into prompt and output tokens when the stream finalizes.
+
 - OpenCode Go's bundled catalog now contains all 33 models advertised by its live provider list, including the seven newly published models. Canonical endpoint metadata supplies their transport, multimodal input, limits, pricing, and reasoning capabilities, while generated output remains deterministic and preserves fail-closed selection when a live catalog is unavailable (#5144).
 
 - SQLite corruption detection is now shared by credential and capability-cache surfaces, so callers can recognize `SQLITE_CORRUPT` and `SQLITE_NOTADB` without inspecting provider-specific error details.

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -24,6 +24,7 @@ import type {
 	Tool,
 	ToolCall,
 	ToolResultMessage,
+	Usage,
 } from "../types";
 import { normalizeSystemPrompts } from "../utils";
 import { kCursorExecResolved } from "../utils/block-symbols";
@@ -733,7 +734,7 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 			let currentTextBlock: (TextContent & { index: number }) | null = null;
 			let currentThinkingBlock: (ThinkingContent & { index: number }) | null = null;
 			let currentToolCall: ToolCallState | null = null;
-			const usageState: UsageState = { sawTokenDelta: false };
+			const usageState: UsageState = { sawTokenDelta: false, conversationUsedTokens: 0 };
 
 			const state: BlockState = {
 				get currentTextBlock() {
@@ -899,6 +900,7 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 				});
 			}
 
+			finalizeCursorUsage(output, usageState);
 			calculateCost(model, output.usage);
 
 			output.duration = Date.now() - startTime;
@@ -959,6 +961,11 @@ interface BlockState {
 
 interface UsageState {
 	sawTokenDelta: boolean;
+	/**
+	 * Latest `ConversationTokenDetails.used_tokens`: the whole conversation's
+	 * token consumption as counted by Cursor, not this turn's output.
+	 */
+	conversationUsedTokens: number;
 }
 
 async function handleServerMessage(
@@ -2855,17 +2862,43 @@ function handleConversationCheckpointUpdate(
 	onConversationCheckpoint?: (checkpoint: ConversationStateStructure) => void,
 ): void {
 	onConversationCheckpoint?.(checkpoint);
-	if (usageState.sawTokenDelta) {
-		return;
-	}
 	const usedTokens = checkpoint.tokenDetails?.usedTokens ?? 0;
 	if (usedTokens <= 0) {
 		return;
 	}
-	if (output.usage.output !== usedTokens) {
-		output.usage.output = usedTokens;
-		output.usage.totalTokens = output.usage.input + output.usage.output;
+	// `used_tokens` counts the whole conversation, so it is prompt-side usage and
+	// must not be attributed to this turn's output. Checkpoints can arrive while
+	// output is still streaming; the split is applied once the stream finalizes.
+	usageState.conversationUsedTokens = usedTokens;
+}
+
+/**
+ * Cursor streams output tokens as deltas and reports whole-conversation
+ * consumption separately as `ConversationTokenDetails.used_tokens`. Derive
+ * prompt tokens from the difference so context accounting and compaction see a
+ * real prompt size instead of zero.
+ */
+export function finalizeCursorUsage(output: AssistantMessage, usageState: UsageState): void {
+	const used = usageState.conversationUsedTokens;
+	if (used <= 0) {
+		return;
 	}
+	output.usage.input = Math.max(0, used - output.usage.output);
+	output.usage.totalTokens = output.usage.input + output.usage.output;
+}
+
+/** Exposes {@link finalizeCursorUsage} for tests without a live HTTP/2 stream. */
+export function finalizeCursorUsageForTest(usedTokens: number, outputTokens: number): Usage {
+	const usage: Usage = {
+		input: 0,
+		output: outputTokens,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: outputTokens,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+	finalizeCursorUsage({ usage } as AssistantMessage, { sawTokenDelta: true, conversationUsedTokens: usedTokens });
+	return usage;
 }
 
 function createBlobId(data: Uint8Array): Uint8Array {

--- a/packages/ai/test/cursor-conversation-usage.test.ts
+++ b/packages/ai/test/cursor-conversation-usage.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "bun:test";
+
+import type { Usage } from "../src/types";
+
+import { finalizeCursorUsageForTest } from "../src/providers/cursor";
+
+/**
+ * Mirror of `calculatePromptTokens` in `@gajae-code/agent`, which drives the
+ * context indicator and the compaction threshold. `packages/ai` does not depend
+ * on `packages/agent`, so the consumer formula is restated here rather than
+ * imported.
+ */
+function promptTokens(usage: Usage): number {
+	const prompt = usage.input + usage.cacheRead + usage.cacheWrite;
+	return prompt > 0 ? prompt : usage.totalTokens || usage.input + usage.output;
+}
+
+/**
+ * Cursor reports whole-conversation consumption as
+ * `ConversationTokenDetails.used_tokens` and streams this turn's output as
+ * token deltas. The prompt side is the difference; attributing `used_tokens` to
+ * output leaves `usage.input` at zero, which makes context accounting and
+ * compaction believe the conversation is empty.
+ */
+describe("cursor conversation usage", () => {
+	it("derives prompt tokens from conversation usage minus streamed output", () => {
+		const usage = finalizeCursorUsageForTest(21_594, 14);
+
+		expect(usage.input).toBe(21_580);
+		expect(usage.output).toBe(14);
+		expect(usage.totalTokens).toBe(21_594);
+	});
+
+	it("reports prompt tokens to the compaction accounting path", () => {
+		const usage = finalizeCursorUsageForTest(21_594, 14);
+
+		// Before the fix `input` stayed 0, so this fell through to the
+		// output-only fallback and reported 14 tokens of context.
+		expect(promptTokens(usage)).toBe(21_580);
+	});
+
+	it("preserves the reported conversation total in totalTokens", () => {
+		// Observed across four turns of a live cursor/kimi-k3-max session.
+		const observed: Array<[used: number, output: number]> = [
+			[22_418, 860],
+			[22_829, 1_089],
+			[22_292, 239],
+			[22_586, 278],
+		];
+
+		for (const [used, output] of observed) {
+			const usage = finalizeCursorUsageForTest(used, output);
+			expect(usage.totalTokens).toBe(used);
+			// The output-only fallback would have reported `output` here.
+			expect(promptTokens(usage)).toBeGreaterThan(20_000);
+		}
+	});
+
+	it("leaves usage untouched when no checkpoint reported conversation usage", () => {
+		const usage = finalizeCursorUsageForTest(0, 91);
+
+		expect(usage.input).toBe(0);
+		expect(usage.output).toBe(91);
+	});
+
+	it("never reports negative prompt tokens when output exceeds reported usage", () => {
+		const usage = finalizeCursorUsageForTest(50, 91);
+
+		expect(usage.input).toBe(0);
+		expect(usage.totalTokens).toBe(91);
+	});
+});


### PR DESCRIPTION
## What

Cursor requests reported `usage.input` / `cacheRead` / `cacheWrite` as `0` on every turn. This makes the transport report real prompt tokens.

## Why

`ConversationTokenDetails` (`agent.v1`) carries the conversation's own accounting:

```protobuf
message agent.v1.ConversationTokenDetails {
  uint32 used_tokens = 1;
  uint32 max_tokens  = 2;
}
```

`handleConversationCheckpointUpdate` did two things with `used_tokens`:

```ts
if (usageState.sawTokenDelta) {
    return;                          // normal streaming path: value discarded
}
...
output.usage.output = usedTokens;    // conversation total attributed to this turn's output
```

Nothing else in `providers/cursor.ts` ever writes `usage.input`, `usage.cacheRead`, or `usage.cacheWrite` — they are only read back in the `totalTokens` sum. So every cursor request finished with `input: 0, cacheRead: 0, cacheWrite: 0`.

The consumer is `calculatePromptTokens` (`packages/agent/src/compaction/compaction.ts`):

```ts
const promptTokens = usage.input + usage.cacheRead + usage.cacheWrite;
if (promptTokens > 0) return promptTokens;
return calculateContextTokens(usage);   // totalTokens, which for cursor is output-only
```

For cursor that sum was always `0`, so it always fell through to the output-only fallback. Consequences:

1. **The context indicator tracked the last response's output size, not the conversation.** It sat at a fraction of a percent and never accumulated.
2. **Automatic compaction never observed a full context.** Sessions ran until the provider silently summarized them instead — cursor does not error when a conversation exceeds its ceiling, it summarizes and drops content.

I hit this as a user first: the context readout was pinned at `0.2%` / `1.6%` and would not move no matter how long the session ran.

### Instrumented evidence

Temporary probe on the checkpoint handler, live `cursor/kimi-k3-max`:

```
[PROBE] usedTokens=21661 maxTokens=200000 sawTokenDelta=true out=91 in=0
```

`used_tokens` is 21,661 while the turn produced 91 output tokens — it is prompt-side, and `sawTokenDelta=true` means the early return threw it away.

## Testing

Four turns of an identical script against live `cursor/kimi-k3-max`, reading `usage` straight out of the session JSONL:

| turn | before (`input` / context) | after (`input` / context) |
|---|---|---|
| 1 | `0` / **0.03%** | `21558` / **2.06%** |
| 2 | `0` / **0.03%** | `21740` / **2.07%** |
| 3 | `0` / **0.03%** | `22053` / **2.10%** |
| 4 | `0` / **0.03%** | `22308` / **2.13%** |

Before, the value is flat and reflects only each response's output. After, it accumulates.

Real tool-using session (read + edit + verify a file), same build:

```
req 1: input=22386 output=1647 total=24033 ctx=2.13%
req 2: input=25139 output= 412 total=25551 ctx=2.40%
req 3: input=25082 output= 240 total=25322 ctx=2.39%
```

Prompt tokens grow as tool results accumulate, and the edit completed correctly.

```
bun test packages/ai/test/cursor-*.test.ts     # 75 pass, 0 fail
bunx tsc --noEmit -p packages/ai/tsconfig.json # clean
```

`packages/ai/test/cursor-conversation-usage.test.ts` is new and covers the split, the compaction-facing formula, the no-checkpoint case, and the floor when output exceeds the reported total.

Two failures in the wider `packages/ai/test/` run — `anthropic-cache-eval.integration.test.ts` (provider source blob OID mismatch) and `openai-first-event-timeout.test.ts` (5s timeout) — reproduce identically on unmodified `origin/dev` with this change stashed, so they are pre-existing and unrelated.

## Implementation notes

`used_tokens` is recorded on `UsageState` and applied when the stream finalizes rather than at checkpoint time, because checkpoints can arrive while output is still streaming and would otherwise race the split. Prompt tokens are the conversation total minus this turn's output, floored at zero.

**`max_tokens` is deliberately left unread.** It reports `200000` for `kimi-k3-max`, but that same transport accepts far more than that in a single request (I measured a 896K-token prompt completing correctly through this provider), so the field does not describe the model's context window. Wiring it into context sizing would cap sessions well below the real limit.

## Risk classification

- [ ] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [x] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

This changes usage accounting for every cursor user, and usage feeds compaction. Sessions that previously never compacted will now begin compacting at the configured threshold — correct, but a behavior change worth a reviewer's eyes. The exact semantics of `used_tokens` relative to a mid-stream checkpoint are inferred from observation, not from a published cursor spec; the prompt/output split can be off by part of one response's output. That is bounded by `maxTokens` and is a large improvement over the current constant zero, but a reviewer who knows the cursor wire format should confirm the split.

## GJC verdict

```text
gajae.pr-review-verdict.v1 needs-human sha256:682e6e49a5604d7e73ffc5bbe2f2d03d95a8ef26ad9bbc0b2402d9677a006344 reviewer:human reviewer-id:none evidence:external-contributor-cannot-self-approve
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken

> `bun check` unchecked: not run to completion on this checkout. Focused cursor tests, the new regression test, and a `packages/ai` typecheck all pass, and the two unrelated failures above are shown to be pre-existing. Full CI on the exact head is authoritative.

Related: #5170 corrects the bundled `contextWindow` for the same cursor models. Independent of this change — that one fixes the denominator, this one fixes the numerator.
