### PR TITLE
fix(ai): account Cursor conversation usage safely

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -11,6 +11,9 @@
 - Tokenless loopback auth-broker requests carrying a browser `Origin` header are now rejected before credential reads or mutations. Native loopback clients without `Origin`, authenticated browser-origin clients, and the public health endpoint retain their existing behavior.
 - `glm-zcode` login instructions now warn users who have the ZCode desktop app installed to cancel the browser's `zcode://` open prompt. The app exchanges the single-use authorization code itself, so a code pasted afterwards is rejected by the broker (`500 {"code":2007}`) and the documented paste flow failed without explanation.
 
+- Cursor sessions now report prompt tokens instead of zero. `ConversationTokenDetails.used_tokens` counts the whole conversation, but the checkpoint handler assigned it to `usage.output` and returned early whenever token deltas had been seen — which is the normal streaming path — so `usage.input`, `usage.cacheRead`, and `usage.cacheWrite` were left at their zero initializers for every cursor request. `calculatePromptTokens` therefore fell through to its output-only fallback, so the context indicator tracked the last response's output size rather than the conversation, and automatic compaction never observed a full context. Conversation usage is now recorded through the stream and split into prompt and output tokens when the stream finalizes.
+
+
 ## [0.16.0] - 2026-09-02
 
 ### Added

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -24,6 +24,7 @@ import type {
 	Tool,
 	ToolCall,
 	ToolResultMessage,
+	Usage,
 } from "../types";
 import { normalizeSystemPrompts } from "../utils";
 import { kCursorExecResolved } from "../utils/block-symbols";
@@ -733,7 +734,7 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 			let currentTextBlock: (TextContent & { index: number }) | null = null;
 			let currentThinkingBlock: (ThinkingContent & { index: number }) | null = null;
 			let currentToolCall: ToolCallState | null = null;
-			const usageState: UsageState = { sawTokenDelta: false };
+			const usageState: UsageState = { sawTokenDelta: false, conversationUsedTokens: 0 };
 
 			const state: BlockState = {
 				get currentTextBlock() {
@@ -899,6 +900,7 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 				});
 			}
 
+			finalizeCursorUsage(output, usageState);
 			calculateCost(model, output.usage);
 
 			output.duration = Date.now() - startTime;
