### PR TITLE
fix(agent): batch wait-mode steering across abort unwind

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed `interruptMode: "wait"` steering rearm so `steeringMode: "all"` delivers every steer admitted during an abort unwind in one ordered successor turn instead of splitting the queue across continuations.
 - Coordinator projection scans now use identity-bracketed directory authority on macOS instead of failing every scan as unsupported, while root and candidate replacement races remain fail-closed.
 - The `/model` selector no longer stalls the UI thread on open, model selection, provider-tab switch, and every catalog change for credentialed users. Each `refresh("offline")` re-ran the built-in-discovery freshness filter across the whole cached catalog (thousands of models) while recomputing per model values that only vary per provider — `#getProviderEvidenceGeneration` (an AuthStorage lookup) and `#getProviderBaseUrlForDiscovery` + endpoint normalization (URL parsing). That provider-keyed work is now memoized once per provider per refresh, so on the bundled catalog with credentials `refresh("offline")` drops from ~40ms to ~15ms per interaction with identical freshness results. Complements the earlier batch canonical-selection fix.
 - Interactive OAuth account selection now handles a stale or missing pinned credential in place, preserving the session and actionable `/login` or AUTO guidance instead of creating an unhandled rejection and crash record.

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -12466,7 +12466,10 @@ export class AgentSession {
 		// user-interrupt abort, so it stalls until the user presses Esc. Schedule a
 		// continue so the steer is delivered promptly. A live loop (or an
 		// already-drained queue) makes the scheduled continue a no-op.
-		if (!this.#cancelAndSubmitInProgress && this.#canAutoContinueForSteer()) {
+		// During an abort unwind, the abort's single rearm owns this boundary. Letting
+		// each steer schedule its own continuation can start the first queued message
+		// before the rest of the unwind cohort is admitted, splitting an `all` batch.
+		if (!this.#cancelAndSubmitInProgress && this.#abortUnwind === undefined && this.#canAutoContinueForSteer()) {
 			this.#scheduleAgentContinue({
 				shouldContinue: () => this.#canAutoContinueForSteer() && this.agent.hasQueuedSteering(),
 				rescheduleOnBusy: true,

--- a/packages/coding-agent/test/agent-session-steer-interrupt.test.ts
+++ b/packages/coding-agent/test/agent-session-steer-interrupt.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";
 import { Agent } from "@gajae-code/agent-core";
 import { getBundledModel } from "@gajae-code/ai";
@@ -12,6 +12,15 @@ import { TempDir } from "@gajae-code/utils";
 
 function userMessage(text: string) {
 	return { role: "user" as const, content: text, timestamp: Date.now() };
+}
+
+async function waitUntil(predicate: () => boolean, timeoutMs = 1_000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (predicate()) return;
+		await Bun.sleep(1);
+	}
+	throw new Error("Timed out waiting for condition");
 }
 
 /**
@@ -110,6 +119,111 @@ describe("AgentSession steer-on-interrupt", () => {
 				m => m.role === "user" && JSON.stringify(m.content).includes("also handle the steer"),
 			),
 		).toBe(true);
+	});
+
+	it("drains all wait-mode steering messages into one successor turn", async () => {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected bundled Anthropic test model to exist");
+		const mock = createMockModel({
+			responses: [{ content: ["first done"], delayMs: 60_000 }, { content: ["handled both steers"] }],
+		});
+		const agent = new Agent({
+			getApiKey: provider => `${provider}-test-key`,
+			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+			interruptMode: "wait",
+			steeringMode: "all",
+			streamFn: mock.stream,
+		});
+		const settings = Settings.isolated({ "compaction.enabled": false });
+		settings.setModelRole("default", `${model.provider}/${model.id}`);
+		session = new AgentSession({ agent, sessionManager: SessionManager.inMemory(), settings, modelRegistry });
+
+		const first = session.prompt("first task");
+		await waitUntil(() => agent.state.isStreaming && mock.calls.length === 1);
+		await session.prompt("steer one", { streamingBehavior: "steer" });
+		await session.prompt("steer two", { streamingBehavior: "steer" });
+		expect(session.getQueuedMessages().steering).toEqual(["steer one", "steer two"]);
+
+		// The wait-mode turn must be interrupted after both steers are admitted.
+		// The provider is still blocked when the real Esc/user-interrupt path claims
+		// the abort, so the successor is exercised through settlement rearm rather
+		// than the ordinary in-loop boundary.
+		const aborting = session.abort({ cause: "user_interrupt" });
+		await aborting;
+		await first.catch(() => {});
+		await session.waitForIdle();
+
+		expect(mock.calls).toHaveLength(2);
+		expect(session.getQueuedMessages()).toEqual({ steering: [], followUp: [] });
+		const successorUserMessages = mock.calls[1]!.context.messages.filter(message => message.role === "user").map(
+			message => JSON.stringify(message.content),
+		);
+		expect(successorUserMessages.slice(-2)).toEqual([
+			JSON.stringify([{ type: "text", text: "steer one" }]),
+			JSON.stringify([{ type: "text", text: "steer two" }]),
+		]);
+	});
+
+	it("lets the abort rearm own steering admitted during unwind", async () => {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected bundled Anthropic test model to exist");
+		const abortHookStarted = Promise.withResolvers<void>();
+		const releaseAbortHook = Promise.withResolvers<void>();
+		const successorGate = Promise.withResolvers<void>();
+		const mock = createMockModel({
+			responses: [
+				{ content: ["first done"], delayMs: 60_000 },
+				async () => {
+					await successorGate.promise;
+					return { content: ["handled both steers"] };
+				},
+				{ content: ["unexpected extra turn"] },
+			],
+		});
+		const agent = new Agent({
+			getApiKey: provider => `${provider}-test-key`,
+			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+			interruptMode: "wait",
+			steeringMode: "all",
+			streamFn: mock.stream,
+		});
+		const settings = Settings.isolated({ "compaction.enabled": false });
+		settings.setModelRole("default", `${model.provider}/${model.id}`);
+		session = new AgentSession({ agent, sessionManager: SessionManager.inMemory(), settings, modelRegistry });
+		vi.spyOn(session.goalRuntime, "onTaskAborted").mockImplementation(async () => {
+			abortHookStarted.resolve();
+			await releaseAbortHook.promise;
+		});
+
+		const first = session.prompt("first task");
+		await waitUntil(() => agent.state.isStreaming && mock.calls.length === 1);
+		const aborting = session.abort({ cause: "user_interrupt" });
+		await abortHookStarted.promise;
+
+		// While abort cleanup owns the boundary, each steer must remain queued for
+		// the one rearm continuation. Without that fence, the first steer starts an
+		// independent continuation before the second steer is admitted.
+		await session.steer("steer one");
+		for (let i = 0; i < 8; i++) await Promise.resolve();
+		expect(mock.calls).toHaveLength(1);
+		await session.steer("steer two");
+		expect(session.getQueuedMessages().steering).toEqual(["steer one", "steer two"]);
+
+		successorGate.resolve();
+		releaseAbortHook.resolve();
+		await aborting;
+		await first.catch(() => {});
+		await session.waitForIdle();
+
+		expect(mock.calls).toHaveLength(2);
+		expect(session.getQueuedMessages()).toEqual({ steering: [], followUp: [] });
+		const successorUserMessages = mock.calls[1]!.context.messages.filter(message => message.role === "user").map(
+			message => JSON.stringify(message.content),
+		);
+		expect(successorUserMessages.slice(-2)).toEqual([
+			JSON.stringify([{ type: "text", text: "steer one" }]),
+			JSON.stringify([{ type: "text", text: "steer two" }]),
+		]);
 	});
 
 	// Execution-drain path: the steer is queued while two shared tools run. Tool A


### PR DESCRIPTION
## What

Fix the wait-mode steering rearm race so all ordered steering messages admitted while a user interrupt is unwinding are delivered by one successor turn.

## Why

When an idle continuation was scheduled for each steer during abort cleanup, the first continuation could claim the queue before later steers were admitted. That split `steeringMode: "all"` across successor calls. Fixes #5199.

## Testing

- `bun test packages/coding-agent/test/agent-session-steer-interrupt.test.ts` — 8 passed, 0 failed
- `bun test packages/coding-agent/test/agent-session-concurrent.test.ts` — 33 passed, 0 failed
- `bun test packages/coding-agent/test/agent-session-terminal-abort-chain.test.ts` — 39 passed, 0 failed
- `bun test packages/coding-agent/test/cancel-and-submit.test.ts` — 27 passed, 0 failed
- `bun --cwd=packages/coding-agent run check:types` — passed
- `bun --cwd=packages/coding-agent run build` — passed

## Risk classification

- [x] `low-risk` — narrow session continuation guard with deterministic regression coverage.
- [ ] `regression-risk`
- [ ] `high-risk`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:1359dfefb39e9cc9835da4c4a8ef024b16a3756b27ac69a1d175acd01a5ebc2f reviewer:architect reviewer-id:Yeachan-Heo evidence:exact-head focused suite and review cohort passed
```

## Exact-head evidence

- Commit: `cd368f13712e4854fff2487bf3836e0e4b01b189`
- Base: `0cbf1da8a5de8651c8e74615a82bcff808b03d3b`
- Exact diff SHA-256: `1359dfefb39e9cc9835da4c4a8ef024b16a3756b27ac69a1d175acd01a5ebc2f`
- Source hash: `sha256:f7b1052126bb127ca1d590735dc134d6a94560b2c373ddeb83b4c29e01bcec78`
- Signed self-review record: posted in PR comments and bound to this exact base, head, and diff.
- Quality-gate artifact: `artifacts/issue-5199-quality-gate.json`
- QA artifact: `artifacts/issue-5199-steering-test-report.json`

---

- [x] Target branch is `dev`
- [x] Tested locally
- [x] CHANGELOG updated (user-facing)
- [x] Verdict matches the exact PR head
- [x] Risk classification matches the merge-self-approved path

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*