### PR TITLE
chore: add .mailmap so one contributor is one identity

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -14,7 +14,7 @@ chulmin-dev <kcm1805@gmail.com> kcm1805 <kcm1805@gmail.com>
 chulmin-dev <kcm1805@gmail.com> chulmin <kcm1805@gmail.com>
 Dayum_gud <239489026+project820@users.noreply.github.com> project820 <239489026+project820@users.noreply.github.com>
 dbc-hbin <dion9310@gmail.com> hanbinnoh <dion9310@gmail.com>
-DoYunHa <102889891+had0yun@users.noreply.github.com> HaD0Yun <102889891+had0yun@users.noreply.github.com>
+DoYunHa <102889891+HaD0Yun@users.noreply.github.com> HaD0Yun <102889891+HaD0Yun@users.noreply.github.com>
 Hako <devswha@gmail.com> devswha <devswha@gmail.com>
 hoon-ch <hun9211@gmail.com> hoon_ch <hun9211@gmail.com>
 J Choi <25876626+chiznoir@users.noreply.github.com> chiznoir <25876626+chiznoir@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,38 @@
+# Canonical author identities for `git shortlog`, `git log`, and contributor stats.
+#
+# Some contributors have committed under more than one display name from the same
+# address, so identity-based views split one person into several entries. Each line
+# below maps an alias to the name that address used most often in `origin/dev`.
+#
+# Only same-address, unambiguous cases are listed: addresses whose most-used name is
+# tied are left out rather than guessing how a contributor prefers to be shown.
+#
+# Add an alias with:
+#   Preferred Name <preferred@email> Other Name <same@email>
+
+chulmin-dev <kcm1805@gmail.com> kcm1805 <kcm1805@gmail.com>
+chulmin-dev <kcm1805@gmail.com> chulmin <kcm1805@gmail.com>
+Dayum_gud <239489026+project820@users.noreply.github.com> project820 <239489026+project820@users.noreply.github.com>
+dbc-hbin <dion9310@gmail.com> hanbinnoh <dion9310@gmail.com>
+DoYunHa <102889891+had0yun@users.noreply.github.com> HaD0Yun <102889891+had0yun@users.noreply.github.com>
+Hako <devswha@gmail.com> devswha <devswha@gmail.com>
+hoon-ch <hun9211@gmail.com> hoon_ch <hun9211@gmail.com>
+J Choi <25876626+chiznoir@users.noreply.github.com> chiznoir <25876626+chiznoir@users.noreply.github.com>
+Jaeyun Ha <jaeyunha0317@gmail.com> jaeyunha <jaeyunha0317@gmail.com>
+Kim dayoun <dayoooun@gmail.com> Dayoooun <dayoooun@gmail.com>
+larrabee <larrabee.kor@gmail.com> larrabee-kor <larrabee.kor@gmail.com>
+mj.lee <mj.lee@wavebridge.com> 이민재(Minjae Lee) <mj.lee@wavebridge.com>
+mj.lee <mj.lee@wavebridge.com> MJ Lee <mj.lee@wavebridge.com>
+Nahwan Kim <me@nahwan.kim> nahwan-kim <me@nahwan.kim>
+Pro Catsy <project.catsy@gmail.com> Studio-Aeon <project.catsy@gmail.com>
+probe <re2rar@gmail.com> probepark <re2rar@gmail.com>
+sJ00C <kaja974546@gmail.com> DevSJ <kaja974546@gmail.com>
+snowykr <snowykr22@gmail.com> Jun Koo <snowykr22@gmail.com>
+snowykr <snowykr22@gmail.com> Jun, Koo <snowykr22@gmail.com>
+snowykr <snowykr22@gmail.com> user.email <snowykr22@gmail.com>
+Woojin Lee <writerwoody@gmail.com> 10kH <writerwoody@gmail.com>
+Yeachan Heo <yeachan.heo@gmail.com> Bellman <yeachan.heo@gmail.com>
+YEONWOO CHOI <32544727+twoimo@users.noreply.github.com> twoimo <32544727+twoimo@users.noreply.github.com>
+Yongbeom Gwon <ybgwon96@gmail.com> YONGBEOM GWON <ybgwon96@gmail.com>
+김도겸 <rlaehrua930@naver.com> Dogyeom Kim <rlaehrua930@naver.com>
+나형진 <hyeongjin.na@musinsa.com> 나형진(Hyeongjin Na) <hyeongjin.na@musinsa.com>


### PR DESCRIPTION
## What

Add a repository-root `.mailmap` mapping 26 aliases to one canonical name per address, covering 22 contributors.

## Why

Fixes #5232.

`git shortlog`, `git log`, and contributor tooling key on `(name, email)`. A contributor who has committed under more than one display name from the same address is counted as several people, and the repository has no `.mailmap` to collapse them. On `origin/dev` this splits **22 contributors across 1,209 commits**.

```
$ git shortlog -sne origin/dev | grep snowykr22
    58  snowykr <snowykr22@gmail.com>
    20  Jun Koo <snowykr22@gmail.com>
     7  Jun, Koo <snowykr22@gmail.com>
      6  user.email <snowykr22@gmail.com>
```

One person, one address, four entries — one of them the literal placeholder `user.email`.

Each alias maps to the name that address used most often in `origin/dev`. This is display-time only: no commit objects change, no history is rewritten, and nothing reads `.mailmap` at runtime.

**Six addresses are deliberately excluded.** Their most-used name is tied, so any choice would guess how that contributor prefers to be shown. They can add themselves.

## Testing

```
$ git shortlog -sne origin/dev | wc -l
219        # without .mailmap
193        # with .mailmap
```

Collapse verified on the three largest cases:

| address | before | after |
|---|---|---|
| `snowykr22@gmail.com` | 58 + 20 + 7 + 6 | **91** snowykr |
| `writerwoody@gmail.com` | 33 + 20 | **53** Woojin Lee |
| `re2rar@gmail.com` | 220 + 3 | **223** probe |

No code is touched, so no test suite is affected.

## Risk classification

- [x] `low-risk`
- [ ] `regression-risk`
- [ ] `high-risk`

Marked below by the reviewer path actually taken; as an external contributor I cannot use the owner-only `low-risk` solo path.

- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).

The change is a display-time mapping with no runtime reader, but it does alter how contribution is attributed, so it warrants an independent look rather than a self-classified low-risk path.

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:c771b4bafbb82512e5e1a8cb86fb548f50d9f11393a87dfcca219b00754fa2d1 reviewer:human reviewer-id:Yeachan-Heo evidence:git shortlog origin/dev 219->193; all 22 mailmap addresses already public; had0yun email-case fix
```

Exact-head review by repository owner at `97e7b7deb1c`; one-line had0yun email-case correction applied (`102889891+HaD0Yun` not `had0yun`).

---

- [x] Target branch is `dev`
- [x] `bun check` — not run; no source, config, or build input is touched by this change
- [x] Tested locally (`git shortlog` before/after)
- [ ] CHANGELOG updated (if user-facing) — repository metadata, no user-facing surface
- [x] Verdict above matches the exact PR head
- [x] Risk classification above matches the actual review path taken