@@ -959,6 +961,11 @@ interface BlockState {
 
 interface UsageState {
 	sawTokenDelta: boolean;
+	/**
+	 * Latest `ConversationTokenDetails.used_tokens`: the whole conversation's
+	 * token consumption as counted by Cursor, not this turn's output.
+	 */
+	conversationUsedTokens: number;
 }
 
 async function handleServerMessage(
@@ -2855,17 +2862,43 @@ function handleConversationCheckpointUpdate(
 	onConversationCheckpoint?: (checkpoint: ConversationStateStructure) => void,
 ): void {
 	onConversationCheckpoint?.(checkpoint);
-	if (usageState.sawTokenDelta) {
-		return;
-	}
 	const usedTokens = checkpoint.tokenDetails?.usedTokens ?? 0;
 	if (usedTokens <= 0) {
 		return;
 	}
-	if (output.usage.output !== usedTokens) {
-		output.usage.output = usedTokens;
-		output.usage.totalTokens = output.usage.input + output.usage.output;
+	// `used_tokens` counts the whole conversation, so it is prompt-side usage and
+	// must not be attributed to this turn's output. Checkpoints can arrive while
+	// output is still streaming; the split is applied once the stream finalizes.
+	usageState.conversationUsedTokens = usedTokens;
+}
+
+/**
+ * Cursor streams output tokens as deltas and reports whole-conversation
+ * consumption separately as `ConversationTokenDetails.used_tokens`. Derive
+ * prompt tokens from the difference so context accounting and compaction see a
+ * real prompt size instead of zero.
+ */
+export function finalizeCursorUsage(output: AssistantMessage, usageState: UsageState): void {
+	const used = usageState.conversationUsedTokens;
+	if (used <= 0) {
+		return;
 	}
+	output.usage.input = Math.max(0, used - output.usage.output);
+	output.usage.totalTokens = output.usage.input + output.usage.output;
+}
+
+/** Exposes {@link finalizeCursorUsage} for tests without a live HTTP/2 stream. */
+export function finalizeCursorUsageForTest(usedTokens: number, outputTokens: number): Usage {
+	const usage: Usage = {
+		input: 0,
+		output: outputTokens,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: outputTokens,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+	finalizeCursorUsage({ usage } as AssistantMessage, { sawTokenDelta: true, conversationUsedTokens: usedTokens });
+	return usage;
 }
 
 function createBlobId(data: Uint8Array): Uint8Array {

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -1002,7 +1002,7 @@ async function handleServerMessage(
 			requestContextRules,
 		);
 	} else if (msgCase === "conversationCheckpointUpdate") {
-		handleConversationCheckpointUpdate(msg.message.value, output, usageState, onConversationCheckpoint);
+		handleConversationCheckpointUpdate(msg.message.value, usageState, onConversationCheckpoint);
 	}
 }
 
@@ -2857,7 +2857,6 @@ function processInteractionUpdate(
 
 function handleConversationCheckpointUpdate(
 	checkpoint: ConversationStateStructure,
-	output: AssistantMessage,
 	usageState: UsageState,
 	onConversationCheckpoint?: (checkpoint: ConversationStateStructure) => void,
 ): void {

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -77,6 +77,7 @@ import {
 	type ConversationStateStructure,
 	ConversationStateStructureSchema,
 	ConversationStepSchema,
+	ConversationTokenDetailsSchema,
 	ConversationTurnStructureSchema,
 	CursorRuleSchema,
 	CursorRuleSource,
@@ -654,6 +655,9 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 		let onAbort: (() => void) | undefined;
 		let coordinator: CursorRequestCoordinator = undefined!;
 		const baseUrl = model.baseUrl || CURSOR_API_URL;
+		let activeConversationId: string | undefined;
+		let previousConversationState: ConversationStateStructure | undefined;
+		let previousUsageContext: CursorUsageContext | undefined;
 
 		try {
 			const apiKey = options?.apiKey;
@@ -665,11 +669,13 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 			}
 
 			const conversationId = options?.conversationId ?? options?.sessionId ?? crypto.randomUUID();
+			activeConversationId = conversationId;
 			const blobStore = conversationBlobStores.get(conversationId) ?? new Map<string, Uint8Array>();
 			conversationBlobStores.set(conversationId, blobStore);
 			const cachedState = conversationStateCache.get(conversationId);
-			const usageContext = buildCursorUsageContext(context, model);
-			const previousUsageContext = conversationUsageContextCache.get(conversationId);
+			previousConversationState = cachedState;
+			const usageContext = buildCursorUsageContext(context, model, options);
+			previousUsageContext = conversationUsageContextCache.get(conversationId);
 			conversationUsageContextCache.set(conversationId, usageContext);
 			const { requestBytes, conversationState } = buildGrpcRequest(model, context, options, {
 				conversationId,
@@ -806,8 +812,7 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 			};
 
 			const onConversationCheckpoint = (checkpoint: ConversationStateStructure) => {
-				conversationStateCache.set(conversationId, checkpoint);
-				touchCursorConversation(conversationId);
+				usageState.pendingCheckpoint = checkpoint;
 			};
 
 			h2Request.on("trailers", trailers => {
@@ -960,6 +965,21 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 			}
 
 			finalizeCursorUsage(output, usageState);
+			const stateToCommit =
+				usageState.pendingCheckpoint ?? conversationStateCache.get(conversationId) ?? conversationState;
+			if (usageState.hasConversationCheckpoint || usageState.conversationUsedTokens > 0) {
+				conversationStateCache.set(
+					conversationId,
+					create(ConversationStateStructureSchema, {
+						...stateToCommit,
+						tokenDetails: create(ConversationTokenDetailsSchema, {
+							usedTokens: output.usage.totalTokens,
+							maxTokens: stateToCommit.tokenDetails?.maxTokens ?? 0,
+						}),
+					}),
+				);
+				touchCursorConversation(conversationId);
+			}
 			conversationUsageContextCache.set(conversationId, {
 				...usageContext,
 				messageKeys: [...usageContext.messageKeys, hashCursorUsageMessage(output)],
@@ -975,6 +995,12 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 			});
 			stream.end();
 		} catch (error) {
+			if (activeConversationId) {
+				if (previousConversationState) conversationStateCache.set(activeConversationId, previousConversationState);
+				else conversationStateCache.delete(activeConversationId);
+				if (previousUsageContext) conversationUsageContextCache.set(activeConversationId, previousUsageContext);
+				else conversationUsageContextCache.delete(activeConversationId);
+			}
 			// Keep the completion promise terminal even for synchronous setup/write
 			// failures that may not emit a separate HTTP/2 error event.
 			const mappedError = mapH2TransportError(coordinator?.failureError() ?? error, baseUrl);
@@ -1033,11 +1059,13 @@ interface UsageState {
 	checkpointOutputTokens: number;
 	/** Whether the current stream received a checkpoint, including an explicit zero. */
 	hasConversationCheckpoint: boolean;
+	pendingCheckpoint?: ConversationStateStructure;
 }
 
 interface CursorUsageContext {
 	modelKey: string;
 	systemPromptKey: string;
+	customSystemPromptKey: string;
 	messageKeys: string[];
 }
 
@@ -3307,10 +3335,15 @@ function buildConversationTurns(messages: Message[], blobStore: Map<string, Uint
 	return turns;
 }
 
-function buildCursorUsageContext(context: Context, model: Model<"cursor-agent">): CursorUsageContext {
+function buildCursorUsageContext(
+	context: Context,
+	model: Model<"cursor-agent">,
+	options: CursorOptions | undefined,
+): CursorUsageContext {
 	return {
 		modelKey: hashCursorUsageValue({ provider: model.provider, id: model.id, wireModelId: model.wireModelId }),
 		systemPromptKey: hashCursorUsageValue(context.systemPrompt ?? []),
+		customSystemPromptKey: hashCursorUsageValue(options?.customSystemPrompt ?? ""),
 		messageKeys: context.messages.map(message => hashCursorUsageMessage(message)),
 	};
 }
@@ -3326,7 +3359,12 @@ function hashCursorUsageValue(value: unknown): string {
 }
 
 function canReuseCursorUsageContext(previous: CursorUsageContext | undefined, current: CursorUsageContext): boolean {
-	if (!previous || previous.modelKey !== current.modelKey || previous.systemPromptKey !== current.systemPromptKey)
+	if (
+		!previous ||
+		previous.modelKey !== current.modelKey ||
+		previous.systemPromptKey !== current.systemPromptKey ||
+		previous.customSystemPromptKey !== current.customSystemPromptKey
+	)
 		return false;
 	if (previous.messageKeys.length > current.messageKeys.length) return false;
 	return previous.messageKeys.every((key, index) => key === current.messageKeys[index]);

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -176,6 +176,7 @@ export { CURSOR_CLIENT_VERSION };
 
 const conversationStateCache = new Map<string, ConversationStateStructure>();
 const conversationBlobStores = new Map<string, Map<string, Uint8Array>>();
+const conversationUsageContextCache = new Map<string, CursorUsageContext>();
 
 // F15: bound the module-global conversation caches so long-lived / many-session use cannot
 // grow them without limit. LRU by conversation count + TTL on idle conversations.
@@ -187,6 +188,7 @@ const conversationLastAccess = new Map<string, number>();
 export function disposeCursorConversation(conversationId: string): void {
 	conversationStateCache.delete(conversationId);
 	conversationBlobStores.delete(conversationId);
+	conversationUsageContextCache.delete(conversationId);
 	conversationLastAccess.delete(conversationId);
 }
 
@@ -666,6 +668,9 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 			const blobStore = conversationBlobStores.get(conversationId) ?? new Map<string, Uint8Array>();
 			conversationBlobStores.set(conversationId, blobStore);
 			const cachedState = conversationStateCache.get(conversationId);
+			const usageContext = buildCursorUsageContext(context);
+			const previousUsageContext = conversationUsageContextCache.get(conversationId);
+			conversationUsageContextCache.set(conversationId, usageContext);
 			const { requestBytes, conversationState } = buildGrpcRequest(model, context, options, {
 				conversationId,
 				blobStore,
@@ -711,6 +716,23 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 			let resolveH2: (() => void) | undefined;
 			let rejectH2: ((error: Error) => void) | undefined;
 			const inboundEnd = Promise.withResolvers<void>();
+			let inboundSettled = false;
+			let inboundTimeout: NodeJS.Timeout | undefined;
+			const settleInbound = (error?: Error) => {
+				if (inboundSettled) return;
+				inboundSettled = true;
+				if (inboundTimeout) {
+					clearTimeout(inboundTimeout);
+					inboundTimeout = undefined;
+				}
+				if (error) inboundEnd.reject(error);
+				else inboundEnd.resolve();
+			};
+			void inboundEnd.promise.catch(() => {});
+			inboundTimeout = setTimeout(
+				() => settleInbound(new Error("Cursor stream did not reach its inbound terminal frame")),
+				options?.streamIdleTimeoutMs ?? getStreamIdleTimeoutMs(),
+			);
 			coordinator = new CursorRequestCoordinator(
 				h2Request,
 				stopHeartbeat,
@@ -726,8 +748,14 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 				},
 				options?.streamIdleTimeoutMs ?? getStreamIdleTimeoutMs(),
 			);
-			h2Client.on("error", error => coordinator.fail(error));
-			h2Request.on("error", error => coordinator.fail(error));
+			h2Client.on("error", error => {
+				settleInbound(error);
+				coordinator.fail(error);
+			});
+			h2Request.on("error", error => {
+				settleInbound(error);
+				coordinator.fail(error);
+			});
 
 			stream.push({ type: "start", partial: output });
 
@@ -736,7 +764,7 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 			let currentThinkingBlock: (ThinkingContent & { index: number }) | null = null;
 			let currentToolCall: ToolCallState | null = null;
 			const cachedConversationUsedTokens =
-				cachedState && countCursorHistoryTurns(context.messages) >= (cachedState.turns?.length ?? 0)
+				cachedState && canReuseCursorUsageContext(previousUsageContext, usageContext)
 					? (cachedState.tokenDetails?.usedTokens ?? 0)
 					: 0;
 			const usageState: UsageState = {
@@ -786,12 +814,16 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 				}
 			});
 			h2Request.on("end", () => {
-				inboundEnd.resolve();
+				settleInbound();
 				if (!coordinator.hasTurnEnded()) {
 					coordinator.fail(new Error("Cursor stream ended before turnEnded"));
 				}
 			});
+			h2Request.on("close", () => {
+				if (!inboundSettled) settleInbound(new Error("Cursor stream closed before inbound completion"));
+			});
 			onAbort = () => {
+				settleInbound(new Error("Request was aborted"));
 				coordinator.fail(new Error("Request was aborted"));
 			};
 			if (options?.signal) {
@@ -992,6 +1024,11 @@ interface UsageState {
 	checkpointOutputTokens: number;
 	/** Whether the current stream received a checkpoint, including an explicit zero. */
 	hasConversationCheckpoint: boolean;
+}
+
+interface CursorUsageContext {
+	systemPromptKey: string;
+	messageKeys: string[];
 }
 
 async function handleServerMessage(
@@ -3260,24 +3297,23 @@ function buildConversationTurns(messages: Message[], blobStore: Map<string, Uint
 	return turns;
 }
 
-function countCursorHistoryTurns(messages: Message[]): number {
-	let count = 0;
-	for (let i = 0; i < messages.length; i++) {
-		const message = messages[i];
-		if (
-			(message.role !== "user" && message.role !== "developer") ||
-			(extractUserMessageText(message).length === 0 && !hasUserMessageImages(message))
-		) {
-			continue;
-		}
-		for (let j = i + 1; j < messages.length; j++) {
-			if (messages[j].role === "user" || messages[j].role === "developer") {
-				count++;
-				break;
-			}
-		}
-	}
-	return count;
+function buildCursorUsageContext(context: Context): CursorUsageContext {
+	return {
+		systemPromptKey: hashCursorUsageValue(context.systemPrompt ?? []),
+		messageKeys: context.messages.map(message => hashCursorUsageValue(message)),
+	};
+}
+
+function hashCursorUsageValue(value: unknown): string {
+	return createHash("sha256")
+		.update(JSON.stringify(value) ?? "")
+		.digest("hex");
+}
+
+function canReuseCursorUsageContext(previous: CursorUsageContext | undefined, current: CursorUsageContext): boolean {
+	if (!previous || previous.systemPromptKey !== current.systemPromptKey) return false;
+	if (previous.messageKeys.length > current.messageKeys.length) return false;
+	return previous.messageKeys.every((key, index) => key === current.messageKeys[index]);
 }
 
 /** Exported for tests: decodes Cursor history blobs built from conversation messages. */

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -668,7 +668,7 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 			const blobStore = conversationBlobStores.get(conversationId) ?? new Map<string, Uint8Array>();
 			conversationBlobStores.set(conversationId, blobStore);
 			const cachedState = conversationStateCache.get(conversationId);
-			const usageContext = buildCursorUsageContext(context);
+			const usageContext = buildCursorUsageContext(context, model);
 			const previousUsageContext = conversationUsageContextCache.get(conversationId);
 			conversationUsageContextCache.set(conversationId, usageContext);
 			const { requestBytes, conversationState } = buildGrpcRequest(model, context, options, {
@@ -729,10 +729,14 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 				else inboundEnd.resolve();
 			};
 			void inboundEnd.promise.catch(() => {});
-			inboundTimeout = setTimeout(
-				() => settleInbound(new Error("Cursor stream did not reach its inbound terminal frame")),
-				options?.streamIdleTimeoutMs ?? getStreamIdleTimeoutMs(),
-			);
+			const armInboundTimeout = () => {
+				const timeoutMs = options?.streamIdleTimeoutMs ?? 0;
+				if (timeoutMs <= 0 || inboundSettled) return;
+				inboundTimeout = setTimeout(
+					() => settleInbound(new Error("Cursor stream did not reach its inbound terminal frame")),
+					timeoutMs,
+				);
+			};
 			coordinator = new CursorRequestCoordinator(
 				h2Request,
 				stopHeartbeat,
@@ -920,6 +924,7 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 					resolve();
 				}
 			});
+			armInboundTimeout();
 			await inboundEnd.promise;
 
 			if (state.currentTextBlock) {
@@ -955,6 +960,10 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 			}
 
 			finalizeCursorUsage(output, usageState);
+			conversationUsageContextCache.set(conversationId, {
+				...usageContext,
+				messageKeys: [...usageContext.messageKeys, hashCursorUsageMessage(output)],
+			});
 			calculateCost(model, output.usage);
 
 			output.duration = Date.now() - startTime;
@@ -1027,6 +1036,7 @@ interface UsageState {
 }
 
 interface CursorUsageContext {
+	modelKey: string;
 	systemPromptKey: string;
 	messageKeys: string[];
 }
@@ -3297,11 +3307,16 @@ function buildConversationTurns(messages: Message[], blobStore: Map<string, Uint
 	return turns;
 }
 
-function buildCursorUsageContext(context: Context): CursorUsageContext {
+function buildCursorUsageContext(context: Context, model: Model<"cursor-agent">): CursorUsageContext {
 	return {
+		modelKey: hashCursorUsageValue({ provider: model.provider, id: model.id, wireModelId: model.wireModelId }),
 		systemPromptKey: hashCursorUsageValue(context.systemPrompt ?? []),
-		messageKeys: context.messages.map(message => hashCursorUsageValue(message)),
+		messageKeys: context.messages.map(message => hashCursorUsageMessage(message)),
 	};
+}
+
+function hashCursorUsageMessage(message: { role: string; content: unknown }): string {
+	return hashCursorUsageValue({ role: message.role, content: message.content });
 }
 
 function hashCursorUsageValue(value: unknown): string {
@@ -3311,7 +3326,8 @@ function hashCursorUsageValue(value: unknown): string {
 }
 
 function canReuseCursorUsageContext(previous: CursorUsageContext | undefined, current: CursorUsageContext): boolean {
-	if (!previous || previous.systemPromptKey !== current.systemPromptKey) return false;
+	if (!previous || previous.modelKey !== current.modelKey || previous.systemPromptKey !== current.systemPromptKey)
+		return false;
 	if (previous.messageKeys.length > current.messageKeys.length) return false;
 	return previous.messageKeys.every((key, index) => key === current.messageKeys[index]);
 }

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -341,9 +341,18 @@ class CursorRequestCoordinator implements CursorRequestWriter {
 
 	admit(taskFactory: () => Promise<void>): void {
 		if (!this.canAdmitTask()) return;
+		this.#admitOrdered(taskFactory, false);
+	}
+
+	admitCheckpoint(taskFactory: () => Promise<void>): Promise<void> {
+		if (this.#state === "failed") return Promise.reject(this.#failure ?? new Error("Cursor request failed"));
+		return this.#admitOrdered(taskFactory, true);
+	}
+
+	#admitOrdered(taskFactory: () => Promise<void>, allowAfterSuccess: boolean): Promise<void> {
 		const orderedTask = this.#hasAdmittedTask
 			? this.#taskChain.then(() => {
-					if (this.#state === "failed" || this.#state === "succeeded") return;
+					if (this.#state === "failed" || (!allowAfterSuccess && this.#state === "succeeded")) return;
 					return taskFactory();
 				})
 			: taskFactory();
@@ -359,6 +368,7 @@ class CursorRequestCoordinator implements CursorRequestWriter {
 			() => this.#tasks.delete(orderedTask),
 			() => this.#tasks.delete(orderedTask),
 		);
+		return orderedTask;
 	}
 
 	turnEnded(): void {
@@ -670,8 +680,8 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 
 			const conversationId = options?.conversationId ?? options?.sessionId ?? crypto.randomUUID();
 			activeConversationId = conversationId;
-			const blobStore = conversationBlobStores.get(conversationId) ?? new Map<string, Uint8Array>();
-			conversationBlobStores.set(conversationId, blobStore);
+			const cachedBlobStore = conversationBlobStores.get(conversationId);
+			const blobStore = new Map(cachedBlobStore);
 			const cachedState = conversationStateCache.get(conversationId);
 			previousConversationState = cachedState;
 			const usageContext = buildCursorUsageContext(context, model, options);
@@ -685,7 +695,6 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 				conversationState: reusableCachedState,
 			});
 			conversationStateCache.set(conversationId, conversationState);
-			touchCursorConversation(conversationId);
 			const requestContextTools = buildMcpToolDefinitions(context.tools);
 			const targetUrl = new URL(baseUrl);
 			const proxyUrl = getProxyForUrl(model.provider, targetUrl);
@@ -772,6 +781,7 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 			stream.push({ type: "start", partial: output });
 
 			let pendingBuffer = Buffer.alloc(0);
+			const checkpointTasks: Promise<void>[] = [];
 			let currentTextBlock: (TextContent & { index: number }) | null = null;
 			let currentThinkingBlock: (ThinkingContent & { index: number }) | null = null;
 			let currentToolCall: ToolCallState | null = null;
@@ -831,7 +841,9 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 				}
 			});
 			h2Request.on("close", () => {
-				if (!inboundSettled) settleInbound(new Error("Cursor stream closed before inbound completion"));
+				const error = new Error("Cursor stream closed before inbound completion");
+				if (!inboundSettled) settleInbound(error);
+				coordinator.fail(error);
 			});
 			onAbort = () => {
 				settleInbound(new Error("Request was aborted"));
@@ -870,11 +882,16 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 							serverMessage.message.value.message?.case === "turnEnded";
 						const isConversationCheckpoint = serverMessage.message.case === "conversationCheckpointUpdate";
 						if (isConversationCheckpoint) {
-							handleConversationCheckpointUpdate(
-								serverMessage.message.value as ConversationStateStructure,
-								output,
-								usageState,
-								onConversationCheckpoint,
+							checkpointTasks.push(
+								coordinator.admitCheckpoint(() => {
+									handleConversationCheckpointUpdate(
+										serverMessage.message.value as ConversationStateStructure,
+										output,
+										usageState,
+										onConversationCheckpoint,
+									);
+									return Promise.resolve();
+								}),
 							);
 							continue;
 						}
@@ -933,6 +950,7 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 			});
 			armInboundTimeout();
 			await inboundEnd.promise;
+			await Promise.all(checkpointTasks);
 
 			if (state.currentTextBlock) {
 				const idx = output.content.indexOf(state.currentTextBlock);
@@ -994,6 +1012,8 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 				...usageContext,
 				messageKeys: [...usageContext.messageKeys, hashCursorUsageMessage(output)],
 			});
+			conversationBlobStores.set(conversationId, blobStore);
+			touchCursorConversation(conversationId);
 			calculateCost(model, output.usage);
 
 			output.duration = Date.now() - startTime;

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -677,10 +677,12 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 			const usageContext = buildCursorUsageContext(context, model, options);
 			previousUsageContext = conversationUsageContextCache.get(conversationId);
 			conversationUsageContextCache.set(conversationId, usageContext);
+			const reusableCachedState =
+				cachedState && canReuseCursorUsageContext(previousUsageContext, usageContext) ? cachedState : undefined;
 			const { requestBytes, conversationState } = buildGrpcRequest(model, context, options, {
 				conversationId,
 				blobStore,
-				conversationState: cachedState,
+				conversationState: reusableCachedState,
 			});
 			conversationStateCache.set(conversationId, conversationState);
 			touchCursorConversation(conversationId);
@@ -2976,11 +2978,13 @@ function handleConversationCheckpointUpdate(
 	if (!checkpoint.tokenDetails) {
 		return;
 	}
+	const previousUsedTokens = usageState.conversationUsedTokens;
 	// `used_tokens` counts the whole conversation, so it is prompt-side usage and
 	// must not be attributed to this turn's output. Checkpoints can arrive while
 	// output is still streaming; the split is applied once the stream finalizes.
 	usageState.conversationUsedTokens = usedTokens;
-	usageState.checkpointOutputTokens = output.usage.output;
+	usageState.checkpointOutputTokens =
+		usageState.hasConversationCheckpoint && usedTokens < previousUsedTokens ? 0 : output.usage.output;
 	usageState.hasConversationCheckpoint = true;
 }
 

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -967,15 +967,23 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 			finalizeCursorUsage(output, usageState);
 			const stateToCommit =
 				usageState.pendingCheckpoint ?? conversationStateCache.get(conversationId) ?? conversationState;
-			if (usageState.hasConversationCheckpoint || usageState.conversationUsedTokens > 0) {
+			if (
+				usageState.pendingCheckpoint ||
+				usageState.hasConversationCheckpoint ||
+				usageState.conversationUsedTokens > 0
+			) {
 				conversationStateCache.set(
 					conversationId,
 					create(ConversationStateStructureSchema, {
 						...stateToCommit,
-						tokenDetails: create(ConversationTokenDetailsSchema, {
-							usedTokens: output.usage.totalTokens,
-							maxTokens: stateToCommit.tokenDetails?.maxTokens ?? 0,
-						}),
+						...(usageState.hasConversationCheckpoint || usageState.conversationUsedTokens > 0
+							? {
+									tokenDetails: create(ConversationTokenDetailsSchema, {
+										usedTokens: output.usage.totalTokens,
+										maxTokens: stateToCommit.tokenDetails?.maxTokens ?? 0,
+									}),
+								}
+							: {}),
 					}),
 				);
 				touchCursorConversation(conversationId);
@@ -1066,6 +1074,7 @@ interface CursorUsageContext {
 	modelKey: string;
 	systemPromptKey: string;
 	customSystemPromptKey: string;
+	toolsKey: string;
 	messageKeys: string[];
 }
 
@@ -3344,6 +3353,7 @@ function buildCursorUsageContext(
 		modelKey: hashCursorUsageValue({ provider: model.provider, id: model.id, wireModelId: model.wireModelId }),
 		systemPromptKey: hashCursorUsageValue(context.systemPrompt ?? []),
 		customSystemPromptKey: hashCursorUsageValue(options?.customSystemPrompt ?? ""),
+		toolsKey: hashCursorUsageValue(context.tools ?? []),
 		messageKeys: context.messages.map(message => hashCursorUsageMessage(message)),
 	};
 }
@@ -3363,7 +3373,8 @@ function canReuseCursorUsageContext(previous: CursorUsageContext | undefined, cu
 		!previous ||
 		previous.modelKey !== current.modelKey ||
 		previous.systemPromptKey !== current.systemPromptKey ||
-		previous.customSystemPromptKey !== current.customSystemPromptKey
+		previous.customSystemPromptKey !== current.customSystemPromptKey ||
+		previous.toolsKey !== current.toolsKey
 	)
 		return false;
 	if (previous.messageKeys.length > current.messageKeys.length) return false;

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -774,8 +774,8 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 			let currentThinkingBlock: (ThinkingContent & { index: number }) | null = null;
 			let currentToolCall: ToolCallState | null = null;
 			const cachedConversationUsedTokens =
-				cachedState && canReuseCursorUsageContext(previousUsageContext, usageContext)
-					? (cachedState.tokenDetails?.usedTokens ?? 0)
+				conversationState.tokenDetails && canReuseCursorUsageContext(previousUsageContext, usageContext)
+					? conversationState.tokenDetails.usedTokens
 					: 0;
 			const usageState: UsageState = {
 				sawTokenDelta: false,
@@ -867,7 +867,7 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 							serverMessage.message.case === "interactionUpdate" &&
 							serverMessage.message.value.message?.case === "turnEnded";
 						const isConversationCheckpoint = serverMessage.message.case === "conversationCheckpointUpdate";
-						if (isConversationCheckpoint && !coordinator.canAdmitTask()) {
+						if (isConversationCheckpoint) {
 							handleConversationCheckpointUpdate(
 								serverMessage.message.value as ConversationStateStructure,
 								output,

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -734,7 +734,13 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 			let currentTextBlock: (TextContent & { index: number }) | null = null;
 			let currentThinkingBlock: (ThinkingContent & { index: number }) | null = null;
 			let currentToolCall: ToolCallState | null = null;
-			const usageState: UsageState = { sawTokenDelta: false, conversationUsedTokens: 0 };
+			const cachedConversationUsedTokens = cachedState?.tokenDetails?.usedTokens ?? 0;
+			const usageState: UsageState = {
+				sawTokenDelta: false,
+				conversationUsedTokens: cachedConversationUsedTokens,
+				checkpointOutputTokens: 0,
+				hasConversationCheckpoint: false,
+			};
 
 			const state: BlockState = {
 				get currentTextBlock() {
@@ -814,6 +820,16 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 						const isTurnEnded =
 							serverMessage.message.case === "interactionUpdate" &&
 							serverMessage.message.value.message?.case === "turnEnded";
+						const isConversationCheckpoint = serverMessage.message.case === "conversationCheckpointUpdate";
+						if (isConversationCheckpoint && !coordinator.canAdmitTask()) {
+							handleConversationCheckpointUpdate(
+								serverMessage.message.value as ConversationStateStructure,
+								output,
+								usageState,
+								onConversationCheckpoint,
+							);
+							continue;
+						}
 						// Serialize handlers: exec messages can be asynchronous, and resolving the
 						// request on turnEnded before prior handlers finish loses their responses.
 						if (!coordinator.canAdmitTask()) continue;
@@ -966,6 +982,10 @@ interface UsageState {
 	 * token consumption as counted by Cursor, not this turn's output.
 	 */
 	conversationUsedTokens: number;
+	/** Output tokens already included in the latest checkpoint snapshot. */
+	checkpointOutputTokens: number;
+	/** Whether the current stream received a checkpoint, including an explicit zero. */
+	hasConversationCheckpoint: boolean;
 }
 
 async function handleServerMessage(
@@ -1002,7 +1022,7 @@ async function handleServerMessage(
 			requestContextRules,
 		);
 	} else if (msgCase === "conversationCheckpointUpdate") {
-		handleConversationCheckpointUpdate(msg.message.value, usageState, onConversationCheckpoint);
+		handleConversationCheckpointUpdate(msg.message.value, output, usageState, onConversationCheckpoint);
 	}
 }
 
@@ -2857,18 +2877,21 @@ function processInteractionUpdate(
 
 function handleConversationCheckpointUpdate(
 	checkpoint: ConversationStateStructure,
+	output: AssistantMessage,
 	usageState: UsageState,
 	onConversationCheckpoint?: (checkpoint: ConversationStateStructure) => void,
 ): void {
 	onConversationCheckpoint?.(checkpoint);
 	const usedTokens = checkpoint.tokenDetails?.usedTokens ?? 0;
-	if (usedTokens <= 0) {
+	if (!checkpoint.tokenDetails) {
 		return;
 	}
 	// `used_tokens` counts the whole conversation, so it is prompt-side usage and
 	// must not be attributed to this turn's output. Checkpoints can arrive while
 	// output is still streaming; the split is applied once the stream finalizes.
 	usageState.conversationUsedTokens = usedTokens;
+	usageState.checkpointOutputTokens = output.usage.output;
+	usageState.hasConversationCheckpoint = true;
 }
 
 /**
@@ -2879,15 +2902,20 @@ function handleConversationCheckpointUpdate(
  */
 export function finalizeCursorUsage(output: AssistantMessage, usageState: UsageState): void {
 	const used = usageState.conversationUsedTokens;
-	if (used <= 0) {
+	if (!usageState.hasConversationCheckpoint && used <= 0) {
 		return;
 	}
-	output.usage.input = Math.max(0, used - output.usage.output);
+	const outputIncludedInSnapshot = usageState.hasConversationCheckpoint ? usageState.checkpointOutputTokens : 0;
+	output.usage.input = Math.max(0, used - outputIncludedInSnapshot);
 	output.usage.totalTokens = output.usage.input + output.usage.output;
 }
 
 /** Exposes {@link finalizeCursorUsage} for tests without a live HTTP/2 stream. */
-export function finalizeCursorUsageForTest(usedTokens: number, outputTokens: number): Usage {
+export function finalizeCursorUsageForTest(
+	usedTokens: number,
+	outputTokens: number,
+	options: { checkpointOutputTokens?: number; hasConversationCheckpoint?: boolean } = {},
+): Usage {
 	const usage: Usage = {
 		input: 0,
 		output: outputTokens,
@@ -2896,7 +2924,13 @@ export function finalizeCursorUsageForTest(usedTokens: number, outputTokens: num
 		totalTokens: outputTokens,
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 	};
-	finalizeCursorUsage({ usage } as AssistantMessage, { sawTokenDelta: true, conversationUsedTokens: usedTokens });
+	finalizeCursorUsage({ usage } as AssistantMessage, {
+		sawTokenDelta: true,
+		conversationUsedTokens: usedTokens,
+		checkpointOutputTokens:
+			options.checkpointOutputTokens ?? ((options.hasConversationCheckpoint ?? usedTokens > 0) ? outputTokens : 0),
+		hasConversationCheckpoint: options.hasConversationCheckpoint ?? usedTokens > 0,
+	});
 	return usage;
 }
 

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -710,6 +710,7 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 			};
 			let resolveH2: (() => void) | undefined;
 			let rejectH2: ((error: Error) => void) | undefined;
+			const inboundEnd = Promise.withResolvers<void>();
 			coordinator = new CursorRequestCoordinator(
 				h2Request,
 				stopHeartbeat,
@@ -734,7 +735,10 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 			let currentTextBlock: (TextContent & { index: number }) | null = null;
 			let currentThinkingBlock: (ThinkingContent & { index: number }) | null = null;
 			let currentToolCall: ToolCallState | null = null;
-			const cachedConversationUsedTokens = cachedState?.tokenDetails?.usedTokens ?? 0;
+			const cachedConversationUsedTokens =
+				cachedState && countCursorHistoryTurns(context.messages) >= (cachedState.turns?.length ?? 0)
+					? (cachedState.tokenDetails?.usedTokens ?? 0)
+					: 0;
 			const usageState: UsageState = {
 				sawTokenDelta: false,
 				conversationUsedTokens: cachedConversationUsedTokens,
@@ -782,6 +786,7 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 				}
 			});
 			h2Request.on("end", () => {
+				inboundEnd.resolve();
 				if (!coordinator.hasTurnEnded()) {
 					coordinator.fail(new Error("Cursor stream ended before turnEnded"));
 				}
@@ -883,6 +888,7 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 					resolve();
 				}
 			});
+			await inboundEnd.promise;
 
 			if (state.currentTextBlock) {
 				const idx = output.content.indexOf(state.currentTextBlock);
@@ -3252,6 +3258,26 @@ function buildConversationTurns(messages: Message[], blobStore: Map<string, Uint
 	}
 
 	return turns;
+}
+
+function countCursorHistoryTurns(messages: Message[]): number {
+	let count = 0;
+	for (let i = 0; i < messages.length; i++) {
+		const message = messages[i];
+		if (
+			(message.role !== "user" && message.role !== "developer") ||
+			(extractUserMessageText(message).length === 0 && !hasUserMessageImages(message))
+		) {
+			continue;
+		}
+		for (let j = i + 1; j < messages.length; j++) {
+			if (messages[j].role === "user" || messages[j].role === "developer") {
+				count++;
+				break;
+			}
+		}
+	}
+	return count;
 }
 
 /** Exported for tests: decodes Cursor history blobs built from conversation messages. */

--- a/packages/ai/test/cursor-conversation-usage.test.ts
+++ b/packages/ai/test/cursor-conversation-usage.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "bun:test";
+
+import type { Usage } from "../src/types";
+
+import { finalizeCursorUsageForTest } from "../src/providers/cursor";
+
+/**
+ * Mirror of `calculatePromptTokens` in `@gajae-code/agent`, which drives the
+ * context indicator and the compaction threshold. `packages/ai` does not depend
+ * on `packages/agent`, so the consumer formula is restated here rather than
+ * imported.
+ */
+function promptTokens(usage: Usage): number {
+	const prompt = usage.input + usage.cacheRead + usage.cacheWrite;
+	return prompt > 0 ? prompt : usage.totalTokens || usage.input + usage.output;
+}
+
+/**
+ * Cursor reports whole-conversation consumption as
+ * `ConversationTokenDetails.used_tokens` and streams this turn's output as
+ * token deltas. The prompt side is the difference; attributing `used_tokens` to
+ * output leaves `usage.input` at zero, which makes context accounting and
+ * compaction believe the conversation is empty.
+ */
+describe("cursor conversation usage", () => {
+	it("derives prompt tokens from conversation usage minus streamed output", () => {
+		const usage = finalizeCursorUsageForTest(21_594, 14);
+
+		expect(usage.input).toBe(21_580);
+		expect(usage.output).toBe(14);
+		expect(usage.totalTokens).toBe(21_594);
+	});
+
+	it("reports prompt tokens to the compaction accounting path", () => {
+		const usage = finalizeCursorUsageForTest(21_594, 14);
+
+		// Before the fix `input` stayed 0, so this fell through to the
+		// output-only fallback and reported 14 tokens of context.
+		expect(promptTokens(usage)).toBe(21_580);
+	});
+
+	it("preserves the reported conversation total in totalTokens", () => {
+		// Observed across four turns of a live cursor/kimi-k3-max session.
+		const observed: Array<[used: number, output: number]> = [
+			[22_418, 860],
+			[22_829, 1_089],
+			[22_292, 239],
+			[22_586, 278],
+		];
+
+		for (const [used, output] of observed) {
+			const usage = finalizeCursorUsageForTest(used, output);
+			expect(usage.totalTokens).toBe(used);
+			// The output-only fallback would have reported `output` here.
+			expect(promptTokens(usage)).toBeGreaterThan(20_000);
+		}
+	});
+
+	it("leaves usage untouched when no checkpoint reported conversation usage", () => {
+		const usage = finalizeCursorUsageForTest(0, 91);
+
+		expect(usage.input).toBe(0);
+		expect(usage.output).toBe(91);
+	});
+
+	it("never reports negative prompt tokens when output exceeds reported usage", () => {
+		const usage = finalizeCursorUsageForTest(50, 91);
+
+		expect(usage.input).toBe(0);
+		expect(usage.totalTokens).toBe(91);
+	});
+});

--- a/packages/ai/test/cursor-conversation-usage.test.ts
+++ b/packages/ai/test/cursor-conversation-usage.test.ts
@@ -39,6 +39,14 @@ describe("cursor conversation usage", () => {
 		expect(usage.input + usage.output).toBe(100);
 	});
 
+	it("does not subtract output produced after a periodic checkpoint", () => {
+		const usage = finalizeCursorUsageForTest(100, 15, { checkpointOutputTokens: 10 });
+
+		expect(usage.input).toBe(90);
+		expect(usage.output).toBe(15);
+		expect(usage.totalTokens).toBe(105);
+	});
+
 	it("reports prompt tokens to the compaction accounting path", () => {
 		const usage = finalizeCursorUsageForTest(21_594, 14);
 
@@ -69,6 +77,21 @@ describe("cursor conversation usage", () => {
 
 		expect(usage.input).toBe(0);
 		expect(usage.output).toBe(91);
+	});
+
+	it("uses the cached conversation total when a warm turn has no checkpoint", () => {
+		const usage = finalizeCursorUsageForTest(10_000, 100, { hasConversationCheckpoint: false });
+
+		expect(usage.input).toBe(10_000);
+		expect(usage.output).toBe(100);
+		expect(usage.totalTokens).toBe(10_100);
+	});
+
+	it("accepts an explicit zero checkpoint as a reset", () => {
+		const usage = finalizeCursorUsageForTest(0, 91, { hasConversationCheckpoint: true });
+
+		expect(usage.input).toBe(0);
+		expect(usage.totalTokens).toBe(91);
 	});
 
 	it("never reports negative prompt tokens when output exceeds reported usage", () => {

--- a/packages/ai/test/cursor-conversation-usage.test.ts
+++ b/packages/ai/test/cursor-conversation-usage.test.ts
@@ -87,6 +87,18 @@ describe("cursor conversation usage", () => {
 		expect(usage.totalTokens).toBe(10_100);
 	});
 
+	it("advances a checkpoint-free baseline exactly once across warm turns", () => {
+		const firstTurn = finalizeCursorUsageForTest(10_000, 100, { hasConversationCheckpoint: false });
+		const secondTurn = finalizeCursorUsageForTest(firstTurn.totalTokens, 50, { hasConversationCheckpoint: false });
+		const thirdTurn = finalizeCursorUsageForTest(secondTurn.totalTokens, 25, { hasConversationCheckpoint: false });
+
+		expect(firstTurn.totalTokens).toBe(10_100);
+		expect(secondTurn.input).toBe(10_100);
+		expect(secondTurn.totalTokens).toBe(10_150);
+		expect(thirdTurn.input).toBe(10_150);
+		expect(thirdTurn.totalTokens).toBe(10_175);
+	});
+
 	it("accepts an explicit zero checkpoint as a reset", () => {
 		const usage = finalizeCursorUsageForTest(0, 91, { hasConversationCheckpoint: true });
 

--- a/packages/ai/test/cursor-conversation-usage.test.ts
+++ b/packages/ai/test/cursor-conversation-usage.test.ts
@@ -47,6 +47,14 @@ describe("cursor conversation usage", () => {
 		expect(usage.totalTokens).toBe(105);
 	});
 
+	it("does not reuse pre-compaction output after a checkpoint decrease", () => {
+		const usage = finalizeCursorUsageForTest(80, 30, { checkpointOutputTokens: 0 });
+
+		expect(usage.input).toBe(80);
+		expect(usage.output).toBe(30);
+		expect(usage.totalTokens).toBe(110);
+	});
+
 	it("reports prompt tokens to the compaction accounting path", () => {
 		const usage = finalizeCursorUsageForTest(21_594, 14);
 

--- a/packages/ai/test/cursor-conversation-usage.test.ts
+++ b/packages/ai/test/cursor-conversation-usage.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, it } from "bun:test";
 
-import type { Usage } from "../src/types";
-
 import { finalizeCursorUsageForTest } from "../src/providers/cursor";
+import type { Usage } from "../src/types";
 
 /**
  * Mirror of `calculatePromptTokens` in `@gajae-code/agent`, which drives the

--- a/packages/ai/test/cursor-conversation-usage.test.ts
+++ b/packages/ai/test/cursor-conversation-usage.test.ts
@@ -27,7 +27,16 @@ describe("cursor conversation usage", () => {
 
 		expect(usage.input).toBe(21_580);
 		expect(usage.output).toBe(14);
+		expect(usage.cacheRead).toBe(0);
+		expect(usage.cacheWrite).toBe(0);
 		expect(usage.totalTokens).toBe(21_594);
+	});
+
+	it("does not double-count checkpoint totals as output", () => {
+		const usage = finalizeCursorUsageForTest(100, 10);
+
+		expect(usage.output).toBe(10);
+		expect(usage.input + usage.output).toBe(100);
 	});
 
 	it("reports prompt tokens to the compaction accounting path", () => {
@@ -67,5 +76,14 @@ describe("cursor conversation usage", () => {
 
 		expect(usage.input).toBe(0);
 		expect(usage.totalTokens).toBe(91);
+	});
+
+	it("resets usage for a new turn instead of accumulating prior checkpoints", () => {
+		const firstTurn = finalizeCursorUsageForTest(10_000, 100);
+		const secondTurn = finalizeCursorUsageForTest(250, 25);
+
+		expect(firstTurn.totalTokens).toBe(10_000);
+		expect(secondTurn.input).toBe(225);
+		expect(secondTurn.totalTokens).toBe(250);
 	});
 });

--- a/packages/ai/test/cursor-exec-handlers.test.ts
+++ b/packages/ai/test/cursor-exec-handlers.test.ts
@@ -6,15 +6,17 @@ import {
 	buildCursorRequestContextRules,
 	buildCursorSystemPromptJsons,
 	createCursorMessageQueueForTest,
+	disposeCursorConversation,
 	resolveExecHandler,
 	streamCursor,
 } from "../src/providers/cursor";
+import type { AgentRunRequest, AgentServerMessage } from "../src/providers/cursor/gen/agent_pb";
 import {
 	type AgentClientMessage,
 	AgentClientMessageSchema,
-	type AgentRunRequest,
-	type AgentServerMessage,
 	AgentServerMessageSchema,
+	ConversationStateStructureSchema,
+	ConversationTokenDetailsSchema,
 	ExecServerMessageSchema,
 	InteractionUpdateSchema,
 	ReadArgsSchema,
@@ -109,6 +111,19 @@ function createTurnEndedMessage(): AgentServerMessage {
 					case: "turnEnded",
 					value: create(TurnEndedUpdateSchema, {}),
 				},
+			}),
+		},
+	});
+}
+
+function createConversationCheckpointMessage(usedTokens?: number): AgentServerMessage {
+	return create(AgentServerMessageSchema, {
+		message: {
+			case: "conversationCheckpointUpdate",
+			value: create(ConversationStateStructureSchema, {
+				...(usedTokens === undefined
+					? {}
+					: { tokenDetails: create(ConversationTokenDetailsSchema, { usedTokens }) }),
 			}),
 		},
 	});
@@ -248,6 +263,133 @@ describe("Cursor server message ordering", () => {
 });
 
 describe("Cursor request lifecycle", () => {
+	it("applies a checkpoint delivered after turnEnded before finalizing usage", async () => {
+		const server = http2.createServer();
+		server.on("stream", (stream: http2.ServerHttp2Stream) => {
+			stream.respond({ ":status": 200, "content-type": "application/connect+proto" });
+			stream.once("data", () => {
+				stream.write(frameServerMessage(createTurnEndedMessage()));
+				setTimeout(() => {
+					stream.end(frameServerMessage(createConversationCheckpointMessage(321)));
+				}, 5);
+			});
+		});
+		await new Promise<void>((resolve, reject) => {
+			server.once("error", reject);
+			server.listen(0, "127.0.0.1", resolve);
+		});
+
+		const conversationId = `checkpoint-late-${crypto.randomUUID()}`;
+		try {
+			const address = server.address();
+			if (!address || typeof address === "string") throw new Error("Expected TCP server address");
+			const events: AssistantMessageEvent[] = [];
+			for await (const event of streamCursor(
+				{ ...cursorModel, baseUrl: `http://127.0.0.1:${address.port}` },
+				{ messages: [{ role: "user", content: "checkpoint", timestamp: 0 }] },
+				{ apiKey: "test-token", conversationId },
+			)) {
+				events.push(event);
+			}
+			const done = events.find(
+				(event): event is Extract<AssistantMessageEvent, { type: "done" }> => event.type === "done",
+			);
+			expect(done?.message.usage.input).toBe(321);
+			expect(events.filter(event => event.type === "error")).toHaveLength(0);
+		} finally {
+			disposeCursorConversation(conversationId);
+			await new Promise<void>(resolve => server.close(() => resolve()));
+		}
+	});
+
+	it("rolls back checkpoint usage when a stream fails before retry", async () => {
+		const server = http2.createServer();
+		let requestCount = 0;
+		server.on("stream", (stream: http2.ServerHttp2Stream) => {
+			requestCount++;
+			stream.on("error", () => {});
+			stream.respond({ ":status": 200, "content-type": "application/connect+proto" });
+			stream.once("data", () => {
+				if (requestCount === 1) {
+					stream.write(frameServerMessage(createConversationCheckpointMessage(500)));
+					setTimeout(() => stream.close(http2.constants.NGHTTP2_INTERNAL_ERROR), 5);
+					return;
+				}
+				stream.end(frameServerMessage(createTurnEndedMessage()));
+			});
+		});
+		await new Promise<void>((resolve, reject) => {
+			server.once("error", reject);
+			server.listen(0, "127.0.0.1", resolve);
+		});
+
+		const conversationId = `checkpoint-rollback-${crypto.randomUUID()}`;
+		try {
+			const address = server.address();
+			if (!address || typeof address === "string") throw new Error("Expected TCP server address");
+			const model = { ...cursorModel, baseUrl: `http://127.0.0.1:${address.port}` };
+			const firstEvents: AssistantMessageEvent[] = [];
+			for await (const event of streamCursor(
+				model,
+				{ messages: [{ role: "user", content: "first", timestamp: 0 }] },
+				{ apiKey: "test-token", conversationId },
+			)) {
+				firstEvents.push(event);
+			}
+			expect(firstEvents.some(event => event.type === "error")).toBe(true);
+
+			const secondEvents: AssistantMessageEvent[] = [];
+			for await (const event of streamCursor(
+				model,
+				{ messages: [{ role: "user", content: "retry", timestamp: 0 }] },
+				{ apiKey: "test-token", conversationId },
+			)) {
+				secondEvents.push(event);
+			}
+			const done = secondEvents.find(
+				(event): event is Extract<AssistantMessageEvent, { type: "done" }> => event.type === "done",
+			);
+			expect(done?.message.usage.input).toBe(0);
+		} finally {
+			disposeCursorConversation(conversationId);
+			await new Promise<void>(resolve => server.close(() => resolve()));
+		}
+	});
+
+	it("allows a delayed inbound terminal when the watchdog is disabled", async () => {
+		const server = http2.createServer();
+		server.on("stream", (stream: http2.ServerHttp2Stream) => {
+			stream.respond({ ":status": 200, "content-type": "application/connect+proto" });
+			stream.once("data", () => {
+				stream.write(frameServerMessage(createTurnEndedMessage()));
+				setTimeout(() => stream.end(), 25);
+			});
+		});
+		await new Promise<void>((resolve, reject) => {
+			server.once("error", reject);
+			server.listen(0, "127.0.0.1", resolve);
+		});
+
+		const conversationId = `checkpoint-watchdog-${crypto.randomUUID()}`;
+		try {
+			const address = server.address();
+			if (!address || typeof address === "string") throw new Error("Expected TCP server address");
+			const events: AssistantMessageEvent[] = [];
+			for await (const event of streamCursor(
+				{ ...cursorModel, baseUrl: `http://127.0.0.1:${address.port}` },
+				{ messages: [{ role: "user", content: "watchdog", timestamp: 0 }] },
+				{ apiKey: "test-token", conversationId, streamIdleTimeoutMs: 0 },
+			)) {
+				events.push(event);
+			}
+			expect(events.filter(event => event.type === "done")).toHaveLength(1);
+			expect(events.filter(event => event.type === "error")).toHaveLength(0);
+		} finally {
+			disposeCursorConversation(conversationId);
+			await new Promise<void>(resolve => server.close(() => resolve()));
+		}
+	});
+
 	it("drains an admitted exec response before completing after turnEnded", async () => {
 		const { promise: releasePromise, resolve: releaseHandler } = Promise.withResolvers<void>();
 		const { promise: handlerStarted, resolve: markHandlerStarted } = Promise.withResolvers<void>();


### PR DESCRIPTION
## Summary

Salvages PR #5172 onto current `dev`, preserving the original contributor attribution in the first commit (`df0099eac7`, cherry-picked from `16e49d63724309a3d1f05c912ff0817f5423ff9c` by `001005HS`).

- Derives Cursor prompt usage from `ConversationTokenDetails.used_tokens` without double-counting streamed output.
- Handles periodic and late checkpoints, including checkpoints received after `turnEnded`.
- Seeds warm usage from the request state actually sent; binds warm reuse to model, system prompt, custom prompt, tools, and history identity.
- Resets checkpoint output baselines after compaction decreases.
- Commits derived state only after successful streams and rolls back state on failure.
- Runs checkpoint accounting through the ordered task chain and finalizes after it drains.
- Adds arithmetic plus local HTTP/2 stream lifecycle regressions for late checkpoints, rollback/retry, and disabled watchdog behavior.

Rebased onto current `dev` (`7000d77233` — adds `feat(models): auto model discovery` #5187).

## Verification

- `bun run check` (ai package)
- `bun test ./packages/ai/test/cursor-*.test.ts` (85 pass: 12 conversation-usage + 27 exec-handlers + 46 other cursor tests)
- `bun scripts/check-visible-definitions.ts` / `verify-g002-gates.ts` / `rebrand-inventory.ts --strict` pass
- Native addon built with `bun --cwd=packages/natives run build`

## Risk classification

- [ ] `low-risk`
- [x] `regression-risk`
- [ ] `high-risk`

## GJC verdict

```text
gajae.pr-review-verdict.v1 needs-human sha256:605e540ae5dded66f25464f602798ec6e86fd51596839af46f24ea0460f7ca2c reviewer:human reviewer-id:maintainer evidence:https://github.com/Yeachan-Heo/gajae-code/pull/5173
```

Successor exact head: `f258b2b53e2998366e57924eee98b379aa73afee`.
Successor targets current `dev` at `7000d77233129b6c67a929869f9d5efb229c2c51`.