### PR TITLE
fix(session): reclaim dead transition claims without delay

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Session-state lock acquisition now retries immediately after positively proving and identity-reclaiming a dead transition owner, so forced exits no longer add a retry delay to the next resume while unproven or live claims retain the bounded backoff path.
 - Coordinator persist failures now include typed lock-cause fields and use a per-document, per-failure-class 30-second warn window; proven-refused local model discovery is debug-level, and `session_closed` delivery failures route by attached-client count.
 - `gjc update` now identifies the active Linux libc instead of treating an optional installed musl loader as proof that a glibc-based Ubuntu host runs musl.
 - Sessions can now be marked with `/star` and `/unstar`; starred sessions persist in append-only metadata, display a `★` in resume and read-only dashboard views, and sort ahead of unstarred sessions without changing deletion or retention behavior.

--- a/packages/coding-agent/src/gjc-runtime/session-state-lock.ts
+++ b/packages/coding-agent/src/gjc-runtime/session-state-lock.ts
@@ -410,6 +410,8 @@ export const SessionStateLockTestHooks: {
 	forcedQuarantineName?: string;
 	/** @internal Observes bounded acquisition retries without changing their timing. */
 	afterAcquireContention?: (lockFile: string, attempt: number, elapsedMs: number) => void;
+	/** @internal Runs after transition mkdir contention and before stale-claim inspection. */
+	afterTransitionClaimContention?: (transitionDir: string) => void | Promise<void>;
 } = {};
 
 /** Raised when the lock could not be acquired; callers map it to their own refusal. */
