### PR TITLE
fix(ai): warn glm-zcode users about the desktop app consuming the login code

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `glm-zcode` login instructions now warn users who have the ZCode desktop app installed to cancel the browser's `zcode://` open prompt. The app exchanges the single-use authorization code itself, so a code pasted afterwards is rejected by the broker (`500 {"code":2007}`) and the documented paste flow failed without explanation.
+
 ## [0.16.0] - 2026-09-02
 
 ### Added

--- a/packages/ai/src/utils/oauth/glm-zcode.ts
+++ b/packages/ai/src/utils/oauth/glm-zcode.ts
@@ -387,7 +387,7 @@ export class GlmZcodeOAuthFlow extends OAuthCallbackFlow {
 		return {
 			url: `${authorizeUrl}?${params.toString()}`,
 			instructions:
-				"Complete Z.AI login in your browser. This is an UNOFFICIAL ZCode-based login — use at your own risk; it may stop working or violate ZCode/Z.AI Terms of Service. Because this CLI cannot receive the zcode:// redirect, paste the final redirect URL or authorization code when prompted.",
+				"Complete Z.AI login in your browser. This is an UNOFFICIAL ZCode-based login — use at your own risk; it may stop working or violate ZCode/Z.AI Terms of Service. Because this CLI cannot receive the zcode:// redirect, paste the final redirect URL or authorization code when prompted. If the ZCode desktop app is installed, cancel the browser's prompt to open it: the app exchanges the single-use code itself and the pasted code is then rejected (broker error 2007).",
 		};
 	}
 

--- a/packages/ai/test/oauth-glm-zcode.test.ts
+++ b/packages/ai/test/oauth-glm-zcode.test.ts
@@ -144,6 +144,10 @@ describe("GLM ZCode OAuth login provider", () => {
 		expect(authUrl.searchParams.get("response_type")).toBe("code");
 		expect(authUrl.searchParams.get("state")).toBe("state-1");
 		expect(instructions ?? "").toMatch(/unofficial/i);
+		// A desktop-app install consumes the single-use code before the user can paste it;
+		// the instructions must warn about that or the documented flow fails silently.
+		expect(instructions ?? "").toMatch(/desktop app/i);
+		expect(instructions ?? "").toMatch(/cancel/i);
 	});
 
 	it("exchanges the code and provisions a Z.AI API key as the credential", async () => {

--- a/packages/ai/test/oauth-glm-zcode.test.ts
+++ b/packages/ai/test/oauth-glm-zcode.test.ts
@@ -15,6 +15,7 @@ import {
 } from "../src/providers/anthropic";
 import { isOAuthToken } from "../src/utils/anthropic-auth";
 import { getOAuthProviders, refreshOAuthToken } from "../src/utils/oauth";
+import { AnthropicOAuthFlow } from "../src/utils/oauth/anthropic";
 import {
 	GLM_ZCODE_ANTHROPIC_BASE_URL,
 	GLM_ZCODE_OAUTH_AUTHORIZE_URL,
@@ -148,6 +149,23 @@ describe("GLM ZCode OAuth login provider", () => {
 		// the instructions must warn about that or the documented flow fails silently.
 		expect(instructions ?? "").toMatch(/desktop app/i);
 		expect(instructions ?? "").toMatch(/cancel/i);
+	});
+
+	it("scopes the desktop-app warning to glm-zcode without exposing login values", async () => {
+		const glmFlow = new GlmZcodeOAuthFlow({ onAuth: () => {}, onPrompt: async () => "" });
+		const { instructions: glmInstructions } = await glmFlow.generateAuthUrl("state-1", GLM_ZCODE_OAUTH_REDIRECT_URI);
+		expect(glmInstructions ?? "").toMatch(/desktop app/i);
+		expect(glmInstructions ?? "").toMatch(/cancel/i);
+		for (const value of [ZCODE_JWT, UPSTREAM, BUSINESS, MINTED_KEY, "auth-code", "state-1"]) {
+			expect(glmInstructions ?? "").not.toContain(value);
+		}
+
+		const anthropicFlow = new AnthropicOAuthFlow({});
+		const { instructions: anthropicInstructions } = await anthropicFlow.generateAuthUrl(
+			"state-1",
+			"http://localhost:54545/callback",
+		);
+		expect(anthropicInstructions ?? "").not.toMatch(/desktop app|broker error 2007|single-use authorization code/i);
 	});
 
 	it("exchanges the code and provisions a Z.AI API key as the credential", async () => {


### PR DESCRIPTION
## What

Warn `glm-zcode` users that an installed ZCode desktop app can consume the one-time authorization code when the browser offers to open the `zcode://` redirect. The instructions now tell users to cancel that prompt before pasting the final redirect URL or authorization code. Deterministic tests also cover provider isolation and secret non-interpolation.

3 files, +27 −1 relative to current `dev`.

## Why

The CLI cannot receive the custom-protocol redirect itself and asks the user to paste the final redirect URL or authorization code. When the ZCode desktop app is installed and the browser opens it, the app exchanges the single-use code first; a later paste is rejected by the broker. The warning explains that preemption and the cancellation step without displaying any credential or authorization-code value.

The change remains limited to the `glm-zcode` instruction string, focused tests, and the `@gajae-code/ai` changelog. Callback handling, broker exchange, credential persistence, refresh behavior, provider dispatch, and process exit paths are unchanged.

## Testing

- `bun test packages/ai/test/oauth-glm-zcode.test.ts packages/ai/test/anthropic-oauth.test.ts packages/ai/test/auth-storage-refresh-skew.test.ts packages/coding-agent/test/oauth-flow.test.ts packages/coding-agent/test/oauth-manual-input.test.ts packages/coding-agent/test/slash-commands/login.test.ts` — 96 pass, 0 fail.
- `bun --cwd=packages/ai run check` — passed; two pre-existing informational `String.raw` notices remain in `openai-codex-responses.ts`.
- `bun --cwd=packages/coding-agent run check:types` — passed.
- `bun --cwd=packages/natives run check && bun --cwd=packages/natives run check:types` — passed.
- `bun run check:rs` — passed.
- `bun --cwd=packages/coding-agent run build` and `packages/coding-agent/dist/gjc --smoke-test` — passed.
- `bun run check:ts` reached the repository SDK-closure manifest but one unrelated `notifications-config.test.ts` case timed out locally; the exact changed package checks and CI remain authoritative for the full matrix.

## Risk classification

- [ ] `low-risk`
- [ ] `regression-risk`
- [x] `high-risk` — this touches the OAuth login surface; exact-head independent maintainer review is required.

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:dd23dded6d7e2908ebf02e78183d45640c93f18e8821305dd1fb38443d087624 reviewer:architect reviewer-id:Yeachan-Heo evidence:exact-head focused auth/login tests and independent architect review
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes (full local check:ts had one unrelated notifications-config timeout; exact changed-package checks passed)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head `58d272819f35ddac0908a84021166cebbeaffcd3`
- [x] Risk classification above matches the OAuth/auth review path
