### PR TITLE
style(sdk): unbreak Affected path validation on dev (formatter, post-#5208)

### DIFF
--- a/packages/coding-agent/src/sdk/cli/session-cli.ts
+++ b/packages/coding-agent/src/sdk/cli/session-cli.ts
@@ -1486,7 +1486,7 @@ async function runLiveTail(
 		if (attachment.sessionId !== sessionId) return;
 		const item = tailItemFromRouterFrame(frame);
 		if (!item) return;
-										if (item.revision === undefined && checkpoint?.revision !== undefined) item.revision = checkpoint.revision;
+		if (item.revision === undefined && checkpoint?.revision !== undefined) item.revision = checkpoint.revision;
 		// If checkpoint was undefined, queue for later stamping? For now leave without rev
 		applyLifecycle(mergeEventTailItems(eventItems, seenEvents, [item], include));
 	};


### PR DESCRIPTION
## Problem

`dev` is currently red for **every** PR that touches `packages/coding-agent`.

`biome check` fails on `dev` itself:

```
packages/coding-agent/src/sdk/cli/session-cli.ts:1489 format
× Formatter would have printed the following content
```

The offending line is the tail `revision` assignment added by #5208 (merged at 15:32 UTC). Because the shard fails on the base branch, `Affected path validation / check:@gajae-code/coding-agent` — and the downstream `evidence producer` and aggregate `Affected path validation` jobs — fail on unrelated PRs. Confirmed on #5197, #5148, and #5051, none of which touch that file.

## Change

Apply the formatter output for that single line. No behavior change; `biome check packages/coding-agent` goes from 1 error to 0 (the 7 remaining entries are pre-existing unsafe-fix suggestions, untouched).

## Verification

```
biome check packages/coding-agent   # before: Found 1 error   after: 0 errors, 7 warnings
```

Base: `origin/dev` @ `4bab035cd50`
—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*