### PR TITLE
fix(sdk): harden session-index v4 guard boundary

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 - Interactive OAuth account selection now handles a stale or missing pinned credential in place, preserving the session and actionable `/login` or AUTO guidance instead of creating an unhandled rejection and crash record.
 - Named-worktree SDK session.create now gives git worktree add/reuse and workspace install independent 30s budgets instead of charging them against the child 10s semantic-readiness clock. Prep timeouts stay typed and terminal (`worktree_preparation_timeout` / `dependency_preparation_timeout`); Coordinator and ACP preserve those codes instead of collapsing them to `unavailable` or `broker_compensation_unobserved`. Ordinary no-worktree sessions stay 10s/21s.
+- SDK session-index scan/replay now explicitly documents and regression-tests the
+	v4 compatibility boundary: supported v4 session-index events and snapshots are
+	accepted at every entry surface (scan, replay, tail, append, repair), future
+	versions stay fail-closed with data-preserving quarantine, and the generic
+	SDK-state guard (`maximum supported version is 1`) is documented as never
+	applying to session-index rows so the #5181 crash class cannot recur.
 
 ## [0.16.0] - 2026-09-02
 

--- a/packages/coding-agent/src/sdk/broker/state-version.ts
+++ b/packages/coding-agent/src/sdk/broker/state-version.ts
@@ -8,6 +8,16 @@ export const SDK_STATE_VERSION = 1;
 export const SESSION_INDEX_SNAPSHOT_VERSION = 4;
 export const SESSION_INDEX_EVENT_VERSION = SESSION_INDEX_SNAPSHOT_VERSION;
 
+/**
+ * Thrown when a persisted SDK state file carries a version this build does not
+ * support. `assertSupportedStateVersion` fences only generic SDK state (broker
+ * discovery, lifecycle-ledger rows, guide cache meta) whose current format is
+ * exactly `SDK_STATE_VERSION`. Session-index files carry their own versions
+ * (see `assertSupportedSessionIndexEventVersion` and
+ * `assertSupportedSnapshotVersion`) and MUST NOT be validated with the generic
+ * guard — a supported v4 index row would crash with "maximum supported version
+ * is 1" (#5181).
+ */
 export class UnsupportedStateVersionError extends Error {
 	readonly code = "unsupported_state_version";
 
@@ -23,6 +33,13 @@ export class UnsupportedStateVersionError extends Error {
 	}
 }
 
