### PR TITLE
fix(auth): handle stale interactive OAuth pins

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Interactive OAuth account selection now handles a stale or missing pinned credential in place, preserving the session and actionable `/login` or AUTO guidance instead of creating an unhandled rejection and crash record.
 - Named-worktree SDK session.create now gives git worktree add/reuse and workspace install independent 30s budgets instead of charging them against the child 10s semantic-readiness clock. Prep timeouts stay typed and terminal (`worktree_preparation_timeout` / `dependency_preparation_timeout`); Coordinator and ACP preserve those codes instead of collapsing them to `unavailable` or `broker_compensation_unobserved`. Ordinary no-worktree sessions stay 10s/21s.
 
 ## [0.16.0] - 2026-09-02

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -7,6 +7,7 @@ import {
 	isSqliteCorruptionError,
 	isSqliteError,
 	type Model,
+	OAuthCredentialSelectorError,
 	resolveOAuthStorageProvider,
 } from "@gajae-code/ai/core";
 import { getOAuthProviders } from "@gajae-code/ai/utils/oauth";
@@ -3706,7 +3707,13 @@ export class SelectorController {
 							{
 								accountProviderId: selectedProviderId,
 								onAccountSelect: async (selectorValue: AuthCredentialSelector) => {
-									await this.ctx.session.setCredentialPin(selectedProviderId, selectorValue);
+									try {
+										await this.ctx.session.setCredentialPin(selectedProviderId, selectorValue);
+									} catch (error: unknown) {
+										if (!(error instanceof OAuthCredentialSelectorError)) throw error;
+										this.ctx.showError(error.message);
+										return;
+									}
 									selector.stopValidation();
 									done();
 									this.ctx.showStatus(`Pinned OAuth account for ${selectedProviderId} to this session.`);

--- a/packages/coding-agent/test/credential-pin-interactive.test.ts
+++ b/packages/coding-agent/test/credential-pin-interactive.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeAll, describe, expect, test } from "bun:test";
+import { AuthStorage, OAuthCredentialSelectorError, SqliteAuthCredentialStore } from "@gajae-code/ai/core";
+import type { OAuthSelectorComponent } from "../src/modes/components/oauth-selector";
+import { SelectorController } from "../src/modes/controllers/selector-controller";
+import { getThemeByName, setThemeInstance } from "../src/modes/theme/theme";
+
+const stores: SqliteAuthCredentialStore[] = [];
+
+beforeAll(async () => {
+	const theme = await getThemeByName("red-claw");
+	if (!theme) throw new Error("test setup failed: theme missing");
+	setThemeInstance(theme);
+});
+
+function createContext(
+	authStorage: AuthStorage,
+	setCredentialPin: (provider: string, selector: { kind: "id"; value: string }) => Promise<void>,
+	showError: (message: string) => void,
+	showStatus: (message: string) => void,
+) {
+	return {
+		isStopped: () => false,
+		session: {
+			credentialSessionId: "session-1",
+			modelRegistry: {
+				authStorage,
+				getModelProfiles: () => new Map(),
+			},
+			setCredentialPin,
+		},
+		showError,
+		showStatus,
+	};
+}
+
+async function createAuthStorage(): Promise<AuthStorage> {
+	const store = await SqliteAuthCredentialStore.open(":memory:");
+	stores.push(store);
+	const authStorage = new AuthStorage(store);
+	await authStorage.set("anthropic", [
+		{
+			type: "oauth",
+			access: "access-token",
+			refresh: "refresh-token",
+			expires: Date.now() + 60_000,
+			email: "account@example.test",
+		},
+	]);
+	return authStorage;
+}
+
+afterEach(() => {
+	for (const store of stores.splice(0)) store.close();
+});
+
+describe("interactive OAuth credential pinning", () => {
+	test("handles a missing pin target without closing the selector or rejecting", async () => {
+		const authStorage = await createAuthStorage();
+		const message = "No stored OAuth credential matches id:999. Run /login or choose AUTO.";
+		const errors: string[] = [];
+		const unhandled: unknown[] = [];
+		const onUnhandled = (error: unknown) => unhandled.push(error);
+		process.on("unhandledRejection", onUnhandled);
+		let component: OAuthSelectorComponent | undefined;
+		let done = false;
+		const context = createContext(
+			authStorage,
+			async () => {
+				throw new OAuthCredentialSelectorError("not-found", "anthropic", { kind: "id", value: "999" }, message);
+			},
+			text => errors.push(text),
+			() => {},
+		);
+		const controller = new SelectorController(context as never);
+		controller.showSelector = ((create: (done: () => void) => { component: unknown; focus: unknown }) => {
+			component = create(() => {
+				done = true;
+			}).component as OAuthSelectorComponent;
+		}) as never;
+
+		await controller.showOAuthSelector("login", "anthropic");
+		const submit = (component?.children[4] as { onSubmit?: () => void } | undefined)?.onSubmit;
+		if (!submit) throw new Error("test setup failed: selector input missing");
+		submit();
+		await Bun.sleep(0);
+		process.off("unhandledRejection", onUnhandled);
+
+		expect(errors).toEqual([message]);
+		expect(unhandled).toEqual([]);
+		expect(done).toBe(false);
+		expect(component).toBeDefined();
+	});
+
+	test("closes the selector and reports success for a valid pin", async () => {
+		const authStorage = await createAuthStorage();
+		const errors: string[] = [];
+		const statuses: string[] = [];
+		let component: OAuthSelectorComponent | undefined;
+		let done = false;
+		const context = createContext(
+			authStorage,
+			async () => {},
+			text => errors.push(text),
+			text => statuses.push(text),
+		);
+		const controller = new SelectorController(context as never);
+		controller.showSelector = ((create: (done: () => void) => { component: unknown; focus: unknown }) => {
+			component = create(() => {
+				done = true;
+			}).component as OAuthSelectorComponent;
+		}) as never;
+
+		await controller.showOAuthSelector("login", "anthropic");
+		const submit = (component?.children[4] as { onSubmit?: () => void } | undefined)?.onSubmit;
+		if (!submit) throw new Error("test setup failed: selector input missing");
+		submit();
+		await Bun.sleep(0);
+
+		expect(errors).toEqual([]);
+		expect(done).toBe(true);
+		expect(statuses).toEqual(["Pinned OAuth account for anthropic to this session."]);
+	});
+});


### PR DESCRIPTION
Closes #5183

## What

Catch only `OAuthCredentialSelectorError` at the interactive OAuth account-selection boundary. The existing actionable message remains visible, the selector and session stay alive, and unexpected faults are still rethrown.

## Why

A selected credential can disappear after the selector renders. The resulting typed rejection escaped the fire-and-forget input callback and was recorded as a fatal crash.

## Testing

- `bun test packages/coding-agent/test/credential-pin-interactive.test.ts packages/coding-agent/test/slash-commands/credential.test.ts packages/coding-agent/test/main-interactive-input.test.ts` (24 passed)
- `bun test packages/coding-agent/test/main-interactive-input.test.ts packages/coding-agent/test/oauth-selector-validation-race.redteam.test.ts` (18 passed)
- `bun --cwd=packages/coding-agent run check`
- `bun --cwd=packages/coding-agent run build`

## Risk classification

- [x] `low-risk` — one typed, user-correctable error is handled at its interactive boundary; no auth selection or headless behavior changes.
- [ ] `regression-risk`
- [ ] `high-risk`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:6e427c5e00d9750c6308ad12c33380156cd975d380cf31e7ea24a7edd58c2ecc reviewer:human reviewer-id:Yeachan-Heo evidence:adversarial exact-head review: stale pin is handled in place; valid pin closes; unexpected errors remain rethrown; 24 focused tests, package check, and binary build passed
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated
- [x] Verdict matches exact PR head 50fdab2dcebdf79ef450e5787b5429937b76c80f
- [x] Risk classification matches the owner low-risk review path