### PR TITLE
fix(sdk): allow --scope all outside Git checkout

### DIFF
--- a/packages/coding-agent/src/sdk/cli/session-cli.ts
+++ b/packages/coding-agent/src/sdk/cli/session-cli.ts
@@ -613,14 +613,15 @@ async function workspaceIdentity(target: string): Promise<WorkspaceIdentity> {
 /**
  * Resolves the list selection from `--repo` (default: process cwd) under the
  * effective scope. Outside Git, `repo`/`worktree` fail typed and actionable —
- * they never broaden to `all`; `cwd` remains an exact canonical match.
+ * they never broaden to `all`; `cwd` remains an exact canonical match, and
+ * `all` ignores the selection entirely so it works outside any checkout.
  */
 export async function resolveSessionListSelection(
 	scope: SdkSessionListScope,
 	repoArg: string | undefined,
 ): Promise<SdkSessionListSelection> {
 	const selection = await workspaceIdentity(repoArg ?? process.cwd());
-	if (scope !== "cwd" && !selection.repoRoot)
+	if (scope !== "cwd" && scope !== "all" && !selection.repoRoot)
 		throw new SdkSessionCliError(
 			"not_a_repository",
 			`--scope ${scope} requires a Git repository, but "${selection.canonicalPath}" is outside any Git checkout. ` +

--- a/packages/coding-agent/test/sdk-session-cli-list-scope.test.ts
+++ b/packages/coding-agent/test/sdk-session-cli-list-scope.test.ts
@@ -174,6 +174,14 @@ describe("sdk session list scope filtering", () => {
 			cwdSelection,
 		);
 		expect(filtered.sessions.map(candidate => candidate.sessionId)).toEqual(["s-plain"]);
+		const allSelection = await resolveSessionListSelection("all", plain);
+		expect(allSelection.descriptor.worktreeRoot).toBeUndefined();
+		const everything = await filterSessionRowsByScope(
+			[row("s-plain", plain), row("s-git", tempRoot)],
+			"all",
+			allSelection,
+		);
+		expect(everything.sessions.map(candidate => candidate.sessionId).sort()).toEqual(["s-git", "s-plain"]);
 	});
 
 	test("removed row workspaces are excluded deterministically with a warning", async () => {


### PR DESCRIPTION
## What

Allow `--scope all` to work outside a Git checkout. `filterSessionRowsByScope` already short-circuits to "return all rows" for `all`, so gating on `repoRoot` in `resolveSessionListSelection` incorrectly throws `not_a_repository` from `/tmp` etc.

- `session-cli.ts:resolveSessionListSelection`: `scope !== "cwd" && scope !== "all"`
- Extend `sdk-session-cli-list-scope.test.ts` to cover `all` from a plain directory

## Why

`gjc session list --scope all` should list everything regardless of cwd; `repo`/`worktree` still fail typed outside Git, `cwd` stays exact-path.

## Testing

`bun test sdk-session-cli-list-scope.test.ts` — 13/13 pass locally.

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:609d3d11708b942e8f44930f42579e3639f7b6862623e35c37938a70b07d2608 reviewer:human reviewer-id:Yeachan-Heo evidence:low-risk owner fix; bun test sdk-session-cli-list-scope.test.ts 13 pass; verified gjc-state-gates pass
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken
