### PR TITLE
fix(ai): fall back to h1 when h2 fetch reports spurious certificate error

### DIFF
--- a/packages/ai/src/utils/h2-fetch.ts
+++ b/packages/ai/src/utils/h2-fetch.ts
@@ -14,6 +14,13 @@
  * or `ConnectionClosed` rather than `HTTP2Unsupported`, so we treat those
  * codes as h2-fallback triggers as well.
  *
+ * ALPN-refusing hosts (notably zcode.z.ai, the GLM ZCode OAuth broker) abort
+ * the TLS handshake entirely when the client offers ALPN h2. Bun reports that
+ * abort as `UNKNOWN_CERTIFICATE_VERIFICATION_ERROR` even though the host's
+ * certificate chain verifies fine over h1 (issue #5178), so that code is a
+ * fallback trigger too — never a reason to accept a bad certificate: the h1
+ * attempt below performs full verification on its own.
+ *
  * Bun negotiates h2 via ALPN over TLS only (no h2c), so plain `http://` URLs
  * skip the attempt entirely — avoids the throw/retry round-trip for localhost.
  *
@@ -36,6 +43,9 @@ export function installH2Fetch(): void {
 		"ConnectionRefused", // Server refused the h2 connection
 		"ConnectionReset", // Server reset during h2 handshake
 		"ConnectionClosed", // Server closed before h2 response
+		// Bun's h2 client reports an ALPN-refusing host's TLS abort with this
+		// code; the h1 fallback below re-verifies the certificate itself.
+		"UNKNOWN_CERTIFICATE_VERIFICATION_ERROR",
 	]);
 	const wrapper = async function h2fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> {
 		if (!isHttps(input)) return original(input, init);

--- a/packages/ai/test/h2-fetch-fallback.test.ts
+++ b/packages/ai/test/h2-fetch-fallback.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { installH2Fetch } from "../src/utils/h2-fetch";
+
+/**
+ * Issue #5178 regression coverage: the gjc login flow fetches the GLM ZCode
+ * OAuth broker through the h2-fetch wrapper. Bun's h2 client reports an
+ * ALPN-refusing host's TLS abort as UNKNOWN_CERTIFICATE_VERIFICATION_ERROR
+ * even though the same request verifies fine over h1, which surfaced as
+ * "Login failed: unknown certificate verification error" during token
+ * exchange. The wrapper must fall back to h1 for that code while genuine
+ * certificate failures keep failing closed with their real codes.
+ *
+ * The tests drive a mock base fetch so they assert the wrapper's fallback
+ * contract only — no network, no secrets.
+ */
+
+interface RecordedCall {
+	input: string | URL | Request;
+	init: RequestInit | undefined;
+}
+
+type FetchLike = (input: string | URL | Request, init?: RequestInit) => Response | Promise<Response>;
+
+function withPatchedFetch(impl: FetchLike): { calls: RecordedCall[]; restore: () => void } {
+	const original = globalThis.fetch;
+	const calls: RecordedCall[] = [];
+	globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+		calls.push({ input, init });
+		return impl(input, init);
+	}) as typeof fetch;
+	return {
+		calls,
+		restore: () => {
+			globalThis.fetch = original;
+		},
+	};
+}
+
+const BROKER_TOKEN_URL = "https://zcode.z.ai/api/v1/oauth/token";
+
+/** The exact request shape exchangeGlmZcodeCode() sends (no real credentials). */
+function brokerBody(): Record<string, string> {
+	return { provider: "zai", code: "test-code", redirect_uri: "zcode://oauth/callback", state: "s" };
+}
+
+function brokerExchangeInit(): RequestInit {
+	return {
+		method: "POST",
+		headers: { Accept: "application/json", "Content-Type": "application/json" },
+		body: JSON.stringify(brokerBody()),
+	};
+}
+
+describe("h2-fetch wrapper (issue #5178)", () => {
+	afterEach(() => {
+		const patchedFetch = globalThis.fetch as unknown as { [key: symbol]: unknown };
+		delete patchedFetch[Symbol.for("gajae-code.h2fetch.installed")];
+	});
+
+	it("falls back to h1 when the h2 attempt fails with UNKNOWN_CERTIFICATE_VERIFICATION_ERROR", async () => {
+		const verificationFailure = Object.assign(new TypeError("unknown certificate verification error"), {
+			code: "UNKNOWN_CERTIFICATE_VERIFICATION_ERROR",
+		});
+
+		const patched = withPatchedFetch((_input, init) => {
+			if ((init as { protocol?: string } | undefined)?.protocol === "http2") {
+				throw verificationFailure;
+			}
+			return Promise.resolve(new Response("ok-h1", { status: 200 }));
+		});
+		installH2Fetch();
+
+		const response = await fetch(BROKER_TOKEN_URL, brokerExchangeInit());
+		expect(response.status).toBe(200);
+		expect(await response.text()).toBe("ok-h1");
+
+		const h2Attempts = patched.calls.filter(c => (c.init as { protocol?: string } | undefined)?.protocol === "http2");
+		const h1Attempts = patched.calls.filter(
+			c => (c.init as { protocol?: string } | undefined)?.protocol === undefined,
+		);
+		expect(h2Attempts).toHaveLength(1);
+		expect(h1Attempts).toHaveLength(1);
+		expect(h1Attempts[0]?.init?.method).toBe("POST");
+		patched.restore();
+	});
+
+	it("retries the identical request on h1 without the protocol hint", async () => {
+		const verificationFailure = Object.assign(new TypeError("unknown certificate verification error"), {
+			code: "UNKNOWN_CERTIFICATE_VERIFICATION_ERROR",
+		});
+
+		const seenInits: Array<Record<string, unknown>> = [];
+		const patched = withPatchedFetch((_input, init) => {
+			if ((init as { protocol?: string } | undefined)?.protocol === "http2") {
+				throw verificationFailure;
+			}
+			seenInits.push({ ...(init ?? {}) });
+			return Promise.resolve(
+				new Response(JSON.stringify({ ok: true }), { headers: { "Content-Type": "application/json" } }),
+			);
+		});
+		installH2Fetch();
+
+		const response = await fetch(BROKER_TOKEN_URL, brokerExchangeInit());
+		expect(await response.json()).toEqual({ ok: true });
+
+		expect(seenInits).toHaveLength(1);
+		const h1Init = seenInits[0] as {
+			method?: string;
+			headers?: Record<string, string>;
+			body?: string;
+			protocol?: string;
+		};
+		expect(h1Init.method).toBe("POST");
+		expect(h1Init.body).toBe(JSON.stringify(brokerBody()));
+		expect(h1Init.headers?.["Content-Type"]).toBe("application/json");
+		expect(h1Init.protocol).toBeUndefined();
+		patched.restore();
+	});
+
+	it("still fails closed on genuine certificate verification errors on h1", async () => {
+		const genuineFailure = Object.assign(new TypeError("self signed certificate"), {
+			code: "DEPTH_ZERO_SELF_SIGNED_CERT",
+		});
+
+		const patched = withPatchedFetch((_input, init) => {
+			if ((init as { protocol?: string } | undefined)?.protocol === "http2") {
+				return Promise.reject(
+					Object.assign(new TypeError("unknown certificate verification error"), {
+						code: "UNKNOWN_CERTIFICATE_VERIFICATION_ERROR",
+					}),
+				);
+			}
+			return Promise.reject(genuineFailure);
+		});
+		installH2Fetch();
+
+		let caught: unknown;
+		try {
+			await fetch(BROKER_TOKEN_URL, brokerExchangeInit());
+		} catch (error) {
+			caught = error;
+		}
+		expect((caught as { code?: string }).code).toBe("DEPTH_ZERO_SELF_SIGNED_CERT");
+		expect((caught as Error).message).not.toContain("unknown certificate");
+		patched.restore();
+	});
+
+	it("does not fall back for application-level failures", async () => {
+		const patched = withPatchedFetch(() => Promise.resolve(new Response("boom", { status: 500 })));
+		installH2Fetch();
+
+		const response = await fetch(BROKER_TOKEN_URL, brokerExchangeInit());
+		expect(response.status).toBe(500);
+		expect(patched.calls).toHaveLength(1);
+		patched.restore();
+	});
+
+	it("passes non-https requests through without the h2 hint", async () => {
+		const patched = withPatchedFetch(() => Promise.resolve(new Response("local", { status: 200 })));
+		installH2Fetch();
+
+		const response = await fetch("http://127.0.0.1:9/callback");
+		expect(response.status).toBe(200);
+		expect(patched.calls).toHaveLength(1);
+		expect((patched.calls[0]?.init as { protocol?: string } | undefined)?.protocol).toBeUndefined();
+		patched.restore();
+	});
+});

