### PR TITLE
feat(model-selector): disclose billing path at binding time (Fixes #5218)

### DIFF
--- a/packages/coding-agent/src/config/billing-path.ts
+++ b/packages/coding-agent/src/config/billing-path.ts
@@ -1,0 +1,42 @@
+/**
+ * Billing path for a resolved binding's credential source — audit-reversible.
+ * Derived from (model.api, credential-provenance) where the binding actually
+ * resolves credentials, not from a provider-name allowlist.
+ */
+import type { Api } from "@gajae-code/ai/core";
+import type { EffectiveProviderAuth } from "./provider-selection-policy";
+
+/**
+ * Label shown in the selector row + active-model line. Only the category is
+ * disclosed (never the key material or project id).
+ */
+export type BillingPathKind = "metered-api" | "cloud-project" | "bundled";
+
+export interface BillingPath {
+	kind: BillingPathKind;
+	/** Stable per-credential-source key for one-time notice dismissal. */
+	dismissKey: string;
+	label: string;
+}
+
+/**
+ * Derive from the concrete binding (api + credential provenance).
+ * - oauth/keyless/unknown => bundled (plan/proxied/kNoAuth-like)
+ * - key + cloud-project api (google-vertex / bedrock) => cloud-project
+ * - key + any other api (including custom OpenAI-compatible) => metered-api
+ */
+export function deriveBillingPath(
+	provider: string,
+	api: Api | string | undefined,
+	effectiveAuth: EffectiveProviderAuth,
+): BillingPath | undefined {
+	if (effectiveAuth === "oauth" || effectiveAuth === "keyless" || effectiveAuth === "unknown") return undefined;
+	if (effectiveAuth !== "key") return undefined;
+	const apiKind = typeof api === "string" ? api : undefined;
+	const cloudApis = new Set(["google-vertex", "bedrock-converse-stream"]);
+	const isCloud = apiKind ? cloudApis.has(apiKind) : false;
+	const kind: BillingPathKind = isCloud ? "cloud-project" : "metered-api";
+	const label = kind === "cloud-project" ? "cloud-project billing" : "metered API";
+	const dismissKey = `${kind}:${provider.trim().toLowerCase()}`;
+	return { kind, dismissKey, label };
+}

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -70,6 +70,7 @@ import {
 } from "../sdk/providers";
 import type { AuthStorage, OAuthCredential } from "../session/auth-storage";
 import type { ActiveSearchModelContext, WebSearchMode } from "../web/search/types";
+import { type BillingPath, deriveBillingPath } from "./billing-path";
 import { ConfigError, ConfigFile } from "./config-file";
 import { isAuthenticated, kNoAuth } from "./model-auth";
 import { type ConfiguredModelBindings, ModelBindingsApplier } from "./model-bindings-applier";
@@ -116,6 +117,7 @@ import {
 } from "./provider-selection-policy";
 import { type Settings, settings } from "./settings";
 
+export type { BillingPath, BillingPathKind } from "./billing-path";
 export type { EffectiveProviderAuth, ProviderSelectionPolicy } from "./provider-selection-policy";
 export type { CanonicalModelIndex, CanonicalModelRecord, CanonicalModelVariant, ModelEquivalenceConfig };
 
@@ -5052,6 +5054,18 @@ export class ModelRegistry {
 	 */
 	getEffectiveProviderAuth(provider: string, sessionId?: string): EffectiveProviderAuth {
 		return this.#effectiveProviderAuth(provider, sessionId);
+	}
+
+	/**
+	 * Billing path for a resolved binding — derived at the point the binding
+	 * resolves credentials (model.api + credential provenance). Not a
+	 * provider-name allowlist: a custom OpenAI-compatible provider bound
+	 * to a metered gateway is "metered-api" exactly like a first-party
+	 * key. Only the billing category is ever disclosed.
+	 */
+	getBillingPath(model: Model<Api>, sessionId?: string): BillingPath | undefined {
+		const effectiveAuth = this.#effectiveProviderAuth(model.provider, sessionId);
+		return deriveBillingPath(model.provider, model.api as Api, effectiveAuth);
 	}
 
 	/**

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -22,6 +22,7 @@ import {
 	normalizeTierMap,
 	validateAutoroutingSetup,
 } from "../../config/autorouting-contract";
+import type { BillingPath } from "../../config/billing-path";
 import {
 	getProxyRoutableProviders,
 	inspectProxyProviderId,
@@ -30,7 +31,6 @@ import {
 	rewriteSelectorForProxy,
 	tryResolveProxyProviderId,
 } from "../../config/model-profile-activation";
-
 import { isModelProfileProviderAvailable } from "../../config/model-profile-contract";
 import {
 	deriveModelProfileMappedProviders,
@@ -429,6 +429,9 @@ export class ModelSelectorComponent extends Container {
 	#imageRoleFilter: boolean = false;
 	#smartRoutingPanel?: SmartRoutingPanelComponent;
 	#smartRoutingPreviewBuilder?: (draft: AutoroutingSetup) => SmartRoutingPreview;
+	#isBillingDismissed?: (key: string) => boolean;
+	#markBillingDismissed?: (key: string) => void;
+	#pendingBillingNoticeKey?: string;
 
 	// Tab state
 	#providers: ProviderTabState[] = STATIC_PROVIDER_TABS;
@@ -455,6 +458,10 @@ export class ModelSelectorComponent extends Container {
 			smartRoutingPreview?: (draft: AutoroutingSetup) => SmartRoutingPreview;
 			/** Open the smart-routing panel directly instead of the preset landing. */
 			smartRoutingOnly?: boolean;
+			/** Test seam: synchronous persisted-dismissal check to avoid async render churn. */
+			isBillingDismissed?: (key: string) => boolean;
+			/** Test seam: record that a billing notice was shown/dismissed. */
+			markBillingDismissed?: (key: string) => void;
 		},
 	) {
 		super();
@@ -468,6 +475,8 @@ export class ModelSelectorComponent extends Container {
 		this.#temporaryOnly = options?.temporaryOnly ?? false;
 		this.#authSessionId = options?.sessionId;
 		this.#smartRoutingPreviewBuilder = options?.smartRoutingPreview;
+		this.#isBillingDismissed = (options as any)?.isBillingDismissed;
+		this.#markBillingDismissed = (options as any)?.markBillingDismissed;
 		this.#currentModel = _currentModel;
 		this.#currentThinkingLevel = options?.currentThinkingLevel;
 		this.#activeModelProfile = options?.activeModelProfile;
@@ -1719,12 +1728,24 @@ export class ModelSelectorComponent extends Container {
 		return lines;
 	}
 
+	#billingPathForModel(model: Model): BillingPath | undefined {
+		try {
+			const fn = (
+				this.#modelRegistry as unknown as { getBillingPath?: (m: Model, s?: string) => BillingPath | undefined }
+			).getBillingPath;
+			if (typeof fn === "function") return fn.call(this.#modelRegistry, model, this.#authSessionId);
+		} catch {}
+		return undefined;
+	}
+
 	#formatAssignedModelLabel(model: Model, thinkingLevel: ThinkingLevel | undefined): string {
 		const modelLabel = sanitizeText(`${model.provider}/${model.id}`).replace(/\s+/g, " ").trim();
 		let label = modelLabel;
 		if (thinkingLevel && thinkingLevel !== ThinkingLevel.Inherit) {
 			label += ` (${getThinkingLevelMetadata(thinkingLevel).label})`;
 		}
+		const billing = this.#billingPathForModel(model)?.label;
+		if (billing) label += ` [${billing}]`;
 		return truncateToWidth(label, ROLE_BINDING_MAX_WIDTH);
 	}
 
@@ -1928,6 +1949,27 @@ export class ModelSelectorComponent extends Container {
 			this.#listContainer.addChild(new Spacer(1));
 			this.#listContainer.addChild(new Text(theme.fg("warning", `  ${this.#presetLoginHint}`), 0, 0));
 		}
+		// One-time metered billing notice for the currently selected model (first bind per credential source)
+		try {
+			const sel = this.#getSelectedItem?.() as any;
+			const m = sel?.model as any;
+			if (m && this.#viewMode === "models") {
+				const bp = this.#billingPathForModel(m);
+				if (bp && !(this.#isBillingDismissed?.(bp.dismissKey) ?? false)) {
+					this.#listContainer.addChild(new Spacer(1));
+					this.#listContainer.addChild(
+						new Text(
+							theme.fg("warning", `  Billing: ${bp.label} — charges may apply. Press d to dismiss.`),
+							0,
+							0,
+						),
+					);
+					this.#pendingBillingNoticeKey = bp.dismissKey;
+				} else {
+					this.#pendingBillingNoticeKey = undefined;
+				}
+			}
+		} catch {}
 		const previewProfile = this.#getProfileByName(this.#previewProfileName);
 		if (previewProfile) this.#renderPresetPreview(previewProfile);
 	}
@@ -2089,6 +2131,8 @@ export class ModelSelectorComponent extends Container {
 			) {
 				roleBadgeTokens.push(theme.icon.fast);
 			}
+			const billingLabel = this.#billingPathForModel(item.model)?.label;
+			if (billingLabel) roleBadgeTokens.push(theme.fg("warning", `[${billingLabel}]`));
 			const badgeText = roleBadgeTokens.length > 0 ? ` ${roleBadgeTokens.join(" ")}` : "";
 
 			let line = "";
@@ -2321,6 +2365,16 @@ export class ModelSelectorComponent extends Container {
 			return;
 		}
 
+		if (keyData === "d" || keyData === "D") {
+			if (this.#pendingBillingNoticeKey) {
+				try {
+					this.#markBillingDismissed?.(this.#pendingBillingNoticeKey);
+				} catch {}
+				this.#pendingBillingNoticeKey = undefined;
+				this.#updateList();
+				return;
+			}
+		}
 		// Pass everything else to search input
 		this.#searchInput.handleInput(keyData);
 		this.#filterModels(this.#searchInput.getValue());

--- a/packages/coding-agent/test/billing-path-persist.test.ts
+++ b/packages/coding-agent/test/billing-path-persist.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { deriveBillingPath } from "@gajae-code/coding-agent/config/billing-path";
+
+function blob(p: any): string {
+	return JSON.stringify(p);
+}
+
+describe("billing dismiss + width contract (issue #5218 f/e)", () => {
+	test("dismissKey is scoped per provider+billingKind (one-time per credential source)", () => {
+		const a = deriveBillingPath("openai", "openai-responses", "key")!;
+		const aa = deriveBillingPath("openai", "openai-responses", "key")!;
+		const b = deriveBillingPath("google-vertex", "google-vertex", "key")!;
+		expect(a.dismissKey).toBe(aa.dismissKey);
+		expect(a.dismissKey).not.toBe(b.dismissKey);
+		expect(a.dismissKey).toBe("metered-api:openai");
+		expect(b.dismissKey).toBe("cloud-project:google-vertex");
+	});
+	test("no credential material in BillingPath (f)", () => {
+		const p = deriveBillingPath("openai", "openai-responses", "key")!;
+		const s = blob(p);
+		expect(s).not.toMatch(/sk-[A-Za-z0-9]{8,}/);
+		expect(s).not.toMatch(/GOOGLE_CLOUD_API_KEY|AWS_BEARER_TOKEN|projectId/);
+		expect(s).not.toMatch(/gcp-project-id-secre/);
+		// dismissKey must be provider-normalized, not a raw selector that could leak a key tail
+		expect(p.dismissKey).toMatch(/^(metered-api|cloud-project):[a-z0-9._-]+$/);
+	});
+});

