### PR TITLE
fix(browser): avoid silent Chrome cookie decrypt failure on macOS (#5190)

### DIFF
--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -3072,7 +3072,7 @@ export const SETTINGS_SCHEMA = {
 			tab: "tools",
 			label: "Profile reuse posture",
 			description:
-				"'auto' (default): when a usable real Chrome profile is available, the browser tool uses an isolated copy of it (cookies/session/cache) for stronger stealth, warns, and falls back to synthetic. 'opt-in': stay synthetic unless a real profile is explicitly requested.",
+				"'auto' (default): when a usable real Chrome profile is available, the browser tool uses an isolated copy of it (cookies/session/cache) for stronger stealth, warns, and falls back to synthetic. 'opt-in': stay synthetic unless a real profile is explicitly requested. On macOS, cookie decryption is brand-specific (Chrome Safe Storage vs Chromium Safe Storage Keychain); a Chrome profile copied into bundled Chromium decrypts to garbage, so auto reuses the profile only when the headless executable can decrypt it — detected system Chrome/Chromium or PUPPETEER_EXECUTABLE_PATH — otherwise it falls back to synthetic with a warning.",
 		},
 	},
 

--- a/packages/coding-agent/src/tools/browser/launch.ts
+++ b/packages/coding-agent/src/tools/browser/launch.ts
@@ -293,6 +293,43 @@ function resolveSystemChromium(): string | undefined {
 	return found;
 }
 
+export function resolveSystemChromiumForTest(): string | undefined {
+	return resolveSystemChromium();
+}
+
+export function resetSystemChromiumForTest(): void {
+	resolvedChromium = undefined;
+}
+
+export function headlessExecutableForProfileReuse(): string | undefined {
+	return resolveSystemChromium() ?? trustedBrowserEnv("PUPPETEER_EXECUTABLE_PATH");
+}
+
+/**
+ * On macOS the Cookies DB is encrypted with a Keychain key whose service name is
+ * brand-specific ("Chrome Safe Storage" vs "Chromium Safe Storage"). A Chrome profile
+ * copied into a bundled Chromium therefore decrypts to garbage with no warning.
+ * Return true only when the headless executable can actually decrypt the discovered profile.
+ */
+export function canDecryptProfileCookies(
+	executablePath: string | undefined,
+	discoveredUserDataDir: string | undefined,
+	platform: NodeJS.Platform = process.platform,
+): boolean {
+	if (platform !== "darwin") return true;
+	if (!discoveredUserDataDir) return true;
+	if (!executablePath) return false;
+	const lowerExe = executablePath.toLowerCase();
+	const lowerDir = discoveredUserDataDir.toLowerCase();
+	const isChromiumExe = lowerExe.includes("chromium");
+	const isChromeExe = lowerExe.includes("google chrome") || lowerExe.includes("/google/chrome");
+	const isChromiumProfile = lowerDir.includes("chromium");
+	const isChromeProfile = lowerDir.includes("google") && lowerDir.includes("chrome");
+	if (isChromeProfile && isChromiumExe && !isChromeExe) return false;
+	if (isChromiumProfile && isChromeExe) return false;
+	return true;
+}
+
 /** Edge is Chromium-based but keeps its own profile format under its own user data root. */
 const EDGE_EXECUTABLE_PATTERN =
 	/(?:^|[/\\])(?:msedge(?:\.exe)?|microsoft-edge(?:-(?:stable|beta|dev|canary))?|com\.microsoft\.Edge|Microsoft Edge(?: Beta| Dev| Canary)?)$/i;

--- a/packages/coding-agent/src/tools/browser/registry.ts
+++ b/packages/coding-agent/src/tools/browser/registry.ts
@@ -12,7 +12,14 @@ import {
 	killExistingByPath,
 	waitForCdp,
 } from "./attach";
-import { BROWSER_PROTOCOL_TIMEOUT_MS, launchHeadlessBrowser, loadPuppeteer, type UserAgentOverride } from "./launch";
+import {
+	BROWSER_PROTOCOL_TIMEOUT_MS,
+	canDecryptProfileCookies,
+	headlessExecutableForProfileReuse,
+	launchHeadlessBrowser,
+	loadPuppeteer,
+	type UserAgentOverride,
+} from "./launch";
 import { defaultDiscoveryEnv } from "./profile-discovery";
 import type { ProfileReusePosture } from "./profile-posture";
 import { resolveProfileReuse } from "./profile-reuse";
@@ -148,7 +155,20 @@ async function openBrowserHandle(
 				discoveryEnv: defaultDiscoveryEnv(fs.existsSync),
 			});
 			if (reuse.warning) logger.warn(reuse.warning);
-			if (reuse.mode === "real" && reuse.warmupDir) {
+			if (reuse.mode === "real" && reuse.warmupDir && reuse.discovered) {
+				const executablePath = headlessExecutableForProfileReuse();
+				if (!canDecryptProfileCookies(executablePath, reuse.discovered.userDataDir)) {
+					try {
+						fs.rmSync(reuse.warmupDir, { recursive: true, force: true });
+					} catch {}
+					const hint = executablePath
+						? `Real Chrome profile at ${reuse.discovered.userDataDir} cannot be decrypted by ${executablePath} on macOS (Chrome Safe Storage vs Chromium Safe Storage Keychain mismatch). Using synthetic browser state instead. Set PUPPETEER_EXECUTABLE_PATH to the matching Chrome/Chromium binary.`
+						: `Real Chrome profile at ${reuse.discovered.userDataDir} found but no compatible browser executable is available on macOS (bundled Chromium cannot decrypt Chrome's cookies — Chrome Safe Storage vs Chromium Safe Storage). Using synthetic browser state instead. Set PUPPETEER_EXECUTABLE_PATH to /Applications/Google Chrome.app/Contents/MacOS/Google Chrome or install Chrome.`;
+					logger.warn(hint);
+				} else {
+					profileWarmupDir = reuse.warmupDir;
+				}
+			} else if (reuse.mode === "real" && reuse.warmupDir) {
 				profileWarmupDir = reuse.warmupDir;
 			}
 		}

--- a/packages/coding-agent/test/tools/browser-profile-reuse.test.ts
+++ b/packages/coding-agent/test/tools/browser-profile-reuse.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { canDecryptProfileCookies } from "../../src/tools/browser/launch";
 import { chromeUserDataRoots, discoverDefaultChromeProfile } from "../../src/tools/browser/profile-discovery";
 import { resolveProfileReuse } from "../../src/tools/browser/profile-reuse";
 import type { WarmupManifest } from "../../src/tools/browser/profile-warmup";
@@ -178,5 +179,52 @@ describe("resolveProfileReuse", () => {
 			},
 		});
 		expect(res.mode).toBe("synthetic");
