### PR TITLE
style(sdk): fix biome format violation on dev base (session-cli live tail)

### DIFF
--- a/packages/coding-agent/src/sdk/cli/session-cli.ts
+++ b/packages/coding-agent/src/sdk/cli/session-cli.ts
@@ -1486,7 +1486,7 @@ async function runLiveTail(
 		if (attachment.sessionId !== sessionId) return;
 		const item = tailItemFromRouterFrame(frame);
 		if (!item) return;
-										if (item.revision === undefined && checkpoint?.revision !== undefined) item.revision = checkpoint.revision;
+		if (item.revision === undefined && checkpoint?.revision !== undefined) item.revision = checkpoint.revision;
 		// If checkpoint was undefined, queue for later stamping? For now leave without rev
 		applyLifecycle(mergeEventTailItems(eventItems, seenEvents, [item], include));
 	};


### PR DESCRIPTION
## Problem

`origin/dev` itself fails `biome check`:

```
packages/coding-agent/src/sdk/cli/session-cli.ts format
  × Formatter would have printed the following content:
    1489 │ → → → → → → → → → → if (item.revision === undefined && checkpoint?.revision !== undefined) ...
```

Because the defect lives on the base branch, every PR rebased onto current `dev` inherits it and its exact-head contract/format validation fails for a reason unrelated to that PR's own diff. This was observed while reviewing PR #5148, which is otherwise clean.

## Change

One line: restore correct indentation at `packages/coding-agent/src/sdk/cli/session-cli.ts:1489`. No behavioral change — formatter-only.

## Verification

In a clean worktree created from `origin/dev`:

- before: `biome check packages/coding-agent/src/sdk/cli/session-cli.ts` → `Found 1 error.`
- after: same command → `Checked 1 file. No fixes applied.` (clean)
- whole repo: `biome check .` → `Checked 3935 files`, 0 errors (8 warnings / 2 infos pre-existing and unrelated)

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*