--- a/packages/ai/test/oauth-glm-zcode.test.ts
+++ b/packages/ai/test/oauth-glm-zcode.test.ts
@@ -531,4 +531,73 @@ describe("GLM ZCode OAuth login provider", () => {
 		expect(headers["X-ZCode-Agent"]).toBeUndefined();
 		expect(headers["User-Agent"] ?? "").not.toBe("ZCode/3.1.2");
 	});
+	it("throws the documented broker failure shape when the broker rejects the exchange", async () => {
+		const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+			const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+			if (url === GLM_ZCODE_OAUTH_BROKER_TOKEN_URL) {
+				return new Response("upstream says no", { status: 401 });
+			}
+			throw new Error(`Unexpected fetch: ${init?.method ?? "GET"} ${url}`);
+		});
+		const flow = new GlmZcodeOAuthFlow(
+			{ onAuth: () => {}, onPrompt: async () => "" },
+			{ fetch: fetchMock as unknown as typeof fetch },
+		);
+		let caught: unknown;
+		try {
+			await flow.exchangeToken("auth-code", "state-1", GLM_ZCODE_OAUTH_REDIRECT_URI);
+		} catch (error) {
+			caught = error;
+		}
+		expect(caught).toBeInstanceOf(Error);
+		const message = (caught as Error).message;
+		// Failure shape: labeled broker failure with status + redacted body, nothing else.
+		expect(message).toMatch(/^GLM ZCode broker request failed: 401 /);
+		expect(message).not.toMatch(/auth-code|state-1/);
+	});
+
+	it("redacts token-like secrets from broker error bodies", async () => {
+		const leaky = `eyJhbGciOiJIUzI1NiJ9.${Buffer.from(JSON.stringify({ sub: "x" })).toString("base64url")}.sigPART`;
+		const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+			const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+			if (url === GLM_ZCODE_OAUTH_BROKER_TOKEN_URL) {
+				return new Response(`token=${leaky} trace ok`, { status: 500 });
+			}
+			throw new Error(`Unexpected fetch: ${init?.method ?? "GET"} ${url}`);
+		});
+		const flow = new GlmZcodeOAuthFlow(
+			{ onAuth: () => {}, onPrompt: async () => "" },
+			{ fetch: fetchMock as unknown as typeof fetch },
+		);
+		let caught: unknown;
+		try {
+			await flow.exchangeToken("auth-code", "state-1", GLM_ZCODE_OAUTH_REDIRECT_URI);
+		} catch (error) {
+			caught = error;
+		}
+		const message = (caught as Error).message;
+		expect(message).toContain("[redacted-jwt]");
+		expect(message).not.toContain(leaky);
+		expect(message).not.toContain("sigPART");
+	});
+
+	it("throws a labeled failure when the broker response is missing required fields", async () => {
+		const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+			const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+			if (url === GLM_ZCODE_OAUTH_BROKER_TOKEN_URL) {
+				return new Response(JSON.stringify({ code: 2007, msg: "http error" }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			}
+			throw new Error(`Unexpected fetch: ${init?.method ?? "GET"} ${url}`);
+		});
+		const flow = new GlmZcodeOAuthFlow(
+			{ onAuth: () => {}, onPrompt: async () => "" },
+			{ fetch: fetchMock as unknown as typeof fetch },
+		);
+		await expect(flow.exchangeToken("auth-code", "state-1", GLM_ZCODE_OAUTH_REDIRECT_URI)).rejects.toThrow(
+			"GLM ZCode broker response missing data.token or data.zai.access_token",
+		);
+	});
 });


### PR DESCRIPTION
Closes #5178

gajae.pr-review-verdict.v1 merge-self-approved sha256:b18f3c28c478adcd577bacb949acb3825c5919337151b0648c79759b9e5f16e6 reviewer:human reviewer-id:Yeachan-Heo evidence:solo owner change; h2-fetch fallback code+tests, no TLS weakening

- [x] `low-risk`

## Summary

`gjc /login` GLM ZCode OAuth failed during "Exchanging authorization code for tokens..." with `Login failed: unknown certificate verification error`. The certificate chain was never actually invalid — GJC's h2-fetch wrapper (`installH2Fetch()`, activated in `packages/coding-agent/src/cli.ts` → `installRuntimeGlobals()`) sends every HTTPS request through Bun's native HTTP/2 client, and Bun's h2 client reports the handshake abort from ALPN-refusing hosts as `UNKNOWN_CERTIFICATE_VERIFICATION_ERROR`.

## Root cause (independently reproduced, no secrets)

1. GLM ZCode token exchange posts to the broker `https://zcode.z.ai/api/v1/oauth/token` via `globalThis.fetch` (`packages/ai/src/utils/oauth/glm-zcode.ts`, `postJson`).
2. `packages/ai/src/utils/h2-fetch.ts` forces `protocol: "http2"` on every HTTPS request and only falls back to HTTP/1.1 for `{HTTP2Unsupported, ConnectionRefused, ConnectionReset, ConnectionClosed}`.
3. `zcode.z.ai` (and `chat.z.ai`) **refuse ALPN h2**: with `-alpn h2` the server aborts the TLS handshake (alert 120, no_application_protocol); with `h2,http/1.1` it negotiates `http/1.1` and verifies fine. Bun's h2 client surfaces that abort as `unknown certificate verification error` (`UNKNOWN_CERTIFICATE_VERIFICATION_ERROR`).
4. That code was not in the fallback set → the error propagated straight into the login failure UI.