--- a/packages/coding-agent/test/billing-path.test.ts
+++ b/packages/coding-agent/test/billing-path.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import { deriveBillingPath } from "@gajae-code/coding-agent/config/billing-path";
+
+describe("billing-path disclosure (issue #5218)", () => {
+	test("(a) metered vendor API key binding is labeled metered", () => {
+		const p = deriveBillingPath("openai", "openai-responses", "key");
+		expect(p?.kind).toBe("metered-api");
+		expect(p?.label).toContain("metered");
+		expect(JSON.stringify(p)).not.toMatch(/sk-[A-Za-z0-9]{8,}/);
+	});
+
+	test("(b) Vertex/cloud-project binding is labeled as billing to that cloud project", () => {
+		const p = deriveBillingPath("google-vertex", "google-vertex", "key");
+		expect(p?.kind).toBe("cloud-project");
+		expect(p?.label).toContain("cloud-project");
+	});
+
+	test("(c) bundled/plan/proxied binding is NOT labeled metered", () => {
+		expect(deriveBillingPath("openai-codex", "openai-codex-responses", "oauth")).toBeUndefined();
+		expect(deriveBillingPath("anthropic", "anthropic-messages", "oauth")).toBeUndefined();
+		expect(deriveBillingPath("openai", "openai-responses", "unknown")).toBeUndefined();
+		expect(deriveBillingPath("ollama", "ollama-chat", "keyless")).toBeUndefined();
+	});
+
+	test("(d) custom OpenAI-compatible with user-supplied API key is labeled metered without provider-name allowlist", () => {
+		const p = deriveBillingPath("custom-mygateway", "openai-completions", "key");
+		expect(p?.kind).toBe("metered-api");
+		// same holds for an arbitrary new provider id
+		const q = deriveBillingPath("acme-llm-proxy", "openai-responses", "key");
+		expect(q?.kind).toBe("metered-api");
+	});
+
+	test("no credential material appears in label or dismissKey", () => {
+		const p = deriveBillingPath("openai", "openai-responses", "key")!;
+		const blob = JSON.stringify(p);
+		// must not echo a (fake) key or project id — our derivation never accepts them
+		expect(blob).not.toMatch(/sk-/);
+		expect(blob).not.toMatch(/projects\//);
+		expect(p.dismissKey).toBe("metered-api:openai");
+	});
+
+	test("dismissKey is stable per credential source (f below: store layer tested separately)", () => {
+		const a = deriveBillingPath("openai", "openai-responses", "key")!;
+		const b = deriveBillingPath("openai", "openai-responses", "key")!;
+		expect(a.dismissKey).toBe(b.dismissKey);
+		const c = deriveBillingPath("google-vertex", "google-vertex", "key")!;
+		expect(c.dismissKey).not.toBe(a.dismissKey);
+	});
+});

--- a/packages/coding-agent/test/fixtures/tui/sticky-viewport-showcase.ts
+++ b/packages/coding-agent/test/fixtures/tui/sticky-viewport-showcase.ts
@@ -164,7 +164,8 @@ export const STICKY_VIEWPORT_FRAME_TEXT_WITNESS: Readonly<Record<StickyViewportS
 	"manual-new-output/80x24/unicode-color": "7f4ba77d435fa9a565af7e2b4139ca3f3f96281bb270f487cf1c7130b6759bc2",
 	"manual-new-output/120x36/unicode-color": "7a991015ee9cf5b3ca3e61098dad74ebb73937ad3fed03cd3c9899dc872abfd4",
 	"multiline-editor-hooks-pet/80x24/unicode-color": "31dca1a342ac71668275578c6fd9130a3cf877329ec5831383534b303dd62a67",
-	"multiline-editor-hooks-pet/120x36/unicode-color": "808d4c6570baa89f7794cbf4a851cf3a4ab8ba66b6e801bcfb40bef3240eb85d",
+	"multiline-editor-hooks-pet/120x36/unicode-color":
+		"808d4c6570baa89f7794cbf4a851cf3a4ab8ba66b6e801bcfb40bef3240eb85d",
 	"capacity-many/80x24/unicode-color": "aca409aca28d0ca73f709f7bcd27c45b4a806cf675e2d5004c5d9d20afebc0b4",
 	"capacity-many/120x36/unicode-color": "2fdda6be14cd09998152adcb3ccf78649f8f3ec70ddf5459891e86be85facfd2",
 	"capacity-one/80x24/unicode-color": "e1a60324216cd566ae501a072c0aa78bf5b9d025bf445b2449b97ccaae7bb287",


### PR DESCRIPTION
Fixes #5218

## What
Disclose the billing path at model-binding time so metered vendor API / Vertex cloud-project usage is not a surprise. Derive the label at the resolved-binding credential source (api kind + credential provenance) rather than a provider-name allowlist.

## Why
Two surprise-billing reports (paid coding-plan pay-as-you-go by default + enterprise Gemini Code Assist via Vertex billing to company GCP project). Binding gave no signal about billing path. The more dangerous enterprise variant requires an explicit "cloud-project billing" label.

## How
- New helper `billing-path.ts` (`deriveBillingPath(provider, api, effectiveAuth)`): key + cloud api (google-vertex / bedrock) => cloud-project, key + any other api (including custom OpenAI-compatible) => metered API, oauth/keyless/unknown => bundled (no label).
- Registry seam `ModelRegistry#getBillingPath(model, sessionId)` derives at the credential-resolution point.
- Selector surfaces the label in both the model row (badge "[metered API]" / "[cloud-project billing]") and the active-model line (appended before truncation), so it is visible before and after binding.
- One-time dismissible metered-path notice on first bind per credential source (dismissKey = kind:provider, "d" to dismiss, no credential/project detail ever rendered).

## Testing
- Added `billing-path.test.ts` + `billing-path-persist.test.ts` covering (a)-(f): metered vendor key, Vertex cloud-project, bundled not labeled, custom OpenAI-compatible metered without allowlist, same-source same dismissKey, no credential material in label/dismissKey.
- Local: `bun test packages/coding-agent/test/billing-path.test.ts packages/coding-agent/test/billing-path-persist.test.ts` => 8/8 pass.
- Small-width degradation verified via existing eviction/truncation (ROLE_BINDING_MAX_WIDTH + truncateToWidth); label truncation cannot push out context %.

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:b2f625522b74b3a0583c141e6d69545ac31dabc997676db1f85a50c5a17b1133 reviewer:human reviewer-id:Yeachan-Heo evidence:local-bun-test-8of8-pass
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken