### PR TITLE
fix(sdk): close stale broker owner identity gap (#5227)

### DIFF
--- a/packages/coding-agent/src/sdk/broker/ensure.ts
+++ b/packages/coding-agent/src/sdk/broker/ensure.ts
@@ -4,6 +4,7 @@ import type { FileHandle } from "node:fs/promises";
 import * as fs from "node:fs/promises";
 import path from "node:path";
 import packageJson from "../../../package.json" with { type: "json" };
+import { SdkClient } from "../client/client";
 import { type BrokerDiscovery, brokerProcessIncarnation, readBrokerDiscovery } from "./discovery";
 import { resolveSdkInternalSpawnCommand, type SdkInternalSpawnCommand } from "./runtime";
 import { BrokerStartupError, clearBrokerStartupFailureMarker, readBrokerStartupFailureMarker } from "./startup-failure";
@@ -262,12 +263,19 @@ function fixtureLeaseUnavailable(): Error {
 const STALE_BROKER_SHUTDOWN_TIMEOUT_MS = 5_000;
 const STALE_BROKER_POLL_MS = 50;
 
+type BrokerOwnerIdentity = Pick<BrokerDiscovery, "ownerId" | "pid" | "incarnation">;
+
+function sameBrokerOwner(left: BrokerOwnerIdentity | null, right: BrokerOwnerIdentity): boolean {
+	return Boolean(
+		left && left.ownerId === right.ownerId && left.pid === right.pid && left.incarnation === right.incarnation,
+	);
+}
+
 async function retireStaleBrokerGeneration(stale: BrokerDiscovery, settings: EnsureBrokerSettings): Promise<void> {
 	let shutdownSucceeded = false;
 	try {
-		const { SdkClient } = await import("../client/client");
 		const current = await readBrokerDiscovery(settings.agentDir, settings.heartbeatTtlMs);
-		if (!current || current.ownerId !== stale.ownerId || current.pid !== stale.pid) return;
+		if (!current || !sameBrokerOwner(current, stale)) return;
 		const client = await SdkClient.connect(current.url, current.token, { timeoutMs: 2_000 });
 		try {
 			await client.global("broker.shutdown", {});
@@ -289,7 +297,7 @@ async function retireStaleBrokerGeneration(stale: BrokerDiscovery, settings: Ens
 	const deadline = Date.now() + STALE_BROKER_SHUTDOWN_TIMEOUT_MS;
 	while (Date.now() < deadline) {
 		const current = await readBrokerDiscovery(settings.agentDir, settings.heartbeatTtlMs);
-		if (!current || current.pid !== stale.pid || current.incarnation !== stale.incarnation) break;
+		if (!sameBrokerOwner(current, stale)) break;
 		await sleep(STALE_BROKER_POLL_MS);
 	}
 }
@@ -534,6 +542,13 @@ export function startFixtureBrokerCommandWithLeaseForTest(command: FixtureBroker
 /** Test hook: returns a stop handle for the detached broker this process spawned. */
 export function brokerOwnerForTest(agentDir: string): BrokerOwner | undefined {
 	return owners.get(agentDir);
+}
+/** Test hook: verifies the complete broker owner identity used during stale retirement. */
+export function brokerOwnerIdentityMatchesForTest(
+	left: BrokerOwnerIdentity | null,
+	right: BrokerOwnerIdentity,
+): boolean {
+	return sameBrokerOwner(left, right);
 }
 /** Test hook: drives the detached-broker reap on a controllable child surface. */
 export function reapSpawnedBrokerForTest(child: ChildProcess, timing: ReapTiming = DEFAULT_REAP_TIMING): Promise<void> {

--- a/packages/coding-agent/test/sdk-broker-stale-generation.test.ts
+++ b/packages/coding-agent/test/sdk-broker-stale-generation.test.ts
@@ -3,12 +3,26 @@ import * as fs from "node:fs/promises";
 import path from "node:path";
 import packageJson from "../package.json" with { type: "json" };
 import { Broker, resolveBrokerPackageGeneration } from "../src/sdk/broker/broker";
+import type { BrokerDiscovery } from "../src/sdk/broker/discovery";
 import { readBrokerDiscovery } from "../src/sdk/broker/discovery";
-import { ensureBroker } from "../src/sdk/broker/ensure";
+import { brokerOwnerIdentityMatchesForTest, ensureBroker } from "../src/sdk/broker/ensure";
 
 const currentGeneration = (packageJson as { version: string }).version;
 
 describe("sdk broker stale-generation fence (#5227)", () => {
+	test("stale retirement requires the exact broker process incarnation", () => {
+		const stale = {
+			ownerId: "stale-owner",
+			pid: 4242,
+			incarnation: "linux:old",
+		} satisfies Pick<BrokerDiscovery, "ownerId" | "pid" | "incarnation">;
+
+		expect(brokerOwnerIdentityMatchesForTest(stale, stale)).toBe(true);
+		expect(brokerOwnerIdentityMatchesForTest({ ...stale, incarnation: "linux:new" }, stale)).toBe(false);
+		expect(brokerOwnerIdentityMatchesForTest({ ...stale, pid: 4243 }, stale)).toBe(false);
+		expect(brokerOwnerIdentityMatchesForTest({ ...stale, ownerId: "replacement-owner" }, stale)).toBe(false);
+	});
+
 	test("broker publishes current package generation, never unknown", async () => {
 		const agentDir = await fs.mkdtemp(path.join(import.meta.dir, "../.tmp-gen-"));
 		const broker = new Broker({ agentDir });
@@ -27,7 +41,7 @@ describe("sdk broker stale-generation fence (#5227)", () => {
 		const agentDir = await fs.mkdtemp(path.join(import.meta.dir, "../.tmp-stale-"));
 		// Start a broker that claims to be old generation "unknown"
 		const staleBroker = new Broker({ agentDir, packageGeneration: "unknown" });
-		let staleDiscovery: Awaited<ReturnType<typeof staleBroker.start>>;
+		let staleDiscovery: BrokerDiscovery;
 		try {
 			staleDiscovery = await staleBroker.start();
 			expect(staleDiscovery.packageGeneration).toBe("unknown");


### PR DESCRIPTION
## What

Complete the #5227 stale-broker replacement fence by requiring owner ID, PID, and process incarnation to match before graceful shutdown or retirement polling. The broker client is statically imported so the replacement path follows the repository import contract.

## Why

The original fix prevents an in-place upgrade from reusing a broker with incompatible package-generation semantics. This follow-up closes the remaining identity gap: PID reuse must not let stale retirement control a different process.

## Testing

- `bun test packages/coding-agent/test/sdk-broker.test.ts packages/coding-agent/test/sdk-broker-stale-generation.test.ts packages/coding-agent/test/notify-health-stale-lock.test.ts`
- `bun --cwd=packages/coding-agent run check` with a Bun runtime shim because the host `/usr/bin/node` is Node 12 and cannot execute the workspace tool shims
- Native Windows execution was not available; the original Windows-specific incident is covered by the exact owner identity regression and the existing stale-generation replacement tests.

## Risk classification

- [x] `low-risk` — narrow validation hardening and regression coverage; no protocol or data-format change
- [ ] `regression-risk`
- [ ] `high-risk`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:da95af7b34305be117a1b97ad8f0044dc6ff145dfb29471332b64316098b720c reviewer:human reviewer-id:Yeachan-Heo evidence:focused broker regression suite and coding-agent check passed locally
```

- [x] Target branch is `dev`
- [x] Tested locally
- [x] Verdict matches the exact PR head