@@ -1668,14 +1670,14 @@ async function reclaimStaleTransitionClaim(transitionDir: string, quarantineName
 	let stat: fsSync.BigIntStats;
 	try {
 		stat = await fs.lstat(transitionDir, { bigint: true });
-	} catch (error) {
-		return (error as NodeJS.ErrnoException).code === "ENOENT";
+	} catch {
+		return false;
 	}
 	// Regular-file claims belong to the superseded protocol. They retain the old
 	// exact-identity stale path; released PID-1 tombstones deliberately require
 	// explicit cleanup before this atomic-directory protocol can take over.
 	if (stat.isFile()) {
-		const reclaimed = await reclaimStaleOwnerRecord(
+		await reclaimStaleOwnerRecord(
 			transitionDir,
 			{
 				afterInspection: SessionStateLockTestHooks.afterTransitionStaleInspection,
@@ -1683,7 +1685,7 @@ async function reclaimStaleTransitionClaim(transitionDir: string, quarantineName
 			},
 			quarantineName,
 		);
-		return reclaimed === "reclaimed";
+		return false;
 	}
 	if (!stat.isDirectory()) throw new SessionStateLockUnavailableError();
 	const ownerSnapshot = await captureRegularLockOwner(`${transitionDir}.owner`);
@@ -1733,7 +1735,7 @@ async function reclaimStaleTransitionClaim(transitionDir: string, quarantineName
 	const removed = nativeSessionStateLock().exactRemoveDirectoryTree(nativePath, captured.snapshot);
 	if (removed.ok || removed.code === "not_found") {
 		exactUnlinkOwnerRecord(`${transitionDir}.owner`, ownerSnapshot, quarantineName);
-		return true;
+		return removed.ok;
 	}
 	if (
 		removed.code === "cleanup_pending" &&
@@ -2014,6 +2016,7 @@ async function withLockPathTransition<T>(
 		} catch (error) {
 			const code = (error as NodeJS.ErrnoException).code;
 			if (code !== "EEXIST" && !isTransientLockError(error)) throw new SessionStateLockUnavailableError(error);
+			await SessionStateLockTestHooks.afterTransitionClaimContention?.(transitionDir);
 			if (await reclaimStaleTransitionClaim(transitionDir, quarantineName)) continue;
 			if (!(await waitForLockRetry(budget)))
 				throw lockUnavailable(transitionDir, "transition_claim_timeout", budget, error);

--- a/packages/coding-agent/src/gjc-runtime/session-state-lock.ts
+++ b/packages/coding-agent/src/gjc-runtime/session-state-lock.ts
@@ -55,6 +55,10 @@ function lockRetryElapsedMs(budget: LockRetryBudget): number {
 	return Math.max(0, performance.now() - budget.startedAt);
 }
 
+function lockRetryExhausted(budget: LockRetryBudget): boolean {
+	return lockRetryElapsedMs(budget) >= LOCK_ACQUIRE_TIMEOUT_MS;
+}
+
 async function waitForLockRetry(budget: LockRetryBudget): Promise<boolean> {
 	budget.attempts++;
 	const remainingMs = LOCK_ACQUIRE_TIMEOUT_MS - lockRetryElapsedMs(budget);
@@ -2019,7 +2023,11 @@ async function withLockPathTransition<T>(
 			const code = (error as NodeJS.ErrnoException).code;
 			if (code !== "EEXIST" && !isTransientLockError(error)) throw new SessionStateLockUnavailableError(error);
 			await SessionStateLockTestHooks.afterTransitionClaimContention?.(transitionDir);
-			if (await reclaimStaleTransitionClaim(transitionDir, quarantineName)) continue;
+			if (await reclaimStaleTransitionClaim(transitionDir, quarantineName)) {
+				if (lockRetryExhausted(budget))
+					throw lockUnavailable(transitionDir, "transition_claim_timeout", budget, error);
+				continue;
+			}
 			if (!(await waitForLockRetry(budget)))
 				throw lockUnavailable(transitionDir, "transition_claim_timeout", budget, error);
 			continue;

--- a/packages/coding-agent/src/gjc-runtime/session-state-lock.ts
+++ b/packages/coding-agent/src/gjc-runtime/session-state-lock.ts
@@ -1664,14 +1664,18 @@ async function releaseTransitionClaim(
 	}
 }
 
-async function reclaimStaleTransitionClaim(transitionDir: string, quarantineName: string): Promise<void> {
-	const stat = await fs.lstat(transitionDir, { bigint: true }).catch(() => null);
-	if (!stat) return;
+async function reclaimStaleTransitionClaim(transitionDir: string, quarantineName: string): Promise<boolean> {
+	let stat: fsSync.BigIntStats;
+	try {
+		stat = await fs.lstat(transitionDir, { bigint: true });
+	} catch (error) {
+		return (error as NodeJS.ErrnoException).code === "ENOENT";
+	}
 	// Regular-file claims belong to the superseded protocol. They retain the old
 	// exact-identity stale path; released PID-1 tombstones deliberately require
 	// explicit cleanup before this atomic-directory protocol can take over.
 	if (stat.isFile()) {
-		await reclaimStaleOwnerRecord(
+		const reclaimed = await reclaimStaleOwnerRecord(
 			transitionDir,
 			{
 				afterInspection: SessionStateLockTestHooks.afterTransitionStaleInspection,
@@ -1679,41 +1683,41 @@ async function reclaimStaleTransitionClaim(transitionDir: string, quarantineName
 			},
 			quarantineName,
 		);
-		return;
+		return reclaimed === "reclaimed";
 	}
 	if (!stat.isDirectory()) throw new SessionStateLockUnavailableError();
 	const ownerSnapshot = await captureRegularLockOwner(`${transitionDir}.owner`);
-	if (!ownerSnapshot) return;
+	if (!ownerSnapshot) return false;
 	let owner: unknown;
 	try {
 		owner = JSON.parse(ownerSnapshot.bytes);
 	} catch {
-		return;
+		return false;
 	}
-	if (!validLockOwner(owner)) return;
+	if (!validLockOwner(owner)) return false;
 	await SessionStateLockTestHooks.afterTransitionStaleInspection?.(transitionDir);
 	if (owner.released === true) {
 		// A released record is safe only when it is qualified by this installation.
 		// Never let a shared-volume tombstone, an absent identity, or a legacy foreign
 		// identity authorize removal of a claim this process cannot own.
-		if (owner.owner_host_id === undefined) return;
+		if (owner.owner_host_id === undefined) return false;
 		const currentHost = await currentOwnerHostId();
 		const legacyHost = await currentLegacyOwnerHostId();
-		if (owner.owner_host_id !== currentHost && owner.owner_host_id !== legacyHost) return;
-		if (Date.now() - Number(ownerSnapshot.mtimeNs / 1_000_000n) < RELEASED_TRANSITION_GRACE_MS) return;
+		if (owner.owner_host_id !== currentHost && owner.owner_host_id !== legacyHost) return false;
+		if (Date.now() - Number(ownerSnapshot.mtimeNs / 1_000_000n) < RELEASED_TRANSITION_GRACE_MS) return false;
 	} else if (await lockOwnerIsAlive(owner)) {
 		// Only a host-qualified owner whose pid is PROVEN dead (ESRCH, or a live pid
 		// with a provably different incarnation) authorizes reclaim. The generation
 		// + exact-tree checks below then bind the removal to the very directory
 		// inspected here, on every platform; a claim stranded by a force-quit
 		// (`postmortem.quit`) would otherwise wall the session directory forever.
-		return;
+		return false;
 	}
 	const generation = transitionGenerationFromStat(stat);
 	const nativePath = await canonicalOwnedTransitionPath(transitionDir).catch(() => null);
-	if (!nativePath) return;
+	if (!nativePath) return false;
 	const captured = nativeSessionStateLock().snapshotDirectoryTree(nativePath);
-	if (!captured.ok || !captured.snapshot) return;
+	if (!captured.ok || !captured.snapshot) return false;
 	const root = captured.snapshot.entries.find(entry => entry.relativePath === "");
 	if (
 		!root ||
@@ -1724,13 +1728,12 @@ async function reclaimStaleTransitionClaim(transitionDir: string, quarantineName
 		root.mtimeNs !== String(generation.mtimeNs) ||
 		root.ctimeNs !== String(generation.ctimeNs)
 	)
-		return;
-	if (captured.snapshot.entries.length !== 1) return;
+		return false;
+	if (captured.snapshot.entries.length !== 1) return false;
 	const removed = nativeSessionStateLock().exactRemoveDirectoryTree(nativePath, captured.snapshot);
 	if (removed.ok || removed.code === "not_found") {
-		const ownerRemoval = exactUnlinkOwnerRecord(`${transitionDir}.owner`, ownerSnapshot, quarantineName);
-		if (ownerRemoval !== "removed" && ownerRemoval !== "absent") return;
-		return;
+		exactUnlinkOwnerRecord(`${transitionDir}.owner`, ownerSnapshot, quarantineName);
+		return true;
 	}
 	if (
 		removed.code === "cleanup_pending" &&
@@ -1746,9 +1749,8 @@ async function reclaimStaleTransitionClaim(transitionDir: string, quarantineName
 		// collision on POSIX. rmdir never follows a directory's contents and refuses if a
 		// successor populated the detached path.
 		await removeTransitionDir(removed.detachedPath);
-		const ownerRemoval = exactUnlinkOwnerRecord(`${transitionDir}.owner`, ownerSnapshot, quarantineName);
-		if (ownerRemoval !== "removed" && ownerRemoval !== "absent") return;
-		return;
+		exactUnlinkOwnerRecord(`${transitionDir}.owner`, ownerSnapshot, quarantineName);
+		return true;
 	}
 	throw new SessionStateLockUnavailableError(
 		new Error(`Stale transition claim could not be reclaimed (${removed.code ?? "unknown"}).`),
@@ -2012,7 +2014,7 @@ async function withLockPathTransition<T>(
 		} catch (error) {
 			const code = (error as NodeJS.ErrnoException).code;
 			if (code !== "EEXIST" && !isTransientLockError(error)) throw new SessionStateLockUnavailableError(error);
-			await reclaimStaleTransitionClaim(transitionDir, quarantineName);
+			if (await reclaimStaleTransitionClaim(transitionDir, quarantineName)) continue;
 			if (!(await waitForLockRetry(budget)))
 				throw lockUnavailable(transitionDir, "transition_claim_timeout", budget, error);
 			continue;

--- a/packages/coding-agent/src/gjc-runtime/session-state-lock.ts
+++ b/packages/coding-agent/src/gjc-runtime/session-state-lock.ts
@@ -1496,6 +1496,7 @@ async function releaseOwnerLock(file: string, held: LockOwnerSnapshot): Promise<
 type SessionStateLockReclaimResult =
 	| "absent_or_changed"
 	| "legacy_directory_unprovenanced"
+	| "owner_removed"
 	| "owner_live_or_unverifiable"
 	| "owner_record_fresh"
 	| "owner_unprovenanced"
@@ -1534,7 +1535,8 @@ async function reclaimStaleOwnerRecord(
 	// A successor that took the path in the final window keeps it; this call just loses.
 	if (outcome === "refused")
 		throw new SessionStateLockUnavailableError(new Error("Stale owner record could not be reclaimed."));
-	return outcome === "removed" || outcome === "absent" ? "reclaimed" : "absent_or_changed";
+	if (outcome === "removed") return "owner_removed";
+	return "absent_or_changed";
 }
 
 /**
@@ -1677,7 +1679,7 @@ async function reclaimStaleTransitionClaim(transitionDir: string, quarantineName
 	// exact-identity stale path; released PID-1 tombstones deliberately require
 	// explicit cleanup before this atomic-directory protocol can take over.
 	if (stat.isFile()) {
-		await reclaimStaleOwnerRecord(
+		const reclaimed = await reclaimStaleOwnerRecord(
 			transitionDir,
 			{
 				afterInspection: SessionStateLockTestHooks.afterTransitionStaleInspection,
@@ -1685,7 +1687,7 @@ async function reclaimStaleTransitionClaim(transitionDir: string, quarantineName
 			},
 			quarantineName,
 		);
-		return false;
+		return reclaimed === "owner_removed";
 	}
 	if (!stat.isDirectory()) throw new SessionStateLockUnavailableError();
 	const ownerSnapshot = await captureRegularLockOwner(`${transitionDir}.owner`);

--- a/packages/coding-agent/test/fixtures/session-state-lock-forced-exit-probe.ts
+++ b/packages/coding-agent/test/fixtures/session-state-lock-forced-exit-probe.ts
@@ -1,0 +1,32 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import "@gajae-code/utils";
+import {
+	SessionStateLockTestHooks,
+	setSessionStateLockNativeBindings,
+	withSessionStateFileLock,
+} from "../../src/gjc-runtime/session-state-lock";
+import { exactIdentityNativeBindings } from "../helpers/exact-identity-natives";
+
+const root = process.argv[2];
+if (!root) throw new Error("root is required");
+
+const stateFile = path.join(root, "runtime-state.json");
+setSessionStateLockNativeBindings(() => exactIdentityNativeBindings);
+SessionStateLockTestHooks.ownerHostId = () => "forced-exit-probe-host";
+SessionStateLockTestHooks.legacyOwnerHostId = () => "forced-exit-probe-legacy-host";
+SessionStateLockTestHooks.unqualifiedOwnerIsLocal = false;
+
+SessionStateLockTestHooks.beforeCurrentOwnerRelease = async file => {
+	if (file !== `${stateFile}.lock.transition.owner`) return;
+	await Bun.write(path.join(root, "lock-held"), "held\n");
+	await new Promise<never>(() => {});
+};
+
+void withSessionStateFileLock(stateFile, async () => undefined);
+for (let attempt = 0; attempt < 200; attempt++) {
+	if (await fs.exists(path.join(root, "lock-held"))) break;
+	await Bun.sleep(10);
+}
+await fs.writeFile(path.join(root, "ready"), "ready\n");
+await new Promise<never>(() => {});

--- a/packages/coding-agent/test/session-state-lock-forced-exit.test.ts
+++ b/packages/coding-agent/test/session-state-lock-forced-exit.test.ts
@@ -163,15 +163,17 @@ describe("session-state lock forced-exit recovery", () => {
 		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-transition-cleanup-refused-"));
 		roots.push(root);
 		const { stateFile, transitionDir } = await seedDeadTransition(root, "cleanup-pending-refused");
+		const detachedPath = `${transitionDir}.removing`;
 		installLocalIdentityBindings();
 		setSessionStateLockNativeBindings(() => ({
 			...exactIdentityNativeBindings,
-			exactRemoveDirectoryTree() {
+			exactRemoveDirectoryTree(target) {
+				fsSync.renameSync(target, detachedPath);
 				return {
 					ok: false,
 					code: "cleanup_pending",
 					payloadDurable: false,
-					detachedPath: `${transitionDir}.removing`,
+					detachedPath,
 				};
 			},
 		}));
@@ -179,7 +181,8 @@ describe("session-state lock forced-exit recovery", () => {
 		await expect(withSessionStateFileLock(stateFile, async () => "not-entered")).rejects.toBeInstanceOf(
 			SessionStateLockUnavailableError,
 		);
-		expect(await fs.exists(transitionDir)).toBe(true);
+		expect(await fs.exists(transitionDir)).toBe(false);
+		expect(await fs.exists(detachedPath)).toBe(true);
 	});
 
 	it("bounds repeated successful dead-claim reclaims without sleeping", async () => {

--- a/packages/coding-agent/test/session-state-lock-forced-exit.test.ts
+++ b/packages/coding-agent/test/session-state-lock-forced-exit.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	SessionStateLockTestHooks,
+	setSessionStateLockNativeBindings,
+	withSessionStateFileLock,
+} from "../src/gjc-runtime/session-state-lock";
+import { exactIdentityNativeBindings } from "./helpers/exact-identity-natives";
+
+const probe = path.join(import.meta.dir, "fixtures", "session-state-lock-forced-exit-probe.ts");
+const roots: string[] = [];
+
+async function waitForFile(file: string): Promise<void> {
+	for (let attempt = 0; attempt < 200; attempt++) {
+		if (await fs.exists(file)) return;
+		await Bun.sleep(10);
+	}
+	throw new Error(`Timed out waiting for ${file}`);
+}
+
+afterEach(async () => {
+	SessionStateLockTestHooks.ownerHostId = undefined;
+	SessionStateLockTestHooks.legacyOwnerHostId = undefined;
+	SessionStateLockTestHooks.unqualifiedOwnerIsLocal = undefined;
+	setSessionStateLockNativeBindings(undefined);
+	vi.restoreAllMocks();
+	await Promise.all(roots.splice(0).map(root => fs.rm(root, { recursive: true, force: true })));
+});
+
+describe("session-state lock forced-exit recovery", () => {
+	it("keeps SIGTERM bounded and immediately reclaims the dead cleanup owner", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-forced-exit-lock-"));
+		roots.push(root);
+		const stateFile = path.join(root, "runtime-state.json");
+		const child = Bun.spawn([process.execPath, probe, root], {
+			cwd: path.resolve(import.meta.dir, "../../.."),
+			env: { ...process.env, GJC_CLEANUP_DEADLINE_MS: "100" },
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		try {
+			await waitForFile(path.join(root, "ready"));
+			const signaledAt = performance.now();
+			child.kill("SIGTERM");
+			const exit = await Promise.race([child.exited, Bun.sleep(2_000).then(() => "timeout" as const)]);
+			expect(exit).toBe(143);
+			expect(performance.now() - signaledAt).toBeLessThan(1_000);
+			const transitionDir = `${stateFile}.lock.transition`;
+			expect(await fs.exists(transitionDir)).toBe(true);
+			expect(JSON.parse(await fs.readFile(`${transitionDir}.owner`, "utf8"))).toMatchObject({
+				pid: child.pid,
+				owner_host_id: "forced-exit-probe-host",
+			});
+
+			setSessionStateLockNativeBindings(() => exactIdentityNativeBindings);
+			SessionStateLockTestHooks.ownerHostId = () => "forced-exit-probe-host";
+			SessionStateLockTestHooks.legacyOwnerHostId = () => "forced-exit-probe-legacy-host";
+			SessionStateLockTestHooks.unqualifiedOwnerIsLocal = false;
+			const sleep = vi.spyOn(Bun, "sleep");
+
+			await expect(withSessionStateFileLock(stateFile, async () => "resumed")).resolves.toBe("resumed");
+			expect(sleep).not.toHaveBeenCalled();
+			expect(await fs.exists(transitionDir)).toBe(false);
+		} finally {
+			if (child.exitCode === null) {
+				child.kill("SIGKILL");
+				await child.exited;
+			}
+		}
+	}, 10_000);
+});

--- a/packages/coding-agent/test/session-state-lock-forced-exit.test.ts
+++ b/packages/coding-agent/test/session-state-lock-forced-exit.test.ts
@@ -182,6 +182,52 @@ describe("session-state lock forced-exit recovery", () => {
 		expect(await fs.exists(transitionDir)).toBe(true);
 	});
 
+	it("bounds repeated successful dead-claim reclaims without sleeping", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-transition-reclaim-loop-"));
+		roots.push(root);
+		const { stateFile, transitionDir } = await seedDeadTransition(root, "reclaim-loop-0");
+		const ownerFile = `${transitionDir}.owner`;
+		installLocalIdentityBindings();
+		let elapsedMs = 0;
+		vi.spyOn(performance, "now").mockImplementation(() => {
+			const current = elapsedMs;
+			elapsedMs += 1_000;
+			return current;
+		});
+		let reclaims = 0;
+		setSessionStateLockNativeBindings(() => ({
+			...exactIdentityNativeBindings,
+			exactRemoveDirectoryTree(target, snapshot) {
+				const removed = exactIdentityNativeBindings.exactRemoveDirectoryTree(target, snapshot);
+				if (!removed.ok) return removed;
+				reclaims++;
+				if (reclaims >= 4) throw new Error("reclaim loop escaped its deadline");
+				fsSync.rmSync(ownerFile, { force: true });
+				fsSync.mkdirSync(transitionDir);
+				fsSync.writeFileSync(
+					ownerFile,
+					JSON.stringify({
+						pid: DEAD_PID,
+						start_time: "unknown",
+						token: `reclaim-loop-${reclaims}`,
+						owner_host_id: "forced-exit-probe-host",
+					}),
+				);
+				return removed;
+			},
+		}));
+		const sleep = vi.spyOn(Bun, "sleep");
+
+		const failure = await withSessionStateFileLock(stateFile, async () => "not-entered").catch(error => error);
+		expect(failure).toBeInstanceOf(SessionStateLockUnavailableError);
+		expect(failure).toMatchObject({
+			lockPath: transitionDir,
+			reason: "transition_claim_timeout",
+		});
+		expect(reclaims).toBeGreaterThan(1);
+		expect(sleep).not.toHaveBeenCalled();
+	});
+
 	it("immediately retries after exact removal of a dead legacy transition record", async () => {
 		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-legacy-transition-reclaimed-"));
 		roots.push(root);

--- a/packages/coding-agent/test/session-state-lock-forced-exit.test.ts
+++ b/packages/coding-agent/test/session-state-lock-forced-exit.test.ts
@@ -131,4 +131,54 @@ describe("session-state lock forced-exit recovery", () => {
 		expect(await fs.exists(transitionDir)).toBe(false);
 		expect(sleep).toHaveBeenCalled();
 	});
+
+	it("immediately retries after exact removal of a dead legacy transition record", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-legacy-transition-reclaimed-"));
+		roots.push(root);
+		const stateFile = path.join(root, "runtime-state.json");
+		const transitionFile = `${stateFile}.lock.transition`;
+		await fs.writeFile(
+			transitionFile,
+			JSON.stringify({
+				pid: DEAD_PID,
+				start_time: "unknown",
+				token: "legacy-transition-reclaimed",
+				owner_host_id: "forced-exit-probe-host",
+			}),
+		);
+		installLocalIdentityBindings();
+		const sleep = vi.spyOn(Bun, "sleep");
+
+		await expect(withSessionStateFileLock(stateFile, async () => "resumed")).resolves.toBe("resumed");
+		expect(sleep).not.toHaveBeenCalled();
+	});
+
+	it("keeps backoff when a dead legacy transition record disappears during exact removal", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-legacy-transition-not-found-"));
+		roots.push(root);
+		const stateFile = path.join(root, "runtime-state.json");
+		const transitionFile = `${stateFile}.lock.transition`;
+		await fs.writeFile(
+			transitionFile,
+			JSON.stringify({
+				pid: DEAD_PID,
+				start_time: "unknown",
+				token: "legacy-transition-not-found",
+				owner_host_id: "forced-exit-probe-host",
+			}),
+		);
+		installLocalIdentityBindings();
+		setSessionStateLockNativeBindings(() => ({
+			...exactIdentityNativeBindings,
+			exactUnlink(file, identity) {
+				const removed = exactIdentityNativeBindings.exactUnlink(file, identity);
+				if (!removed.ok) return removed;
+				return { ok: false, code: "not_found" };
+			},
+		}));
+		const sleep = vi.spyOn(Bun, "sleep");
+
+		await expect(withSessionStateFileLock(stateFile, async () => "resumed")).resolves.toBe("resumed");
+		expect(sleep).toHaveBeenCalled();
+	});
 });

--- a/packages/coding-agent/test/session-state-lock-forced-exit.test.ts
+++ b/packages/coding-agent/test/session-state-lock-forced-exit.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as fsSync from "node:fs";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import {
 	SessionStateLockTestHooks,
+	SessionStateLockUnavailableError,
 	setSessionStateLockNativeBindings,
 	withSessionStateFileLock,
 } from "../src/gjc-runtime/session-state-lock";
@@ -130,6 +132,54 @@ describe("session-state lock forced-exit recovery", () => {
 		await expect(withSessionStateFileLock(stateFile, async () => "resumed")).resolves.toBe("resumed");
 		expect(await fs.exists(transitionDir)).toBe(false);
 		expect(sleep).toHaveBeenCalled();
+	});
+
+	it("immediately retries after a durable cleanup_pending transition detach", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-transition-cleanup-pending-"));
+		roots.push(root);
+		const { stateFile, transitionDir } = await seedDeadTransition(root, "cleanup-pending-reclaimed");
+		installLocalIdentityBindings();
+		setSessionStateLockNativeBindings(() => ({
+			...exactIdentityNativeBindings,
+			exactRemoveDirectoryTree(target) {
+				const detachedPath = `${target}.removing`;
+				fsSync.renameSync(target, detachedPath);
+				return {
+					ok: false,
+					code: "cleanup_pending",
+					payloadDurable: true,
+					detachedPath,
+				};
+			},
+		}));
+		const sleep = vi.spyOn(Bun, "sleep");
+
+		await expect(withSessionStateFileLock(stateFile, async () => "resumed")).resolves.toBe("resumed");
+		expect(sleep).not.toHaveBeenCalled();
+		expect(await fs.exists(`${transitionDir}.removing`)).toBe(false);
+	});
+
+	it("refuses a cleanup_pending transition receipt that is not durable", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-transition-cleanup-refused-"));
+		roots.push(root);
+		const { stateFile, transitionDir } = await seedDeadTransition(root, "cleanup-pending-refused");
+		installLocalIdentityBindings();
+		setSessionStateLockNativeBindings(() => ({
+			...exactIdentityNativeBindings,
+			exactRemoveDirectoryTree() {
+				return {
+					ok: false,
+					code: "cleanup_pending",
+					payloadDurable: false,
+					detachedPath: `${transitionDir}.removing`,
+				};
+			},
+		}));
+
+		await expect(withSessionStateFileLock(stateFile, async () => "not-entered")).rejects.toBeInstanceOf(
+			SessionStateLockUnavailableError,
+		);
+		expect(await fs.exists(transitionDir)).toBe(true);
 	});
 
 	it("immediately retries after exact removal of a dead legacy transition record", async () => {

--- a/packages/coding-agent/test/session-state-lock-forced-exit.test.ts
+++ b/packages/coding-agent/test/session-state-lock-forced-exit.test.ts
@@ -11,6 +11,7 @@ import { exactIdentityNativeBindings } from "./helpers/exact-identity-natives";
 
 const probe = path.join(import.meta.dir, "fixtures", "session-state-lock-forced-exit-probe.ts");
 const roots: string[] = [];
+const DEAD_PID = 2 ** 22 - 1;
 
 async function waitForFile(file: string): Promise<void> {
 	for (let attempt = 0; attempt < 200; attempt++) {
@@ -20,10 +21,34 @@ async function waitForFile(file: string): Promise<void> {
 	throw new Error(`Timed out waiting for ${file}`);
 }
 
+async function seedDeadTransition(root: string, token: string): Promise<{ stateFile: string; transitionDir: string }> {
+	const stateFile = path.join(root, "runtime-state.json");
+	const transitionDir = `${stateFile}.lock.transition`;
+	await fs.mkdir(transitionDir);
+	await fs.writeFile(
+		`${transitionDir}.owner`,
+		JSON.stringify({
+			pid: DEAD_PID,
+			start_time: "unknown",
+			token,
+			owner_host_id: "forced-exit-probe-host",
+		}),
+	);
+	return { stateFile, transitionDir };
+}
+
+function installLocalIdentityBindings(): void {
+	setSessionStateLockNativeBindings(() => exactIdentityNativeBindings);
+	SessionStateLockTestHooks.ownerHostId = () => "forced-exit-probe-host";
+	SessionStateLockTestHooks.legacyOwnerHostId = () => "forced-exit-probe-legacy-host";
+	SessionStateLockTestHooks.unqualifiedOwnerIsLocal = false;
+}
+
 afterEach(async () => {
 	SessionStateLockTestHooks.ownerHostId = undefined;
 	SessionStateLockTestHooks.legacyOwnerHostId = undefined;
 	SessionStateLockTestHooks.unqualifiedOwnerIsLocal = undefined;
+	SessionStateLockTestHooks.afterTransitionClaimContention = undefined;
 	setSessionStateLockNativeBindings(undefined);
 	vi.restoreAllMocks();
 	await Promise.all(roots.splice(0).map(root => fs.rm(root, { recursive: true, force: true })));
@@ -54,10 +79,7 @@ describe("session-state lock forced-exit recovery", () => {
 				owner_host_id: "forced-exit-probe-host",
 			});
 
-			setSessionStateLockNativeBindings(() => exactIdentityNativeBindings);
-			SessionStateLockTestHooks.ownerHostId = () => "forced-exit-probe-host";
-			SessionStateLockTestHooks.legacyOwnerHostId = () => "forced-exit-probe-legacy-host";
-			SessionStateLockTestHooks.unqualifiedOwnerIsLocal = false;
+			installLocalIdentityBindings();
 			const sleep = vi.spyOn(Bun, "sleep");
 
 			await expect(withSessionStateFileLock(stateFile, async () => "resumed")).resolves.toBe("resumed");
@@ -70,4 +92,43 @@ describe("session-state lock forced-exit recovery", () => {
 			}
 		}
 	}, 10_000);
+
+	it("keeps backoff when an EEXIST claim disappears before inspection", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-transition-disappeared-"));
+		roots.push(root);
+		const { stateFile, transitionDir } = await seedDeadTransition(root, "disappeared-before-inspection");
+		installLocalIdentityBindings();
+		let injected = false;
+		SessionStateLockTestHooks.afterTransitionClaimContention = async contended => {
+			if (injected || contended !== transitionDir) return;
+			injected = true;
+			await fs.rm(transitionDir, { recursive: true, force: true });
+			await fs.rm(`${transitionDir}.owner`, { force: true });
+		};
+		const sleep = vi.spyOn(Bun, "sleep");
+
+		await expect(withSessionStateFileLock(stateFile, async () => "resumed")).resolves.toBe("resumed");
+		expect(injected).toBe(true);
+		expect(sleep).toHaveBeenCalled();
+	});
+
+	it("keeps backoff when exact removal reports a lost not_found race", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-transition-not-found-"));
+		roots.push(root);
+		const { stateFile, transitionDir } = await seedDeadTransition(root, "native-not-found-race");
+		installLocalIdentityBindings();
+		setSessionStateLockNativeBindings(() => ({
+			...exactIdentityNativeBindings,
+			exactRemoveDirectoryTree(target, snapshot) {
+				const removed = exactIdentityNativeBindings.exactRemoveDirectoryTree(target, snapshot);
+				if (!removed.ok) return removed;
+				return { ok: false, code: "not_found" };
+			},
+		}));
+		const sleep = vi.spyOn(Bun, "sleep");
+
+		await expect(withSessionStateFileLock(stateFile, async () => "resumed")).resolves.toBe("resumed");
+		expect(await fs.exists(transitionDir)).toBe(false);
+		expect(sleep).toHaveBeenCalled();
+	});
 });


### PR DESCRIPTION
## What

- Return whether stale transition-claim recovery actually freed the claim.
- Retry `mkdir` immediately after positive same-installation dead-owner proof and identity-bound removal.
- Add a subprocess regression that strands a claim during release, proves SIGTERM exits 143 within the deadline, and proves the next acquirer resumes without entering lock backoff.

## Why

Fixes #5216.

A forced exit must not perform synchronous JavaScript filesystem cleanup: blocking NFS/CIFS/FUSE calls cannot be bounded after the async cleanup deadline. The safe reader-side path already verifies host identity, PID/start-time liveness, and the exact transition-tree generation before removal; this change removes the unconditional retry sleep after that removal succeeds.

The corruption-style diagnostic half landed separately in #5207 and is preserved here through the live `dev` base. The rejected synchronous terminal-tombstone implementation remains preserved only on `wip/forced-exit-lock-release-5207` at `6e1b4d024a`; none of that exit hook or synchronous I/O is re-landed.

## Testing

- Red test before implementation: `bun test packages/coding-agent/test/session-state-lock-forced-exit.test.ts` — 0 pass, 1 fail; the successor entered one `Bun.sleep` backoff after successful reclaim.
- `bun test packages/coding-agent/test/session-state-lock-forced-exit.test.ts packages/coding-agent/test/session-state-lock.test.ts packages/coding-agent/test/session-state-lock-debris-subprocess.test.ts` — 110 pass, 0 fail, including bounded repeated successful reclaims, atomic and legacy positive reclaim, durable `cleanup_pending`, non-durable refusal, EEXIST→ENOENT, and native `not_found` races.
- `bun test packages/coding-agent/test/session-state-sidecar.test.ts` — 160 pass, 0 fail.
- `bunx biome check packages/coding-agent/src/gjc-runtime/session-state-lock.ts packages/coding-agent/test/session-state-lock-forced-exit.test.ts packages/coding-agent/test/fixtures/session-state-lock-forced-exit-probe.ts packages/coding-agent/CHANGELOG.md` — no errors; two pre-existing optional-chain warnings in `session-state-lock.ts` remain unchanged.

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:1de826fbfdaa3c97105e9e00c17b119a3a1f3a1b95fb27d6f614c3e0df5005c7 reviewer:architect reviewer-id:Yeachan-Heo evidence:owner-directed-determinate-lock-review-and-targeted-exact-head-verification
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*