### PR TITLE
fix(editor): bypass cmd for native Windows editors

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Broker-launched SDK sessions now activate an already-cached default model profile before refreshing provider catalogs in the background, preventing redundant online discovery from consuming the fixed semantic-readiness window while preserving strict refresh fallback when cached profile resolution fails.
+- Native Windows external editors now launch executable commands directly instead of through `cmd.exe`, preventing the shell handoff from swallowing the first editor keystroke; `.cmd` and `.bat` editor commands retain shell execution.
 - Ask now rejects standalone custom-input pseudo-option labels such as `Other (type your own)`, `custom input`, and `직접 입력` while preserving genuine labels that merely contain those words; single-option asks no longer publish a recommended marker, including through workflow-gate/SDK question projection.
 - Session-state lock acquisition now retries immediately after positively proving and identity-reclaiming a dead transition owner, so forced exits no longer add a retry delay to the next resume while unproven or live claims retain the bounded backoff path.
 - Coordinator persist failures now include typed lock-cause fields and use a per-document, per-failure-class 30-second warn window; proven-refused local model discovery is debug-level, and `session_closed` delivery failures route by attached-client count.

--- a/packages/coding-agent/src/utils/external-editor.ts
+++ b/packages/coding-agent/src/utils/external-editor.ts
@@ -28,6 +28,16 @@ export function trimEditorTrailingNewline(text: string): string {
 }
 
 /**
+ * Native Windows editor executables must bypass cmd.exe. The shell wrapper
+ * reclaims the shared console input buffer while it waits for the editor,
+ * reopening the cooked-mode window that loses the first keystroke. Batch
+ * files still require a shell on Windows; ordinary executables do not.
+ */
+export function shouldUseExternalEditorShell(editor: string, platform: NodeJS.Platform = process.platform): boolean {
+	return platform === "win32" && /\.(?:cmd|bat)$/iu.test(editor);
+}
+
+/**
  * On Windows the console input buffer is shared between the parent and the
  * child. When the parent TUI stops it restores the console to cooked mode
  * (ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT) and disables
@@ -104,7 +114,10 @@ export async function openInEditor(
 
 		prepareWindowsConsoleForExternalEditor();
 
-		const child = spawn(editor, [...editorArgs, tmpFile], { stdio, shell: process.platform === "win32" });
+		const child = spawn(editor, [...editorArgs, tmpFile], {
+			stdio,
+			shell: shouldUseExternalEditorShell(editor),
+		});
 		const { promise, reject, resolve } = Promise.withResolvers<number>();
 		child.once("exit", (code, signal) => resolve(code ?? (signal ? -1 : 0)));
 		child.once("error", error => reject(error));

--- a/packages/coding-agent/test/utils/external-editor.test.ts
+++ b/packages/coding-agent/test/utils/external-editor.test.ts
@@ -1,5 +1,21 @@
 import { describe, expect, it } from "bun:test";
-import { trimEditorTrailingNewline } from "../../src/utils/external-editor";
+import { shouldUseExternalEditorShell, trimEditorTrailingNewline } from "../../src/utils/external-editor";
+
+describe("shouldUseExternalEditorShell", () => {
+	it("spawns native Windows executables directly", () => {
+		expect(shouldUseExternalEditorShell("nvim", "win32")).toBe(false);
+		expect(shouldUseExternalEditorShell("C:\\Tools\\nvim.exe", "win32")).toBe(false);
+	});
+
+	it("keeps the shell for Windows batch editors", () => {
+		expect(shouldUseExternalEditorShell("editor.cmd", "win32")).toBe(true);
+		expect(shouldUseExternalEditorShell("C:\\Tools\\editor.bat", "win32")).toBe(true);
+	});
+
+	it("never adds a shell on POSIX", () => {
+		expect(shouldUseExternalEditorShell("editor.cmd", "linux")).toBe(false);
+	});
+});
 
 describe("trimEditorTrailingNewline", () => {
 	it("removes a single CRLF terminator completely", () => {


### PR DESCRIPTION
## Summary

Fix native Windows external-editor startup for Neovim and other executable editors.

## Root cause

After GJC stops its TUI, the Windows console is restored to cooked input mode. The previous implementation then launched every Windows editor through `cmd.exe` (`shell: true`), adding a shell process that could retain the shared console in cooked mode during the handoff. That is the exact path behind the reported first-keystroke loss: `i` is line-buffered until `Enter` is pressed. The earlier console re-arm in PR #5225 did not fix the report because the `cmd.exe` hop remained.

## Fix

- Keep the existing Windows console flush/raw-mode preparation.
- Launch native Windows editor executables directly, avoiding the `cmd.exe` handoff.
- Preserve shell execution for `.cmd` and `.bat` editor commands, which require a shell on Windows.
- Leave POSIX launch behavior unchanged.

## Verification

- `bun test packages/coding-agent/test/utils/external-editor.test.ts` — 6 passed.
- `bun node_modules/@biomejs/biome/bin/biome check packages/coding-agent/src/utils/external-editor.ts packages/coding-agent/test/utils/external-editor.test.ts packages/coding-agent/CHANGELOG.md` — passed.
- `bun node_modules/typescript/bin/tsc -p packages/coding-agent/tsconfig.json --noEmit` — passed.
- Native Windows interactive verification is unavailable on this Linux host; the source-level reproduction is the exact `shell: process.platform === "win32"` path at the original base commit, covered by the platform-policy regression tests.

## Risk classification

- [x] `low-risk`
- [ ] `regression-risk`
- [ ] `high-risk`

## Review contract

gajae.pr-review-verdict.v1 merge-self-approved sha256:129da4992524d1fa4329dd0f7c5312933f3ae5ff3946259a00145634c75e50a3 reviewer:human reviewer-id:Yeachan-Heo evidence:Owner low-risk self-review is bound to exact base 4ffd3d01054498d2a520c3dfe29c6517f81be570 and head 84bd690f8f24a9483cfaa2d796ba2a8ee82394a8; direct executable and batch shell behavior are regression-tested.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*