+/**
+ * Generic SDK-state fence: rejects any version above `SDK_STATE_VERSION`.
+ * ONLY for generic state whose current format is exactly `SDK_STATE_VERSION`
+ * (broker discovery `broker.json`, lifecycle-ledger rows, guide cache meta).
+ * Never validate session-index rows or snapshots with this guard — they have
+ * dedicated version fences and currently accept v4 (#5181).
+ */
 export function assertSupportedStateVersion(file: string, value: unknown): void {
 	if (!value || typeof value !== "object") return;
 	const record = value as { version?: unknown; stateVersion?: unknown };

--- a/packages/coding-agent/test/sdk-session-index.test.ts
+++ b/packages/coding-agent/test/sdk-session-index.test.ts
@@ -11,9 +11,12 @@ import {
 	sessionWorktreeRoot,
 } from "../src/sdk/broker/session-index";
 import {
+	assertSupportedSessionIndexEventVersion,
+	assertSupportedSnapshotVersion,
 	assertSupportedStateVersion,
 	SDK_STATE_VERSION,
 	SESSION_INDEX_EVENT_VERSION,
+	SESSION_INDEX_SNAPSHOT_VERSION,
 	UnsupportedStateVersionError,
 } from "../src/sdk/broker/state-version";
 
@@ -1936,6 +1939,146 @@ describe("SDK session index", () => {
 		expect(index.listSessions().sessions).toEqual([]);
 		expect(index.listSessions().warnings).toContain(
 			"Session mixed-session has a legacy locator row and must re-register.",
+		);
+	});
+	it("accepts v4 events and snapshots across scan, replay, tail, append, and repair (#5181)", async () => {
+		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-index-v4-accept-"));
+		const sessionsDir = path.join(dir, "sdk", "sessions");
+		const logPath = path.join(sessionsDir, "index.jsonl");
+		const snapshotPath = path.join(sessionsDir, "index.snapshot.json");
+		await fs.mkdir(sessionsDir, { recursive: true });
+		const v4Event = (sessionId: string, indexSeq: number) => {
+			const unsigned = {
+				...event(sessionId),
+				version: SESSION_INDEX_EVENT_VERSION,
+				indexSeq,
+				ts: 1,
+			};
+			return { ...unsigned, checksum: sessionIndexChecksum(unsigned as Parameters<typeof sessionIndexChecksum>[0]) };
+		};
+
+		// Scan + replay of a v4-only log must stay healthy and project the session.
+		await fs.writeFile(logPath, `${JSON.stringify(v4Event("v4-a", 1))}\n`);
+		const scanned = new SessionIndex(dir);
+		expect(await scanned.diagnose()).toMatchObject({ status: "healthy", validPrefixSeq: 1 });
+		const replayed = await new SessionIndex(dir).open();
+		expect(replayed.listSessions().sessions.map(s => s.sessionId)).toEqual(["v4-a"]);
+		expect(replayed.listSessions().warnings).toEqual([]);
+
+		// Keep a second reader open so its refresh exercises the append-only tail path.
+		const tailer = await new SessionIndex(dir).open();
+		// Appending through the replayed reader writes v4 and accepts it.
+		const appended = await replayed.append(event("v4-b"));
+		expect(appended.version).toBe(SESSION_INDEX_EVENT_VERSION);
+		expect((await fs.readFile(logPath, "utf8")).trim().split("\n")).toHaveLength(2);
+
+		// The existing reader tails the grown v4 log without a replay-class crash.
+		expect(await tailer.refreshIfChanged()).toBe(true);
+		expect(tailer.listSessions().sessions.map(s => s.sessionId)).toEqual(["v4-a", "v4-b"]);
+
+		// Snapshot path: a v4 snapshot replays healthy, and repair is a no-op.
+		await tailer.snapshot();
+		const snapshot = JSON.parse(await fs.readFile(snapshotPath, "utf8"));
+		expect(snapshot.version).toBe(SESSION_INDEX_EVENT_VERSION);
+		await fs.rm(logPath);
+		const fromSnapshot = new SessionIndex(dir);
+		expect(await fromSnapshot.diagnose()).toMatchObject({ status: "healthy", validPrefixSeq: 2 });
+		expect(await fromSnapshot.repair()).toMatchObject({ status: "healthy", repaired: false });
+		expect(JSON.parse(await fs.readFile(snapshotPath, "utf8"))).toEqual(snapshot);
+
+		// Mixed v1-prefix + v4-suffix log replays both formats; checksums stay valid.
+		const legacyV1 = {
+			...event("v1-c"),
+			version: SDK_STATE_VERSION,
+			indexSeq: 3,
+			ts: 1,
+		};
+		await fs.writeFile(
+			logPath,
+			[
+				JSON.stringify({
+					...legacyV1,
+					checksum: sessionIndexChecksum(legacyV1 as Parameters<typeof sessionIndexChecksum>[0]),
+				}),
+				JSON.stringify(v4Event("v4-d", 4)),
+				JSON.stringify(v4Event("v4-e", 5)),
+				"",
+			].join("\n"),
+		);
+		const mixed = await new SessionIndex(dir).open();
+		expect(await mixed.diagnose()).toMatchObject({ status: "healthy", validPrefixSeq: 5 });
+		expect(mixed.listSessions().sessions.map(s => s.sessionId)).toEqual(
+			expect.arrayContaining(["v1-c", "v4-d", "v4-e"]),
+		);
+		expect(mixed.listSessions().warnings).toEqual([]);
+	});
+	it("keeps future index versions fail-closed with data-preserving quarantine (#5181)", async () => {
+		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-index-v4-future-"));
+		const sessionsDir = path.join(dir, "sdk", "sessions");
+		const logPath = path.join(sessionsDir, "index.jsonl");
+		const snapshotPath = path.join(sessionsDir, "index.snapshot.json");
+		await fs.mkdir(sessionsDir, { recursive: true });
+		const signed = (version: number, sessionId: string, indexSeq: number) => {
+			const unsigned = { ...event(sessionId), version, indexSeq, ts: 1 };
+			return { ...unsigned, checksum: sessionIndexChecksum(unsigned as Parameters<typeof sessionIndexChecksum>[0]) };
+		};
+
+		// A future v5 log row fails closed BEFORE mutation and preserves every byte.
+		const futureLog = `${JSON.stringify(signed(SESSION_INDEX_EVENT_VERSION, "ok", 1))}\n${JSON.stringify(
+			signed(SESSION_INDEX_EVENT_VERSION + 1, "future", 2),
+		)}\n`;
+		await fs.writeFile(logPath, futureLog);
+		const future = new SessionIndex(dir);
+		expect(await future.diagnose()).toMatchObject({
+			status: "unsupported",
+			validPrefixSeq: 1,
+			reason: expect.stringContaining("maximum supported version is 4"),
+		});
+		expect(await future.repair()).toMatchObject({ status: "unsupported", repaired: false });
+		await expect(new SessionIndex(dir).open()).rejects.toThrow(/maximum supported version is 4/);
+		expect(await fs.readFile(logPath, "utf8")).toBe(futureLog);
+		expect(await fs.exists(snapshotPath)).toBe(false);
+
+		// Repair never manufactures a snapshot from an unsupported log.
+		expect(await fs.readdir(sessionsDir)).not.toContain("quarantine");
+
+		// A malformed row mid-log stays quarantined with full byte contents on repair.
+		await fs.writeFile(
+			logPath,
+			`${JSON.stringify(signed(SESSION_INDEX_EVENT_VERSION, "prefix", 1))}\nbroken-not-json\n`,
+		);
+		const corrupt = await new SessionIndex(dir).open();
+		const repair = await corrupt.repair();
+		expect(repair).toMatchObject({ status: "corrupt", repaired: true });
+		expect(repair.quarantinePath).toEqual(expect.any(String));
+		const quarantinedLog = await fs.readFile(path.join(repair.quarantinePath!, "index.jsonl"), "utf8");
+		expect(quarantinedLog).toContain("broken-not-json");
+		expect(quarantinedLog).toContain('"sessionId":"prefix"');
+		// The valid prefix is republished; the corrupt suffix is dropped from it.
+		const repairedSnapshot = JSON.parse(await fs.readFile(snapshotPath, "utf8"));
+		expect(repairedSnapshot.version).toBe(SESSION_INDEX_EVENT_VERSION);
+		expect(repairedSnapshot.indexSeq).toBe(1);
+	});
+	it("fences the generic state-version guard away from session-index rows (#5181)", async () => {
+		// The exact reported crash class: assertSupportedStateVersion rejects v4
+		// with "maximum supported version is 1", while the dedicated index event
+		// guard accepts v4. The guards must stay distinguishable so no scan path
+		// can apply the generic fence to index rows again.
+		const v4 = { version: SESSION_INDEX_EVENT_VERSION };
+		expect(() => assertSupportedStateVersion("index.jsonl", v4)).toThrow(
+			new UnsupportedStateVersionError("index.jsonl", SESSION_INDEX_EVENT_VERSION),
+		);
+		expect(() => assertSupportedSessionIndexEventVersion("index.jsonl", v4)).not.toThrow();
+		expect(() => assertSupportedSessionIndexEventVersion("index.jsonl", { version: 1 })).not.toThrow();
+		expect(() => assertSupportedSessionIndexEventVersion("index.jsonl", { version: 5 })).toThrow(
+			new UnsupportedStateVersionError("index.jsonl", 5, SESSION_INDEX_EVENT_VERSION),
+		);
+		expect(() =>
+			assertSupportedSnapshotVersion("index.snapshot.json", { version: SESSION_INDEX_SNAPSHOT_VERSION }),
+		).not.toThrow();
+		expect(() => assertSupportedSnapshotVersion("index.snapshot.json", { version: 1 })).not.toThrow();
+		expect(() => assertSupportedSnapshotVersion("index.snapshot.json", { version: 5 })).toThrow(
+			new UnsupportedStateVersionError("index.snapshot.json", 5, SESSION_INDEX_SNAPSHOT_VERSION),
 		);
 	});
 	it("canonicalizes cwd and reports null worktree root outside Git", async () => {


### PR DESCRIPTION
## What

Harden the session-index v4 guard boundary and add regression coverage for issue #5181.

<!-- exact-head contract recheck -->

## Why

Fixes #5181.

The source tree already contains the production guard split from `b80b9c0db6`: session-index snapshots use the v4 snapshot fence and session-index events use the v1/v4 event fence, while the generic SDK-state fence remains max 1 for broker discovery, lifecycle-ledger, and guide-cache state. A stale globally installed package still reproduces the reported crash because its session-index scan calls the generic guard.

This change makes the compatibility boundary explicit and adds regression coverage over the real scan/replay surfaces so a future merge cannot reintroduce the max-1 guard on v4 index rows.

## Testing

- `bun test packages/coding-agent/test/sdk-session-index.test.ts packages/coding-agent/test/sdk-downgrade-unknown-version.test.ts packages/coding-agent/test/gc-runtime.test.ts packages/coding-agent/test/gc-e2e.test.ts`
- `bun test packages/coding-agent/test/sdk-downgrade-rollback.test.ts`
- `bun --cwd=packages/coding-agent run build`
- `bun --cwd=packages/coding-agent run check`
- `bun run lint`
- `bun run check` (full Rust + TypeScript + SDK closure)
- `bun scripts/check-visible-definitions.ts`
- `bun scripts/verify-g002-gates.ts`
- `bun scripts/rebrand-inventory.ts --strict`
- `bun test packages/coding-agent/test/default-gjc-definitions.test.ts`

All fixture data used temporary directories only. No user session index, token, credential, or transcript contents were read or modified. The original index is never deleted or hand-edited; malformed data is preserved in the existing quarantine repair path.

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk`
- [ ] `high-risk`

## GJC verdict

gajae.pr-review-verdict.v1 merge-self-approved sha256:dd15fc95b947eabec0ec62665042b3483b15aab39cba2ea7f7cb688239228128 reviewer:human reviewer-id:Yeachan-Heo evidence:https://github.com/Yeachan-Heo/gajae-code/actions/runs/33592293222

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*