+	});
+});
+
+describe("canDecryptProfileCookies", () => {
+	it("darwin: Chrome profile vs bundled Chromium (no executable) is incompatible", () => {
+		expect(canDecryptProfileCookies(undefined, "/Users/x/Library/Application Support/Google/Chrome", "darwin")).toBe(
+			false,
+		);
+	});
+
+	it("darwin: Chrome profile vs Chromium executable is incompatible", () => {
+		expect(
+			canDecryptProfileCookies(
+				"/Applications/Chromium.app/Contents/MacOS/Chromium",
+				"/Users/x/Library/Application Support/Google/Chrome",
+				"darwin",
+			),
+		).toBe(false);
+	});
+
+	it("darwin: Chrome profile vs Chrome executable is compatible", () => {
+		expect(
+			canDecryptProfileCookies(
+				"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+				"/Users/x/Library/Application Support/Google/Chrome",
+				"darwin",
+			),
+		).toBe(true);
+	});
+
+	it("darwin: Chromium profile vs Chrome executable is incompatible", () => {
+		expect(
+			canDecryptProfileCookies(
+				"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+				"/Users/x/Library/Application Support/Chromium",
+				"darwin",
+			),
+		).toBe(false);
+	});
+
+	it("darwin: no discovered profile is compatible (no copy needed)", () => {
+		expect(canDecryptProfileCookies(undefined, undefined, "darwin")).toBe(true);
+	});
+
+	it("linux: any combination is compatible (Keychain brand not applicable)", () => {
+		expect(canDecryptProfileCookies(undefined, "/home/x/.config/google-chrome", "linux")).toBe(true);
+		expect(canDecryptProfileCookies("/usr/bin/chromium", "/home/x/.config/google-chrome", "linux")).toBe(true);
 	});
 });

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -2586,7 +2586,7 @@
 				},
 				"profileReuse": {
 					"type": "string",
-					"description": "'auto' (default): when a usable real Chrome profile is available, the browser tool uses an isolated copy of it (cookies/session/cache) for stronger stealth, warns, and falls back to synthetic. 'opt-in': stay synthetic unless a real profile is explicitly requested.",
+					"description": "'auto' (default): when a usable real Chrome profile is available, the browser tool uses an isolated copy of it (cookies/session/cache) for stronger stealth, warns, and falls back to synthetic. 'opt-in': stay synthetic unless a real profile is explicitly requested. On macOS, cookie decryption is brand-specific (Chrome Safe Storage vs Chromium Safe Storage Keychain); a Chrome profile copied into bundled Chromium decrypts to garbage, so auto reuses the profile only when the headless executable can decrypt it — detected system Chrome/Chromium or PUPPETEER_EXECUTABLE_PATH — otherwise it falls back to synthetic with a warning.",
 					"default": "auto"
 				},
 				"geo": {


### PR DESCRIPTION
Fixes #5190.

## Summary

On macOS `browser.profileReuse: auto` copies the real Chrome profile (Cookies, …) into an isolated warm-up dir but default headless launch uses bundled Chromium. Chrome encrypts cookies with a Keychain-derived key whose service name is brand-specific (`Chrome Safe Storage` vs `Chromium Safe Storage`). The copied `Cookies` DB therefore decrypts to garbage — every site appears logged-out with no warning. For token-rotating sites it actively invalidates the real session.

## Cause

`registry.ts:openBrowserHandle` resolved posture to `real` and copied artifacts unconditionally; `launch.ts:ensureChromiumExecutable` chose the executable independently (system Chrome → `PUPPETEER_EXECUTABLE_PATH` → bundled Chromium). No brand-compatibility check linked the two.

## Fix

* `launch.ts`: add `canDecryptProfileCookies(exe, userDataDir, platform)` (darwin-only brand guard) and `headlessExecutableForProfileReuse()` / `resolveSystemChromiumForTest()` seams.
* `registry.ts`: after `resolveProfileReuse` returns `real` + `warmupDir`, check decrypt compatibility. On mismatch (bundled Chromium with Chrome profile, or Chrome exe with Chromium profile): remove the isolated copy, fall back to synthetic, `logger.warn` with remediation (`PUPPETEER_EXECUTABLE_PATH`).
* `settings-schema.ts` + `config.schema.json`: document the Keychain constraint in `browser.profileReuse`.

Behavior is reversible and audit-ready: real profile reuse still works when the executable matches (system Chrome present or `PUPPETEER_EXECUTABLE_PATH` pointed at it); only the silent garbage-decrypt path is removed.

## Tests

* `browser-profile-reuse.test.ts`: 6 new `canDecryptProfileCookies` cases covering darwin Chrome↔Chromium mismatch, bundled fallback, no-profile, and linux no-op.

## Verification

* `bun test` — 57 browser-profile tests pass (benchmark suite pre-existing failure on both base and head, unrelated).
* `bun --cwd=packages/coding-agent run check` — 0 errors.
* `bun --cwd=packages/coding-agent run build` — success.
* `bun run generate-schemas` — schema in sync.

## Risk

Wide: browser launch path. Mitigated: change is darwin-gated, no-op on linux/win32, and degrades to existing synthetic warning path.

Closes #5190.