### PR TITLE
fix(skills): auto-discover marketplace plugin skills and diagnose dangling scan roots

### DIFF
--- a/packages/coding-agent/src/cli/plugin-cli.ts
+++ b/packages/coding-agent/src/cli/plugin-cli.ts
@@ -886,7 +886,9 @@ async function handleLink(manager: PluginManager, paths: string[], flags: { json
 	}
 }
 
-async function collectMarketplaceDoctorChecks(): Promise<Array<{ name: string; status: "ok" | "warning" | "error"; message: string }>> {
+async function collectMarketplaceDoctorChecks(): Promise<
+	Array<{ name: string; status: "ok" | "warning" | "error"; message: string }>
+> {
 	const extra: Array<{ name: string; status: "ok" | "warning" | "error"; message: string }> = [];
 	try {
 		const mktMgr = await makeMarketplaceManager();

--- a/packages/coding-agent/src/cli/plugin-cli.ts
+++ b/packages/coding-agent/src/cli/plugin-cli.ts
@@ -886,11 +886,38 @@ async function handleLink(manager: PluginManager, paths: string[], flags: { json
 	}
 }
 
+async function collectMarketplaceDoctorChecks(): Promise<Array<{ name: string; status: "ok" | "warning" | "error"; message: string }>> {
+	const extra: Array<{ name: string; status: "ok" | "warning" | "error"; message: string }> = [];
+	try {
+		const mktMgr = await makeMarketplaceManager();
+		const installed = await mktMgr.listInstalledPlugins();
+		for (const summary of installed) {
+			for (const entry of summary.entries) {
+				let exists = false;
+				try {
+					const { statSync } = await import("node:fs");
+					statSync(entry.installPath);
+					exists = true;
+				} catch {}
+				if (!exists) {
+					extra.push({
+						name: `marketplace:${summary.id}:${entry.scope}`,
+						status: "error",
+						message: `Marketplace plugin "${summary.id}" (${entry.scope}) references missing cache dir "${entry.installPath}" (v${entry.version}); reinstall or upgrade the plugin`,
+					});
+				}
+			}
+		}
+	} catch {}
+	return extra;
+}
+
 async function handleDoctor(
 	manager: PluginManager,
 	flags: { json?: boolean; fix?: boolean; migratePlugins?: boolean },
 ): Promise<void> {
 	const checks = await manager.doctor({ fix: flags.fix });
+	checks.push(...(await collectMarketplaceDoctorChecks()));
 	try {
 		const statuses = flags.migratePlugins
 			? await runGjcPluginMigrationPreflight(getProjectDir())

--- a/packages/coding-agent/src/extensibility/runtime-skill-discovery.ts
+++ b/packages/coding-agent/src/extensibility/runtime-skill-discovery.ts
@@ -1,20 +1,13 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { getTrustedHomeDir } from "@gajae-code/utils";
-import { findRepoRoot } from "../capability/fs";
+import { getPluginsDir, getTrustedHomeDir } from "@gajae-code/utils";
+import { findRepoRoot, invalidate as invalidateFsCache } from "../capability/fs";
 import type { Skill as CapabilitySkill } from "../capability/skill";
 import type { SkillsSettings } from "../config/settings-schema";
 import { resolveSkillScopeTrust } from "../config/skill-settings-defaults";
 import { scanClaudeProjectSkills, scanClaudeUserSkills } from "../discovery/claude";
 import { scanCodexProjectSkills, scanCodexUserSkills } from "../discovery/codex";
-import {
-	compareSkillOrder,
-	listClaudePluginRoots,
-	SOURCE_PATHS,
-	scanSkillsFromDir,
-} from "../discovery/helpers";
-import { invalidate as invalidateFsCache } from "../capability/fs";
-import { getPluginsDir } from "@gajae-code/utils";
+import { compareSkillOrder, listClaudePluginRoots, SOURCE_PATHS, scanSkillsFromDir } from "../discovery/helpers";
 import { CANONICAL_GJC_WORKFLOW_SKILLS } from "../skill-state/canonical-skills";
 import { expandTilde } from "../tools/path-utils";
 import type { Skill } from "./skills";
@@ -261,10 +254,7 @@ async function collectPluginSkillDirs(
 	}
 }
 
-async function diagnoseCustomDir(
-	expandedDir: string,
-	diagnostics: string[],
-): Promise<boolean> {
+async function diagnoseCustomDir(expandedDir: string, diagnostics: string[]): Promise<boolean> {
 	try {
 		const stat = await fs.lstat(expandedDir);
 		if (stat.isSymbolicLink()) {
@@ -571,12 +561,15 @@ export async function findRuntimeSkillByName(
 			for (const entry of pluginDirs) {
 				if (!sourceEnabled(entry.level, policy)) continue;
 				scanJobs.push(
-					scanSkillsFromDir({ cwd, home, repoRoot: home }, {
-						dir: entry.dir,
-						providerId: "plugin",
-						level: entry.level,
-						requireDescription: true,
-					}).then(result => {
+					scanSkillsFromDir(
+						{ cwd, home, repoRoot: home },
+						{
+							dir: entry.dir,
+							providerId: "plugin",
+							level: entry.level,
+							requireDescription: true,
+						},
+					).then(result => {
 						for (const skill of result.items) skill.name = `${entry.pluginName}:${skill.name}`;
 						return result.items.map(skill => ({ skill, source: entry.level as RuntimeSkillDiscoverySource }));
 					}),

--- a/packages/coding-agent/src/extensibility/runtime-skill-discovery.ts
+++ b/packages/coding-agent/src/extensibility/runtime-skill-discovery.ts
@@ -7,7 +7,14 @@ import type { SkillsSettings } from "../config/settings-schema";
 import { resolveSkillScopeTrust } from "../config/skill-settings-defaults";
 import { scanClaudeProjectSkills, scanClaudeUserSkills } from "../discovery/claude";
 import { scanCodexProjectSkills, scanCodexUserSkills } from "../discovery/codex";
-import { compareSkillOrder, SOURCE_PATHS, scanSkillsFromDir } from "../discovery/helpers";
+import {
+	compareSkillOrder,
+	listClaudePluginRoots,
+	SOURCE_PATHS,
+	scanSkillsFromDir,
+} from "../discovery/helpers";
+import { invalidate as invalidateFsCache } from "../capability/fs";
+import { getPluginsDir } from "@gajae-code/utils";
 import { CANONICAL_GJC_WORKFLOW_SKILLS } from "../skill-state/canonical-skills";
 import { expandTilde } from "../tools/path-utils";
 import type { Skill } from "./skills";
@@ -234,6 +241,56 @@ function pushDiagnostic(diagnostics: string[], message: string): void {
 	if (diagnostics.length < MAX_DIAGNOSTICS) diagnostics.push(message);
 }
 
+async function collectPluginSkillDirs(
+	home: string,
+	cwd: string,
+): Promise<Array<{ dir: string; pluginName: string; level: "user" | "project" }>> {
+	// Ensure the underlying installed_plugins.json fs cache is current — install/upgrade
+	// writers already invalidate via clearPluginRootsAndCaches; this is a defensive
+	// fallback so a stale in-memory cache cannot mask a disabled/removed plugin.
+	invalidateFsCache(`${getPluginsDir(home)}/installed_plugins.json`);
+	try {
+		const { roots } = await listClaudePluginRoots(home, cwd);
+		return roots.map(root => ({
+			dir: `${root.path}/skills`,
+			pluginName: root.plugin,
+			level: root.scope,
+		}));
+	} catch {
+		return [];
+	}
+}
+
+async function diagnoseCustomDir(
+	expandedDir: string,
+	diagnostics: string[],
+): Promise<boolean> {
+	try {
+		const stat = await fs.lstat(expandedDir);
+		if (stat.isSymbolicLink()) {
+			try {
+				await fs.stat(expandedDir);
+			} catch {
+				pushDiagnostic(
+					diagnostics,
+					`skills.customDirectories entry "${expandedDir}" is a dangling symlink (target missing, likely a purged plugin cache dir); fix or remove it`,
+				);
+				return true;
+			}
+		}
+		return false;
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+			pushDiagnostic(
+				diagnostics,
+				`skills.customDirectories entry "${expandedDir}" does not exist (missing directory, likely a purged plugin cache dir); fix or remove it`,
+			);
+			return true;
+		}
+		return false;
+	}
+}
+
 async function scanProjectOrUserDir(
 	ctx: { cwd: string; home: string; repoRoot: string | null },
 	dir: string,
@@ -376,6 +433,44 @@ export async function discoverRuntimeSkills(
 		}
 	}
 
+	// Marketplace plugin skills: version-stable, enabled-only.
+	// Uses the same trust gate as native user/project scopes and the same
+	// discovery root (<installPath>/skills) the capability provider uses,
+	// namespaced as `plugin:skillName`.
+	if (policy?.enabled === true) {
+		const pluginDirs = await collectPluginSkillDirs(home, options.cwd);
+		for (const entry of pluginDirs) {
+			if (entry.level === "project" && !(source === "all" || source === "project")) continue;
+			if (entry.level === "user" && !(source === "all" || source === "user")) continue;
+			if (!sourceEnabled(entry.level, policy)) continue;
+			const label = `plugin ${entry.pluginName} skills`;
+			scanJobs.push(
+				(async () => {
+					const pluginCtx = { cwd: options.cwd, home, repoRoot: home };
+					const result = await scanSkillsFromDir(pluginCtx, {
+						dir: entry.dir,
+						providerId: "plugin",
+						level: entry.level,
+						requireDescription: true,
+					});
+					for (const skill of result.items) {
+						skill.name = `${entry.pluginName}:${skill.name}`;
+					}
+					return {
+						items: result.items.map(skill => ({ skill, source: entry.level as RuntimeSkillDiscoverySource })),
+						warnings: result.warnings ?? [],
+						label,
+					};
+				})(),
+			);
+		}
+	}
+	if (policy?.enabled === true && policy.customDirectories && policy.customDirectories.length > 0) {
+		for (const dir of getCustomSkillDirs(policy, home)) {
+			await diagnoseCustomDir(dir, diagnostics);
+		}
+	}
+
 	const settled = await Promise.all(scanJobs.map(job => job.catch(error => ({ error: String(error), label: "" }))));
 
 	const seenNames = new Set<string>();
@@ -469,6 +564,25 @@ export async function findRuntimeSkillByName(
 				).then(result => result.items.map(skill => ({ skill, source: "user" as const }))),
 			);
 		}
+	}
+	if (policy?.enabled === true) {
+		try {
+			const pluginDirs = await collectPluginSkillDirs(home, cwd);
+			for (const entry of pluginDirs) {
+				if (!sourceEnabled(entry.level, policy)) continue;
+				scanJobs.push(
+					scanSkillsFromDir({ cwd, home, repoRoot: home }, {
+						dir: entry.dir,
+						providerId: "plugin",
+						level: entry.level,
+						requireDescription: true,
+					}).then(result => {
+						for (const skill of result.items) skill.name = `${entry.pluginName}:${skill.name}`;
+						return result.items.map(skill => ({ skill, source: entry.level as RuntimeSkillDiscoverySource }));
+					}),
+				);
+			}
+		} catch {}
 	}
 	for (const entry of (await Promise.all(scanJobs)).flat()) {
 		if (entry.skill.name === normalized && isAllowedByPolicy(entry.skill, policy, [])) {


### PR DESCRIPTION
Fixes #5212

## What

Marketplace-installed plugin skills (`~/.gjc/plugins/cache/plugins/<name>___<name>___<version>/skills/<name>/SKILL.md`) were invisible to `gjc skills discover` and `skill_discovery`. Plugin skills are now auto-discovered from every *enabled* plugin's `<installPath>/skills`, namespaced as `plugin:skill` (matching the existing `claude-plugins` capability provider's convention). The namespacing and trust gating prevent silent shadowing of project (`.gjc/skills`) / user skills and of the protected bundled workflows (`autoresearch`, `deep-interview`, `ralplan`, `ultragoal`).

## Why

The marketplace docs imply installed plugins ship skills, and every operator workaround was version-qualified: `skills.customDirectories` pointing at a versioned cache dir dangles on every `plugin upgrade` (old cache dir purged). Reporter's decay scenario: a symlink to `___0.5.5` kept pointing at the old cache while `installed_plugins.json` already said `0.13.0`, yielding weeks of silent zero results.

## Testing

- `skill-discovery.test.ts`: 21 existing tests pass.
- Targeted ad-hoc run (temp home `installed_plugins.json` + fake marketplace cache): verified (a) enabled plugin skills appear as `craft-skills:hello` and `craft-skills:other` while a bundled-name impostor (`ralplan`) inside a plugin is filtered; (b) `enabled:false` plugin contributes nothing; (c) a `skills.customDirectories` entry that is a dangling symlink (simulated upgrade purging old `___0.13.0` dir) yields an explicit diagnostic instead of a silent zero; (d) after version bump `___0.13.0` -> `___0.14.1` discovery still resolves plugin skills from the new installPath without any operator relink; (e) a native project skill and a plugin namespaced skill coexist without shadowing ("`other`" vs `"craft-skills:other"`).

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:2269f0dfa6d6dce4ab454e9da66a5d3e7ff05fc72cb9e48cae48a08ec9ec368c reviewer:human reviewer-id:Yeachan-Heo evidence:local-skill-discovery-21-pass-and-5212-adhoc-9-expect
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*