Evidence gathered on this host:
- `openssl s_client -connect zcode.z.ai:443 -servername zcode.z.ai`: TLSv1.3, Sectigo chain, `Verification: OK`. With `-alpn h2`: alert 120. With `-alpn h2,http/1.1`: negotiates `http/1.1`, `Verification: OK`.
- `curl --http2 https://zcode.z.ai/`: "server accepted to use http/1.1", `SSL certificate verify ok`.
- Deterministic Bun probe: `POST` to the broker with `protocol:"http2"` → `UNKNOWN_CERTIFICATE_VERIFICATION_ERROR` 3/3; without the hint → HTTP response (server reachable). `api.z.ai` works fine over h2 — matching the reporter's observation that direct Bun probes to api.z.ai succeeded while the broker-based login failed.
- Control: `self-signed.badssl.com` still fails with its real code (`DEPTH_ZERO_SELF_SIGNED_CERT`) on both h1 and h2 — Bun's h2 verification itself is intact; the failure on zcode.z.ai is a transport artifact of ALPN refusal.

The certificate error therefore masks **nothing**: the request never left the TLS handshake, before any HTTP status, OAuth body, or callback parsing. (The separately reported headless `zcode://` display issue is real but distinct; pasted `zcode://` URLs are already parsed and tested.)

## Fix

`packages/ai/src/utils/h2-fetch.ts`: add `UNKNOWN_CERTIFICATE_VERIFICATION_ERROR` to the h2 fallback triggers and retry the **identical** request without the h2 hint.

- TLS verification is fully preserved: the h1 retry performs complete certificate verification on its own; genuinely bad certificates still fail closed with their real codes. No `rejectUnauthorized` changes, no CA overrides, no auth bypasses.
- `api.z.ai` (which negotiates h2) is unaffected — still h2.

## Regression tests

- `packages/ai/test/h2-fetch-fallback.test.ts` (new):
  - falls back to h1 when the h2 attempt fails with `UNKNOWN_CERTIFICATE_VERIFICATION_ERROR`;
  - retries the identical request (method/body/headers preserved, no `protocol` hint);
  - **fails closed** on genuine certificate failures (`DEPTH_ZERO_SELF_SIGNED_CERT` propagates);
  - does not fall back for application-level failures (HTTP 500 passes through, single attempt);
  - non-https requests pass through without the h2 hint.
- `packages/ai/test/oauth-glm-zcode.test.ts` (extended):
  - broker failure shape: labeled `GLM ZCode broker request failed: <status>`, no authorization code / state leaked;
  - JWT redaction: error bodies containing token-like strings surface as `[redacted-jwt]`, raw secret absent;
  - missing-field broker response fails with the documented message;
  - existing coverage retained for successful mocked exchange, pasted `zcode://` redirect URL, and headless/manual callback flow (`callback-server-manual-input.test.ts`).

## Verification

- `bun test packages/ai/test/h2-fetch-fallback.test.ts packages/ai/test/oauth-glm-zcode.test.ts packages/ai/test/callback-server-manual-input.test.ts` → 36 pass
- `bun --cwd=packages/ai run check` (biome + tsc) → exit 0
- Live wrapper probe post-fix: broker reachable through the wrapper (500 on a deliberately invalid body — endpoint responds), `api.z.ai` 200, badssl still rejected.
- No credentials, authorization codes, or tokens were requested, captured, or logged at any point.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
