### PR TITLE
fix(ai): honor antigravity agentModelSorts visibility

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Antigravity discovery now keeps mid-rollout models that the backend marks `isInternal` when the same response surfaces them through `agentModelSorts`. Internal models absent from the IDE's surfaced model groups remain hidden, and denylisted or retired selectors still take precedence.
 - Tokenless loopback auth-broker requests carrying a browser `Origin` header are now rejected before credential reads or mutations. Native loopback clients without `Origin`, authenticated browser-origin clients, and the public health endpoint retain their existing behavior.
 - `glm-zcode` login instructions now warn users who have the ZCode desktop app installed to cancel the browser's `zcode://` open prompt. The app exchanges the single-use authorization code itself, so a code pasted afterwards is rejected by the broker (`500 {"code":2007}`) and the documented paste flow failed without explanation.
 

--- a/packages/ai/src/utils/discovery/antigravity.ts
+++ b/packages/ai/src/utils/discovery/antigravity.ts
@@ -218,13 +218,22 @@ export async function fetchAntigravityDiscoveryModels(
 			continue;
 		}
 
+		const surfacedModelIds = new Set<string>();
+		for (const sort of parsed.agentModelSorts ?? []) {
+			for (const group of sort.groups ?? []) {
+				for (const modelId of group.modelIds ?? []) {
+					surfacedModelIds.add(modelId);
+				}
+			}
+		}
+
 		const models: Model<"google-gemini-cli">[] = [];
 
 		for (const [modelId, model] of Object.entries(parsed.models ?? {})) {
 			if (ANTIGRAVITY_DISCOVERY_DENYLIST.has(modelId) || isRetiredModelKey(targetProvider, modelId)) {
 				continue;
 			}
-			if (model.isInternal === true) {
+			if (model.isInternal === true && !surfacedModelIds.has(modelId)) {
 				continue;
 			}
 

--- a/packages/ai/test/antigravity-discovery.test.ts
+++ b/packages/ai/test/antigravity-discovery.test.ts
@@ -32,6 +32,33 @@ function createAntigravityModel(id: string, name: string): Model<Api> {
 }
 
 describe("Antigravity model discovery", () => {
+	async function resolveDiscoveryPayload(payload: unknown): Promise<Model<Api>[]> {
+		const cacheDir = mkdtempSync(join(tmpdir(), "pi-ai-antigravity-model-cache-"));
+		cacheDirs.push(cacheDir);
+		const cacheDbPath = join(cacheDir, "models.db");
+		const fetcher = (async () =>
+			new Response(JSON.stringify(payload), {
+				headers: { "content-type": "application/json" },
+			})) as unknown as typeof fetch;
+
+		const { models } = await resolveProviderModels<Api>(
+			{
+				providerId: "google-antigravity",
+				staticModels: [],
+				cacheDbPath,
+				fetchDynamicModels: () =>
+					fetchAntigravityDiscoveryModels({
+						token: "test-token",
+						endpoint: "https://antigravity.example.test",
+						fetcher,
+					}),
+			},
+			"online",
+		);
+
+		return models;
+	}
+
 	function createDiscoveryFetcher(): typeof fetch {
 		return (async () =>
 			new Response(
@@ -85,6 +112,48 @@ describe("Antigravity model discovery", () => {
 		});
 
 		expect(models?.map(model => model.id)).toEqual(["gemini-3.1-pro-low", "gemini-3.7-flash-tiered"]);
+	});
+
+	it("resolves an internal mid-rollout model surfaced by agentModelSorts", async () => {
+		const models = await resolveDiscoveryPayload({
+			models: {
+				"gemini-future-flash-medium": {
+					displayName: "Gemini Future Flash (Medium)",
+					isInternal: true,
+					supportsImages: true,
+					supportsThinking: true,
+				},
+			},
+			agentModelSorts: [{ groups: [{ modelIds: ["gemini-future-flash-medium"] }] }],
+		});
+
+		expect(models.map(model => model.id)).toEqual(["gemini-future-flash-medium"]);
+	});
+
+	it("keeps genuinely internal models absent from agentModelSorts hidden", async () => {
+		const models = await resolveDiscoveryPayload({
+			models: {
+				"internal-evaluation-model": {
+					displayName: "Internal Evaluation Model",
+					isInternal: true,
+				},
+			},
+			agentModelSorts: [{ groups: [{ modelIds: ["public-model"] }] }],
+		});
+
+		expect(models).toEqual([]);
+	});
+
+	it("keeps denylisted and retired models hidden when agentModelSorts surfaces them", async () => {
+		const models = await resolveDiscoveryPayload({
+			models: {
+				chat_20706: { displayName: "Denylisted", isInternal: true },
+				"gemini-3.1-pro-high": { displayName: "Retired", isInternal: true },
+			},
+			agentModelSorts: [{ groups: [{ modelIds: ["chat_20706", "gemini-3.1-pro-high"] }] }],
+		});
+
+		expect(models).toEqual([]);
 	});
 
 	it("keeps gemini-3.1-pro-high when discovery targets google-gemini-cli", async () => {


### PR DESCRIPTION
## What

- Use `agentModelSorts[].groups[].modelIds` as the backend's explicit IDE-visibility signal during Antigravity discovery.
- Allow a surfaced model to survive `isInternal: true` while keeping unsurfaced internal models hidden.
- Preserve denylist and retired-selector precedence.
- Add discovery-to-resolution regressions for the surfaced, genuinely internal, denylisted, and retired cases.

## Why

The live issue evidence corrected the original Gemini 3.8 assumption: `/v1internal:fetchAvailableModels` currently contains no 3.8 key, so adding speculative static ids or invented limits would be wrong. The real defect is that discovery already parsed `agentModelSorts` but discarded it, causing an IDE-visible mid-rollout model to be filtered solely because it was marked internal.

Fixes #5215

## Testing

- `bun test packages/ai/test/antigravity-discovery.test.ts` — 7 passed, 0 failed, 14 expectations
- `bun test packages/ai/test/preset-catalog-models.test.ts` — 11 passed, 0 failed, 83 expectations
- Combined evidence: 18 passed, 0 failed, 97 expectations (`artifacts/issue-5215/focused-tests.txt` locally)
- `bunx biome check packages/ai/src/utils/discovery/antigravity.ts packages/ai/test/antigravity-discovery.test.ts packages/ai/CHANGELOG.md` — passed
- Frozen-source architect review — CLEAR / APPROVE
- Frozen-source executor red-team review — passed

Live 3.8 listing was not claimed or seeded: the current backend payload has no 3.8 model key to list. The synthetic mid-rollout payload proves that any future backend-served id reaches the resolved provider catalog without a per-id patch.

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:8892a8060ab02eea947068ac5067880ce3ddaeee93fc0219b16efd2b90521aa4 reviewer:human reviewer-id:Yeachan-Heo evidence:focused AI tests 18 pass; frozen architect CLEAR and executor red-team passed
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken
