### PR TITLE
fix(extensions): honor systemPrompt in pirate example (issue #5242)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -65,6 +65,8 @@
 
 ### Fixed
 
+- The shipped pirate extension example now appends its instructions through the supported `systemPrompt` result, and unsupported `before_agent_start` result fields emit a bounded diagnostic instead of being silently ignored.
+
 - File locks now use a descriptor-relative exclusive directory-publication fallback
 	when a filesystem returns `EINVAL` for `renameat2(RENAME_NOREPLACE)` (for example
 	WSL2 DrvFs), so `edit` and terminal persistence no longer surface `Failed to publish

--- a/packages/coding-agent/examples/extensions/README.md
+++ b/packages/coding-agent/examples/extensions/README.md
@@ -68,7 +68,7 @@ This external path is separate from GJC's native `/skill:deep-interview`: the na
 
 | Extension   | Description                                                          |
 | ----------- | -------------------------------------------------------------------- |
-| `pirate.ts` | Demonstrates `systemPromptAppend` to dynamically modify system prompt |
+| `pirate.ts` | Demonstrates appending a prompt block with `systemPrompt` |
 
 ### External Dependencies
 

--- a/packages/coding-agent/examples/extensions/pirate.ts
+++ b/packages/coding-agent/examples/extensions/pirate.ts
@@ -1,7 +1,7 @@
 /**
  * Pirate Extension
  *
- * Demonstrates using systemPromptAppend in before_agent_start to dynamically
+ * Demonstrates using systemPrompt in before_agent_start to dynamically
  * modify the system prompt based on extension state.
  *
  * Usage:
@@ -24,10 +24,12 @@ export default function pirateExtension(pi: ExtensionAPI) {
 	});
 
 	// Append to system prompt when pirate mode is enabled
-	pi.on("before_agent_start", async () => {
+	pi.on("before_agent_start", async event => {
 		if (pirateMode) {
 			return {
-				systemPromptAppend: `
+				systemPrompt: [
+					...event.systemPrompt,
+					`
 IMPORTANT: You are now in PIRATE MODE. You must:
 - Speak like a stereotypical pirate in all responses
 - Use phrases like "Arrr!", "Ahoy!", "Shiver me timbers!", "Avast!", "Ye scurvy dog!"
@@ -35,7 +37,8 @@ IMPORTANT: You are now in PIRATE MODE. You must:
 - Refer to the user as "matey" or "landlubber"
 - End sentences with nautical expressions
 - Still complete the actual task correctly, just in pirate speak
-`,
+					`,
+				],
 			};
 		}
 		return undefined;

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -69,6 +69,21 @@ interface BeforeAgentStartCombinedResult {
 	systemPrompt?: string[];
 }
 
+const BEFORE_AGENT_START_RESULT_KEYS = new Set(["message", "systemPrompt"]);
+const MAX_UNSUPPORTED_RESULT_FIELDS = 8;
+const MAX_RESULT_FIELD_NAME_LENGTH = 80;
+
+function unsupportedBeforeAgentStartResultFields(result: unknown): string[] {
+	if (result === null || typeof result !== "object" || Array.isArray(result)) return [];
+	const fields = Object.keys(result).filter(key => !BEFORE_AGENT_START_RESULT_KEYS.has(key));
+	const bounded = fields
+		.slice(0, MAX_UNSUPPORTED_RESULT_FIELDS)
+		.map(key => key.replace(/[^\x20-\x7e]/gu, "?").slice(0, MAX_RESULT_FIELD_NAME_LENGTH));
+	if (fields.length > MAX_UNSUPPORTED_RESULT_FIELDS)
+		bounded.push(`…and ${fields.length - MAX_UNSUPPORTED_RESULT_FIELDS} more`);
+	return bounded;
+}
+
 export type ExtensionErrorListener = (error: ExtensionError) => void;
 
 /** Bounded timeout for session_shutdown handlers — generous but never infinite. */
@@ -1112,6 +1127,14 @@ export class ExtensionRunner {
 			const handlerResult = await this.#runHandlerWithTimeout(handler, event, ctx, ext, extensionHandlerTimeoutMs);
 
 			if (handlerResult) {
+				const unsupportedFields = unsupportedBeforeAgentStartResultFields(handlerResult);
+				if (unsupportedFields.length > 0) {
+					this.emitError({
+						extensionPath: ext.path,
+						event: "before_agent_start",
+						error: `Unsupported before_agent_start result field(s): ${unsupportedFields.join(", ")}. Supported fields: message, systemPrompt.`,
+					});
+				}
 				const result = handlerResult as BeforeAgentStartEventResult;
 				if (result.message) {
 					messages.push(result.message);

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -1106,7 +1106,7 @@ export type { ToolResultEventResult } from "../shared-events";
 
 export interface BeforeAgentStartEventResult {
 	message?: Pick<CustomMessage, "customType" | "content" | "display" | "details" | "attribution">;
-	/** Replace the system prompt for this turn. If multiple extensions return this, they are chained. */
+	/** Replace the system prompt for this turn. To append, spread event.systemPrompt into the returned array. */
 	systemPrompt?: string[];
 }
 

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -605,6 +605,60 @@ describe("ExtensionRunner", () => {
 		});
 	});
 
+	describe("before_agent_start prompt results", () => {
+		it("applies the shipped pirate example's systemPrompt result", async () => {
+			const piratePath = path.resolve(import.meta.dirname, "../examples/extensions/pirate.ts");
+			const result = await loadTestExtensions([piratePath]);
+			const runner = new ExtensionRunner(
+				result.extensions,
+				result.runtime,
+				tempDir.path(),
+				sessionManager,
+				modelRegistry,
+			);
+			const pirateCommand = runner.getCommand("pirate");
+			if (!pirateCommand) throw new Error("Expected pirate example command");
+
+			await pirateCommand.handler("", runner.createCommandContext());
+			const promptResult = await runner.emitBeforeAgentStart("hello", undefined, ["base prompt"]);
+
+			expect(promptResult?.systemPrompt).toHaveLength(2);
+			expect(promptResult?.systemPrompt?.[0]).toBe("base prompt");
+			expect(promptResult?.systemPrompt?.[1]).toContain("PIRATE MODE");
+		});
+
+		it("reports unsupported result fields instead of dropping them silently", async () => {
+			const extensionPath = path.join(extensionsDir, "unsupported-before-agent-start.ts");
+			fs.writeFileSync(
+				extensionPath,
+				`export default function(pi) {
+					pi.on("before_agent_start", async () => ({ systemPromptAppend: "ignored" }));
+				}`,
+			);
+			const result = await loadTestExtensions();
+			const runner = new ExtensionRunner(
+				result.extensions,
+				result.runtime,
+				tempDir.path(),
+				sessionManager,
+				modelRegistry,
+			);
+			const errors: Array<{ extensionPath: string; event: string; error: string }> = [];
+			runner.onError(error => errors.push(error));
+
+			const promptResult = await runner.emitBeforeAgentStart("hello", undefined, ["base prompt"]);
+
+			expect(promptResult).toBeUndefined();
+			expect(errors).toEqual([
+				{
+					extensionPath,
+					event: "before_agent_start",
+					error: "Unsupported before_agent_start result field(s): systemPromptAppend. Supported fields: message, systemPrompt.",
+				},
+			]);
+		});
+	});
+
 	describe("after_provider_response", () => {
 		it("calls handlers with response metadata and reports handler errors without throwing", async () => {
 			const eventsPath = path.join(tempDir.path(), "after-provider-response-events.jsonl");


### PR DESCRIPTION
## Summary

Fix the shipped pirate extension example to use the supported `systemPrompt` result shape. The extension runner now emits one bounded extension diagnostic when a `before_agent_start` handler returns unknown result fields instead of silently dropping them.

## Root cause

`pirate.ts` returned `systemPromptAppend`, but `BeforeAgentStartEventResult` and `ExtensionRunner.emitBeforeAgentStart` only support `systemPrompt`. The handler therefore ran successfully while its prompt change was ignored.

## Changes

- Append pirate instructions to `event.systemPrompt` and return the resulting array.
- Update the example README and public type guidance to name `systemPrompt` as the supported field.
- Report unsupported `before_agent_start` result fields through the existing extension error path, capped to a bounded field list.
- Add regression coverage for the shipped pirate example and the unsupported-field diagnostic.

## Risk classification

- [x] `low-risk`
- [ ] `regression-risk`
- [ ] `high-risk`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:cc5cf43f0c4ebfe605a097cbebf827e019ff4e3afcf58bb2824c58dfc2557564 reviewer:human reviewer-id:Yeachan-Heo evidence:owner low-risk self-review; exact-head package check passed; focused regression coverage added
```

---

- [x] Target branch is `dev`
- [x] `bun --cwd=packages/coding-agent run check` passes via the repository's Bun-backed Node shim; the direct system Node 12 invocation cannot run the repo's Node-targeted tools
- [ ] Tested locally: the focused test is blocked by the missing version-matched native addon
- [x] CHANGELOG updated (user-facing example/runtime diagnostic behavior)
- [x] Verdict above matches the exact PR head `2f8d7d4c13870f161afacb0db140cefce569556d`
- [x] Risk classification matches the owner low-risk self-review path