### PR TITLE
fix(editor): flush and re-arm Windows console before external editor (#5224)

### DIFF
--- a/packages/coding-agent/src/utils/external-editor.ts
+++ b/packages/coding-agent/src/utils/external-editor.ts
@@ -1,6 +1,7 @@
 /**
  * Utilities for launching an external text editor ($VISUAL / $EDITOR).
  */
+import { dlopen, FFIType, ptr } from "bun:ffi";
 import { spawn } from "node:child_process";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
@@ -27,6 +28,61 @@ export function trimEditorTrailingNewline(text: string): string {
 }
 
 /**
+ * On Windows the console input buffer is shared between the parent and the
+ * child. When the parent TUI stops it restores the console to cooked mode
+ * (ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT) and disables
+ * ENABLE_VIRTUAL_TERMINAL_INPUT. A child TUI such as Neovim then inherits
+ * that cooked state: the very next keystroke is line-buffered until an
+ * Enter flushes it — exactly the "first i is swallowed, Enter fixes it"
+ * symptom reported in #5224.
+ *
+ * Neovim (via libuv's uv_tty) re-enables raw VT input on startup, but the
+ * race window between the parent's restore and the child's init is enough
+ * to deterministically line-buffer the first typed keystroke when the child
+ * is spawned through `cmd.exe` (`shell: true`), because `cmd` itself keeps
+ * the console in cooked mode while it waits for the child.
+ *
+ * To make the handover symmetric:
+ *  - flush any pending console input left over from the parent (e.g. probe
+ *    reply fragments that were already read into the kernel buffer), and
+ *  - leave the console in raw VT mode (VT on, LINE/ECHO off) so the child
+ *    inherits an immediately-usable mode; the caller's `ui.start()` will
+ *    reconcile the mode again when the editor exits.
+ */
+const STD_INPUT_HANDLE = -10;
+const ENABLE_LINE_INPUT = 0x0002;
+const ENABLE_ECHO_INPUT = 0x0004;
+const ENABLE_WINDOW_INPUT = 0x0008;
+const ENABLE_VIRTUAL_TERMINAL_INPUT = 0x0200;
+
+function prepareWindowsConsoleForExternalEditor(): void {
+	if (process.platform !== "win32") return;
+	try {
+		const kernel32 = dlopen("kernel32.dll", {
+			GetStdHandle: { args: [FFIType.i32], returns: FFIType.ptr },
+			GetConsoleMode: { args: [FFIType.ptr, FFIType.ptr], returns: FFIType.bool },
+			SetConsoleMode: { args: [FFIType.ptr, FFIType.u32], returns: FFIType.bool },
+			FlushConsoleInputBuffer: { args: [FFIType.ptr], returns: FFIType.bool },
+		});
+		const handle = kernel32.symbols.GetStdHandle(STD_INPUT_HANDLE);
+		try {
+			kernel32.symbols.FlushConsoleInputBuffer(handle);
+		} catch {}
+		const mode = new Uint32Array(1);
+		const modePtr = ptr(mode);
+		if (modePtr && kernel32.symbols.GetConsoleMode(handle, modePtr)) {
+			const cur = mode[0]!;
+			const next =
+				(cur | ENABLE_VIRTUAL_TERMINAL_INPUT | ENABLE_WINDOW_INPUT) & ~(ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT);
+			if (next !== cur) {
+				kernel32.symbols.SetConsoleMode(handle, next);
+			}
+		}
+		kernel32.close();
+	} catch {}
+}
+
+/**
  * Opens `content` in the user's external editor and returns the edited text.
  * Returns `null` if the editor exits with a non-zero code.
  *
@@ -45,6 +101,8 @@ export async function openInEditor(
 
 		const [editor, ...editorArgs] = editorCmd.split(" ");
 		const stdio = options?.stdio ?? ["inherit", "inherit", "inherit"];
+
+		prepareWindowsConsoleForExternalEditor();
 
 		const child = spawn(editor, [...editorArgs, tmpFile], { stdio, shell: process.platform === "win32" });
 		const { promise, reject, resolve } = Promise.withResolvers<number>();


### PR DESCRIPTION
## What

On Windows, `Ctrl+G` leaves the console in cooked mode (`ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT`) and clears `ENABLE_VIRTUAL_TERMINAL_INPUT` when the TUI stops. A child TUI such as Neovim then inherits cooked mode through `cmd.exe` (`shell: true`), so the first typed key is line-buffered until `Enter` — the exact symptom in #5224 (first `i` swallowed, `Enter` fixes it; repeats every open; also reproduces outside `psmux`).

Fix: just before `spawn`, flush any pending console input and re-arm raw VT mode (`VT+WINDOW` on, `LINE+ECHO` off). The parent's `ui.start()` reconciles the mode again when the editor exits. No-op on non-Windows/POSIX (guarded by `process.platform !== "win32"`), so the POSIX path is unchanged.

## Why

The handover was asymmetric: the parent restored cooked mode before the hand-off but never prepared the console for the child. The symmetric contract is "release the terminal fully before spawn, re-acquire after exit" scoped to console flags. The fix is minimal (one call site: `openInEditor` in `packages/coding-agent/src/utils/external-editor.ts`) and uses `bun:ffi`/`kernel32` consistently with `packages/tui/src/terminal.ts`.

## Risk

- `low-risk`
- Single code path (`openInEditor`), Windows-only runtime effect, failure is best-effort (editor still launches).
- No public API surface change. `bun:ffi` unavailable → editor still opens (flush/mode is non-fatal).

## Tested

- `bun --cwd packages/coding-agent tsc --noEmit` — pass
- `bun --cwd packages/coding-agent test test/utils/external-editor.test.ts` — 3/3 pass (POSIX-trailing-newline contract unchanged)
- `npx @biomejs/biome check` — pass
- `origin/dev` head is `96cc179ba0b8824647b17befd7936f79404c58e6`; current head is `59307305d0ebb43c74c960873433bc8a09c3ca83` (single commit on this branch).

## Notes

I am on Linux and cannot reproduce native Windows console behavior directly. Verification request is in #5224. `origin/dev`'s biome state is clean (`session-cli.ts:1489` is clean at this base); if CI shows a formatter red it is not from this diff.

Fixes #5224

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:ee5239a9022470257d38ee8aed1c19cf1dad0fbd6825a60cbc66dbd563f1abee reviewer:human reviewer-id:Yeachan-Heo evidence:local tsc + focused external-editor tests (POSIX path unchanged) + diff digest recomputed locally
```
