### PR TITLE
fix(browser): remove the Chrome profile warm-up dir on release

### DIFF
--- a/packages/coding-agent/src/tools/browser/registry.ts
+++ b/packages/coding-agent/src/tools/browser/registry.ts
@@ -53,6 +53,13 @@ export interface BrowserHandle {
 	cdpUrl?: string;
 	pid?: number;
 	subprocess?: Subprocess;
+	/**
+	 * Temp dir holding the copied Chrome profile warm-up artifacts, when this
+	 * handle was launched with profile reuse and the registry owns the dir.
+	 * Removed on release so repeated headless launches do not leak one Chrome
+	 * user-data-dir per open() into the OS temp directory.
+	 */
+	warmupDir?: string;
 	refCount: number;
 	stealth: { browserSession: CDPSession | null; override: UserAgentOverride | null };
 }
@@ -172,12 +179,20 @@ async function openBrowserHandle(
 				profileWarmupDir = reuse.warmupDir;
 			}
 		}
-		const browser = await launchHeadlessBrowser({
-			headless: kind.headless,
-			viewport: opts.viewport,
-			profileWarmupDir,
-			...(geo ? { geo } : {}),
-		});
+		let browser: Browser;
+		try {
+			browser = await launchHeadlessBrowser({
+				headless: kind.headless,
+				viewport: opts.viewport,
+				profileWarmupDir,
+				...(geo ? { geo } : {}),
+			});
+		} catch (error) {
+			// Launch failed after the warm-up copy landed: drop the temp dir here,
+			// because no handle will exist to carry it into releaseBrowser().
+			removeWarmupDir(profileWarmupDir);
+			throw error;
+		}
 		return {
 			key,
 
@@ -187,6 +202,7 @@ async function openBrowserHandle(
 			browser,
 			refCount: 0,
 			stealth: { browserSession: null, override: null },
+			...(profileWarmupDir ? { warmupDir: profileWarmupDir } : {}),
 		};
 	}
 	if (kind.kind === "connected") {
@@ -438,6 +454,22 @@ export async function releaseBrowser(handle: BrowserHandle, opts: { kill: boolea
 	}
 }
 
+/**
+ * Delete a registry-owned Chrome profile warm-up dir. Best-effort: a leftover
+ * temp dir is preferable to a teardown that throws.
+ */
+function removeWarmupDir(dir: string | undefined): void {
+	if (!dir) return;
+	try {
+		fs.rmSync(dir, { recursive: true, force: true });
+	} catch (err) {
+		logger.debug("Failed to remove Chrome profile warm-up dir", {
+			dir,
+			error: (err as Error).message,
+		});
+	}
+}
+
 async function disposeBrowserHandle(handle: BrowserHandle, opts: { kill: boolean }): Promise<void> {
 	if (handle.kind.kind === "headless") {
 		// Capture the launched Chrome process before close() so a forced (signal-path)
@@ -456,6 +488,9 @@ async function disposeBrowserHandle(handle: BrowserHandle, opts: { kill: boolean
 			}
 		}
 		if (opts.kill && proc?.pid !== undefined) await gracefulKillTreeOnce(proc.pid);
+		// Chrome owns files under the warm-up dir until the process is gone, so this
+		// runs after close()/kill rather than alongside them.
+		removeWarmupDir(handle.warmupDir);
 		return;
 	}
 	if (handle.kind.kind === "connected") {

--- a/packages/coding-agent/src/tools/browser/registry.ts
+++ b/packages/coding-agent/src/tools/browser/registry.ts
@@ -1,4 +1,5 @@
 import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 import { logger } from "@gajae-code/utils";
 import type { Subprocess } from "bun";
@@ -129,15 +130,16 @@ export function browserKeyForTest(
 }
 
 /**
- * Register a warm-up dir as registry-owned for `handle`.
+ * Create and register a warm-up dir as registry-owned for `handle`.
  *
- * Mirrors what the headless launch path does after it creates the dir. Exists so tests
- * can exercise disposal without spawning Chrome; it is the only way to add an ownership
- * entry from outside, which keeps the "deletion targets only dirs this module made"
- * invariant checkable — a handle that never went through here is never deleted.
+ * Exists so tests can exercise disposal without spawning Chrome. The caller cannot
+ * supply the deletion target: this module creates the directory itself before recording
+ * ownership, preserving the same invariant as the production launch path.
  */
-export function registerOwnedWarmupDirForTest(handle: BrowserHandle, dir: string): void {
+export function createOwnedWarmupDirForTest(handle: BrowserHandle): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-profile-warmup-"));
 	ownedWarmupDirs.set(handle, dir);
+	return dir;
 }
 
 export async function acquireBrowser(kind: BrowserKind, opts: AcquireBrowserOptions): Promise<BrowserHandle> {

--- a/packages/coding-agent/src/tools/browser/registry.ts
+++ b/packages/coding-agent/src/tools/browser/registry.ts
@@ -53,13 +53,6 @@ export interface BrowserHandle {
 	cdpUrl?: string;
 	pid?: number;
 	subprocess?: Subprocess;
-	/**
-	 * Temp dir holding the copied Chrome profile warm-up artifacts, when this
-	 * handle was launched with profile reuse and the registry owns the dir.
-	 * Removed on release so repeated headless launches do not leak one Chrome
-	 * user-data-dir per open() into the OS temp directory.
-	 */
-	warmupDir?: string;
 	refCount: number;
 	stealth: { browserSession: CDPSession | null; override: UserAgentOverride | null };
 }
@@ -68,6 +61,17 @@ type SpawnedChromeProfileKind = Extract<BrowserKind, { kind: "chrome-profile" }>
 
 const browsers = new Map<string, BrowserHandle>();
 const browserOpenPromises = new Map<string, Promise<BrowserHandle>>();
+
+/**
+ * Chrome profile warm-up dirs this module created, keyed by the handle that owns one.
+ *
+ * Ownership is a registry-internal fact, not a property of the handle: `BrowserHandle`
+ * is exported and mutable, so a field would let any caller point recursive deletion at
+ * an arbitrary path. Recording the dir here — only on the launch path that created it —
+ * means disposal can delete exactly what this module made and nothing else. A path
+ * prefix check would not prove ownership; an entry in this map does.
+ */
+const ownedWarmupDirs = new WeakMap<BrowserHandle, string>();
 
 /**
  * Upper bound on the CDP `browser.close()` round-trip during a forced (signal-path)
@@ -122,6 +126,18 @@ export function browserKeyForTest(
 ): string {
 	const geo = kind.kind === "headless" ? normalizeGeo(opts.geo) : undefined;
 	return browserKey(kind, geo, opts.profileReuse);
+}
+
+/**
+ * Register a warm-up dir as registry-owned for `handle`.
+ *
+ * Mirrors what the headless launch path does after it creates the dir. Exists so tests
+ * can exercise disposal without spawning Chrome; it is the only way to add an ownership
+ * entry from outside, which keeps the "deletion targets only dirs this module made"
+ * invariant checkable — a handle that never went through here is never deleted.
+ */
+export function registerOwnedWarmupDirForTest(handle: BrowserHandle, dir: string): void {
+	ownedWarmupDirs.set(handle, dir);
 }
 
 export async function acquireBrowser(kind: BrowserKind, opts: AcquireBrowserOptions): Promise<BrowserHandle> {
@@ -193,7 +209,7 @@ async function openBrowserHandle(
 			removeWarmupDir(profileWarmupDir);
 			throw error;
 		}
-		return {
+		const handle: BrowserHandle = {
 			key,
 
 			kind,
@@ -202,8 +218,12 @@ async function openBrowserHandle(
 			browser,
 			refCount: 0,
 			stealth: { browserSession: null, override: null },
-			...(profileWarmupDir ? { warmupDir: profileWarmupDir } : {}),
 		};
+		// Record ownership only here, where this module created the dir. Disposal
+		// deletes solely what this map holds, so a caller-supplied path is never
+		// a deletion target.
+		if (profileWarmupDir) ownedWarmupDirs.set(handle, profileWarmupDir);
+		return handle;
 	}
 	if (kind.kind === "connected") {
 		const cdpUrl = kind.cdpUrl.replace(/\/+$/, "");
@@ -455,9 +475,22 @@ export async function releaseBrowser(handle: BrowserHandle, opts: { kill: boolea
 }
 
 /**
- * Delete a registry-owned Chrome profile warm-up dir. Best-effort: a leftover
- * temp dir is preferable to a teardown that throws.
+ * Delete the warm-up dir this module created for `handle`, if any.
+ *
+ * The path comes from `ownedWarmupDirs`, never from the caller, so recursive deletion
+ * can only ever target a dir this registry made. The entry is consumed first, making a
+ * second call a no-op even if disposal runs twice.
+ *
+ * Best-effort: a leftover temp dir is preferable to a teardown that throws.
  */
+function removeOwnedWarmupDir(handle: BrowserHandle): void {
+	const dir = ownedWarmupDirs.get(handle);
+	if (dir === undefined) return;
+	ownedWarmupDirs.delete(handle);
+	removeWarmupDir(dir);
+}
+
+/** Delete a dir this module created. Callers must have proven ownership first. */
 function removeWarmupDir(dir: string | undefined): void {
 	if (!dir) return;
 	try {
@@ -490,7 +523,7 @@ async function disposeBrowserHandle(handle: BrowserHandle, opts: { kill: boolean
 		if (opts.kill && proc?.pid !== undefined) await gracefulKillTreeOnce(proc.pid);
 		// Chrome owns files under the warm-up dir until the process is gone, so this
 		// runs after close()/kill rather than alongside them.
-		removeWarmupDir(handle.warmupDir);
+		removeOwnedWarmupDir(handle);
 		return;
 	}
 	if (handle.kind.kind === "connected") {

--- a/packages/coding-agent/test/tools/browser-registry-teardown.test.ts
+++ b/packages/coding-agent/test/tools/browser-registry-teardown.test.ts
@@ -4,7 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import type { Browser } from "puppeteer-core";
 import * as attach from "../../src/tools/browser/attach";
-import { type BrowserHandle, releaseBrowser } from "../../src/tools/browser/registry";
+import { type BrowserHandle, registerOwnedWarmupDirForTest, releaseBrowser } from "../../src/tools/browser/registry";
 
 interface FakeBrowserOptions {
 	pid?: number;
@@ -25,8 +25,10 @@ function makeHeadlessHandle(opts: FakeBrowserOptions = {}): { handle: BrowserHan
 		browser,
 		refCount: 1,
 		stealth: { browserSession: null, override: null },
-		...(opts.warmupDir ? { warmupDir: opts.warmupDir } : {}),
 	};
+	// Ownership is registry-internal, so tests take the same registration path the
+	// launch code does instead of setting a field on the handle.
+	if (opts.warmupDir) registerOwnedWarmupDirForTest(handle, opts.warmupDir);
 	return { handle, close };
 }
 
@@ -123,5 +125,42 @@ describe("browser registry headless teardown (#698)", () => {
 		await releaseBrowser(handle, { kill: false });
 
 		expect(close).toHaveBeenCalledTimes(1);
+	});
+
+	it("refuses to delete a directory the registry does not own", async () => {
+		vi.spyOn(attach, "gracefulKillTreeOnce").mockResolvedValue(undefined);
+		// Shaped like a real Chrome profile, and named like a warm-up dir, but never
+		// registered as registry-owned. Disposal must not touch it: ownership comes
+		// from the launch path, not from the path's shape or prefix.
+		const foreign = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-profile-warmup-"));
+		fs.mkdirSync(path.join(foreign, "Default"), { recursive: true });
+		fs.writeFileSync(path.join(foreign, "Default", "Cookies"), "real-profile");
+		fs.writeFileSync(path.join(foreign, "Local State"), "{}");
+		const { handle, close } = makeHeadlessHandle({ pid: 4242 });
+
+		await releaseBrowser(handle, { kill: false });
+
+		expect(close).toHaveBeenCalledTimes(1);
+		expect(fs.existsSync(foreign)).toBe(true);
+		expect(fs.readFileSync(path.join(foreign, "Default", "Cookies"), "utf-8")).toBe("real-profile");
+		fs.rmSync(foreign, { recursive: true, force: true });
+	});
+
+	it("does not delete twice when disposal runs again", async () => {
+		vi.spyOn(attach, "gracefulKillTreeOnce").mockResolvedValue(undefined);
+		const warmupDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-warmup-test-"));
+		const { handle } = makeHeadlessHandle({ pid: 4242, warmupDir });
+
+		await releaseBrowser(handle, { kill: false });
+		expect(fs.existsSync(warmupDir)).toBe(false);
+
+		// A path recreated at the same location after disposal is a different
+		// resource; the consumed ownership entry must not reclaim it.
+		fs.mkdirSync(warmupDir, { recursive: true });
+		handle.refCount = 1;
+		await releaseBrowser(handle, { kill: false });
+
+		expect(fs.existsSync(warmupDir)).toBe(true);
+		fs.rmSync(warmupDir, { recursive: true, force: true });
 	});
 });

--- a/packages/coding-agent/test/tools/browser-registry-teardown.test.ts
+++ b/packages/coding-agent/test/tools/browser-registry-teardown.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import type { Browser } from "puppeteer-core";
 import * as attach from "../../src/tools/browser/attach";
 import { type BrowserHandle, releaseBrowser } from "../../src/tools/browser/registry";
@@ -6,6 +9,7 @@ import { type BrowserHandle, releaseBrowser } from "../../src/tools/browser/regi
 interface FakeBrowserOptions {
 	pid?: number;
 	close?: () => Promise<void>;
+	warmupDir?: string;
 }
 
 function makeHeadlessHandle(opts: FakeBrowserOptions = {}): { handle: BrowserHandle; close: ReturnType<typeof vi.fn> } {
@@ -21,6 +25,7 @@ function makeHeadlessHandle(opts: FakeBrowserOptions = {}): { handle: BrowserHan
 		browser,
 		refCount: 1,
 		stealth: { browserSession: null, override: null },
+		...(opts.warmupDir ? { warmupDir: opts.warmupDir } : {}),
 	};
 	return { handle, close };
 }
@@ -73,5 +78,50 @@ describe("browser registry headless teardown (#698)", () => {
 		await releaseBrowser(handle, { kill: true });
 		expect(close).toHaveBeenCalledTimes(1);
 		expect(killSpy).toHaveBeenCalledWith(4242);
+	});
+
+	it("removes the Chrome profile warm-up dir on release", async () => {
+		vi.spyOn(attach, "gracefulKillTreeOnce").mockResolvedValue(undefined);
+		const warmupDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-warmup-test-"));
+		fs.writeFileSync(path.join(warmupDir, "Cookies"), "x");
+		const { handle } = makeHeadlessHandle({ pid: 4242, warmupDir });
+
+		await releaseBrowser(handle, { kill: false });
+
+		expect(fs.existsSync(warmupDir)).toBe(false);
+	});
+
+	it("removes the warm-up dir on a forced release too", async () => {
+		vi.spyOn(attach, "gracefulKillTreeOnce").mockResolvedValue(undefined);
+		const warmupDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-warmup-test-"));
+		const { handle } = makeHeadlessHandle({ pid: 4242, warmupDir });
+
+		await releaseBrowser(handle, { kill: true });
+
+		expect(fs.existsSync(warmupDir)).toBe(false);
+	});
+
+	it("keeps the warm-up dir while refCount is still held", async () => {
+		vi.spyOn(attach, "gracefulKillTreeOnce").mockResolvedValue(undefined);
+		const warmupDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-warmup-test-"));
+		const { handle } = makeHeadlessHandle({ pid: 4242, warmupDir });
+		handle.refCount = 2;
+
+		await releaseBrowser(handle, { kill: false });
+		expect(fs.existsSync(warmupDir)).toBe(true);
+
+		await releaseBrowser(handle, { kill: false });
+		expect(fs.existsSync(warmupDir)).toBe(false);
+	});
+
+	it("tolerates an already-deleted warm-up dir", async () => {
+		vi.spyOn(attach, "gracefulKillTreeOnce").mockResolvedValue(undefined);
+		const warmupDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-warmup-test-"));
+		fs.rmSync(warmupDir, { recursive: true, force: true });
+		const { handle, close } = makeHeadlessHandle({ pid: 4242, warmupDir });
+
+		await releaseBrowser(handle, { kill: false });
+
+		expect(close).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/coding-agent/test/tools/browser-registry-teardown.test.ts
+++ b/packages/coding-agent/test/tools/browser-registry-teardown.test.ts
@@ -4,12 +4,11 @@ import * as os from "node:os";
 import * as path from "node:path";
 import type { Browser } from "puppeteer-core";
 import * as attach from "../../src/tools/browser/attach";
-import { type BrowserHandle, registerOwnedWarmupDirForTest, releaseBrowser } from "../../src/tools/browser/registry";
+import { type BrowserHandle, createOwnedWarmupDirForTest, releaseBrowser } from "../../src/tools/browser/registry";
 
 interface FakeBrowserOptions {
 	pid?: number;
 	close?: () => Promise<void>;
-	warmupDir?: string;
 }
 
 function makeHeadlessHandle(opts: FakeBrowserOptions = {}): { handle: BrowserHandle; close: ReturnType<typeof vi.fn> } {
@@ -26,9 +25,6 @@ function makeHeadlessHandle(opts: FakeBrowserOptions = {}): { handle: BrowserHan
 		refCount: 1,
 		stealth: { browserSession: null, override: null },
 	};
-	// Ownership is registry-internal, so tests take the same registration path the
-	// launch code does instead of setting a field on the handle.
-	if (opts.warmupDir) registerOwnedWarmupDirForTest(handle, opts.warmupDir);
 	return { handle, close };
 }
 
@@ -84,9 +80,9 @@ describe("browser registry headless teardown (#698)", () => {
 
 	it("removes the Chrome profile warm-up dir on release", async () => {
 		vi.spyOn(attach, "gracefulKillTreeOnce").mockResolvedValue(undefined);
-		const warmupDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-warmup-test-"));
+		const { handle } = makeHeadlessHandle({ pid: 4242 });
+		const warmupDir = createOwnedWarmupDirForTest(handle);
 		fs.writeFileSync(path.join(warmupDir, "Cookies"), "x");
-		const { handle } = makeHeadlessHandle({ pid: 4242, warmupDir });
 
 		await releaseBrowser(handle, { kill: false });
 
@@ -95,8 +91,8 @@ describe("browser registry headless teardown (#698)", () => {
 
 	it("removes the warm-up dir on a forced release too", async () => {
 		vi.spyOn(attach, "gracefulKillTreeOnce").mockResolvedValue(undefined);
-		const warmupDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-warmup-test-"));
-		const { handle } = makeHeadlessHandle({ pid: 4242, warmupDir });
+		const { handle } = makeHeadlessHandle({ pid: 4242 });
+		const warmupDir = createOwnedWarmupDirForTest(handle);
 
 		await releaseBrowser(handle, { kill: true });
 
@@ -105,8 +101,8 @@ describe("browser registry headless teardown (#698)", () => {
 
 	it("keeps the warm-up dir while refCount is still held", async () => {
 		vi.spyOn(attach, "gracefulKillTreeOnce").mockResolvedValue(undefined);
-		const warmupDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-warmup-test-"));
-		const { handle } = makeHeadlessHandle({ pid: 4242, warmupDir });
+		const { handle } = makeHeadlessHandle({ pid: 4242 });
+		const warmupDir = createOwnedWarmupDirForTest(handle);
 		handle.refCount = 2;
 
 		await releaseBrowser(handle, { kill: false });
@@ -118,9 +114,9 @@ describe("browser registry headless teardown (#698)", () => {
 
 	it("tolerates an already-deleted warm-up dir", async () => {
 		vi.spyOn(attach, "gracefulKillTreeOnce").mockResolvedValue(undefined);
-		const warmupDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-warmup-test-"));
+		const { handle, close } = makeHeadlessHandle({ pid: 4242 });
+		const warmupDir = createOwnedWarmupDirForTest(handle);
 		fs.rmSync(warmupDir, { recursive: true, force: true });
-		const { handle, close } = makeHeadlessHandle({ pid: 4242, warmupDir });
 
 		await releaseBrowser(handle, { kill: false });
 
@@ -148,8 +144,8 @@ describe("browser registry headless teardown (#698)", () => {
 
 	it("does not delete twice when disposal runs again", async () => {
 		vi.spyOn(attach, "gracefulKillTreeOnce").mockResolvedValue(undefined);
-		const warmupDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-warmup-test-"));
-		const { handle } = makeHeadlessHandle({ pid: 4242, warmupDir });
+		const { handle } = makeHeadlessHandle({ pid: 4242 });
+		const warmupDir = createOwnedWarmupDirForTest(handle);
 
 		await releaseBrowser(handle, { kill: false });
 		expect(fs.existsSync(warmupDir)).toBe(false);
@@ -162,5 +158,19 @@ describe("browser registry headless teardown (#698)", () => {
 
 		expect(fs.existsSync(warmupDir)).toBe(true);
 		fs.rmSync(warmupDir, { recursive: true, force: true });
+	});
+
+	it("cannot register a caller-selected directory as registry-owned", async () => {
+		vi.spyOn(attach, "gracefulKillTreeOnce").mockResolvedValue(undefined);
+		const foreign = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-profile-warmup-"));
+		fs.writeFileSync(path.join(foreign, "Local State"), "foreign");
+		const { handle } = makeHeadlessHandle({ pid: 4242 });
+		const owned = createOwnedWarmupDirForTest(handle);
+
+		await releaseBrowser(handle, { kill: false });
+
+		expect(fs.existsSync(owned)).toBe(false);
+		expect(fs.readFileSync(path.join(foreign, "Local State"), "utf-8")).toBe("foreign");
+		fs.rmSync(foreign, { recursive: true, force: true });
 	});
 });


### PR DESCRIPTION
## What

Delete the `gjc-profile-warmup-*` temp dir when the browser handle is released. `BrowserHandle` gains an optional `warmupDir` so the registry can carry and clean up the dir it owns.

## Why

Fixes #5206.

`resolveProfileReuse()` creates a temp dir via `fs.mkdtempSync(... "gjc-profile-warmup-")` and copies the discovered Chrome profile into it. The failure path cleans up (`profile-reuse.ts:88-92`), but the success path returns the dir as `warmupDir` and nothing ever deletes it. `BrowserHandle` had no field to carry that path, so `disposeBrowserHandle()` could not have removed it even in principle.

Every headless `open()` with profile reuse therefore leaks one Chrome `user-data-dir` into the OS temp directory, permanently.

Observed on macOS 15 / Chrome 152 in a single working session:

```
13  /var/folders/.../T/gjc-profile-warmup-*                    leaked dirs
11  Google Chrome --user-data-dir=.../gjc-profile-warmup-*     live processes
```

At that point launching Chrome from the Dock silently did nothing — no window, no error — until the stale automation instances were killed by hand. Each dir also holds a copy of the user's real profile artifacts (`Cookies`, `Login Data`), so this is disk growth plus credential-bearing copies left behind indefinitely.

## Testing

4 regression cases added to `packages/coding-agent/test/tools/browser-registry-teardown.test.ts`:

| case | asserts |
|---|---|
| removes the warm-up dir on release | graceful path (`kill: false`) |
| removes the warm-up dir on a forced release too | signal path (`kill: true`) |
| keeps the warm-up dir while refCount is still held | not removed until refCount hits 0 |
| tolerates an already-deleted warm-up dir | no throw when the dir is gone |

Verified the cases actually catch the bug by stashing the `registry.ts` change:

```
bun test packages/coding-agent/test/tools/browser-registry-teardown.test.ts
  without the fix:  5 pass, 3 fail
  with the fix:     8 pass, 0 fail
```

Browser tool suite (12 files) goes 53 → 57 pass with no new failures. The 5 pre-existing failures are `@gajae-code/natives` not being built in this checkout and reproduce identically on `dev`.

`biome check` clean on both touched files.

`bun check` fails on `check:public-sync` (`@gajae-code/bridge-client` 0.11.8 vs canonical 0.16.0) — pre-existing on `dev`, reproduced with this change stashed, unrelated to these files.

Implementation notes:
- removal runs **after** `close()`/kill, because Chrome holds files under the dir until the process exits
- `openBrowserHandle()` also removes it when `launchHeadlessBrowser()` throws, where no handle exists to carry it into release
- removal is best-effort and debug-logged: a leftover temp dir beats a throwing teardown


### Review follow-up (2026-09-03)

`removeWarmupDir()` previously deleted any string it received while
`BrowserHandle.warmupDir` was an exported mutable field, so a constructed or
mutated handle could aim recursive deletion at an arbitrary path. Ownership is
now a module-local `WeakMap<BrowserHandle, string>` populated only by the launch
path that creates the dir, and disposal consumes the entry before deleting. A
prefix check was rejected: it proves shape, not provenance.

Two negative cases were added as requested:

| case | asserts |
|---|---|
| refuses to delete a directory the registry does not own | a real-profile-shaped `gjc-profile-warmup-*` dir with `Default/Cookies` and `Local State`, never registered, survives release with contents intact |
| does not delete twice when disposal runs again | a path recreated at the same location after disposal is not reclaimed by the consumed entry |

Both fail against a prefix-matching implementation (verified by swapping one in:
8 pass / 2 fail) and pass with the ownership record (10 pass / 0 fail).
Browser suite 63 -> 65 pass, same 5 pre-existing native-build failures.


### Hardening by reviewer (2026-09-03, `ec2010065`)

The reviewer closed the last gap on this branch. `registerOwnedWarmupDirForTest(handle, dir)`
still let a caller choose the path that became an authorized deletion target, even though the
map itself was private. It is replaced by `createOwnedWarmupDirForTest(handle)`, which creates
the `gjc-profile-warmup-*` dir inside the registry before recording ownership — so every entry
in the map now has registry-created provenance, matching the production launch path.

Verified locally at this head: `browser-registry-teardown.test.ts` 11 passed,
`browser-profile-warmup.test.ts` 7 passed (18 total), diff digest reproduces as
`8f828b825c185a9ca04a627ca1f4b209bdf4d05b216c81e307ee31f90a303b2c`.

Since the reviewer authored the final commit, this head needs an independent reviewer.

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk`
- [ ] `high-risk`

Scope is one optional field plus a best-effort `rmSync` on an already-terminal teardown path. No behavior change when profile reuse is off.

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:8f828b825c185a9ca04a627ca1f4b209bdf4d05b216c81e307ee31f90a303b2c reviewer:human reviewer-id:Yeachan-Heo evidence:exact-head-review-381431f622c-18-tests-ts-biome-state-writer-concurrency-pass
```

I am the PR author, so I cannot self-issue `merge-approved`. Requesting an independent reviewer.

---

- [x] Target branch is `dev`
- [ ] `bun check` passes — fails only on the pre-existing `check:public-sync` version mismatch, reproduced on `dev` with this change stashed
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing) — internal resource cleanup, no user-facing surface change
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken


