### PR TITLE
feat(status-line): add bounded command HUD segment

### DIFF
--- a/docs/theme.md
+++ b/docs/theme.md
@@ -69,6 +69,38 @@ All tokens below are required in `colors`.
 
 `statusLineSep`, `statusLineModel`, `statusLinePath`, `statusLineGitClean`, `statusLineGitDirty`, `statusLineContext`, `statusLineSpend`, `statusLineStaged`, `statusLineDirty`, `statusLineUntracked`, `statusLineOutput`, `statusLineCost`, `statusLineSubagents`
 
+## User-produced status content
+
+The `command` segment is the supported way to put user-produced content in the
+status line. It is configured alongside a custom segment layout:
+
+```yaml
+statusLine:
+  preset: custom
+  leftSegments: [model, command]
+  segmentOptions:
+    command:
+      command: "git branch --show-current"
+      refreshMs: 5000
+      timeoutMs: 500
+      maxLength: 80
+```
+
+The command runs in the configured shell from the project directory. GJC starts
+it in the background and renders the last successful value while the next
+refresh is pending, so a slow command cannot block TUI rendering. Each run has
+a bounded timeout (50–10,000 ms), stdout is capped before decoding, and the
+displayed value is ANSI/control-character sanitized and width-bounded (1–256
+columns). A timeout, non-zero exit, or launch failure leaves the last value in
+place; when no value exists, the segment shows a placeholder and records a
+bounded logger diagnostic. The normal status-line `maxRows` layout still owns
+final row fitting and overflow behavior.
+
+This is an explicit arbitrary-command execution boundary: review commands in
+project and user configuration before enabling the segment. The command is not
+executed unless `command` is present in an active `leftSegments` or
+`rightSegments` list.
+
 ## Optional tokens
 
 ### `export` section (optional)

--- a/docs/theme.md
+++ b/docs/theme.md
@@ -86,19 +86,21 @@ statusLine:
       maxLength: 80
 ```
 
-The command runs in the configured shell from the project directory. GJC starts
-it in the background and renders the last successful value while the next
-refresh is pending, so a slow command cannot block TUI rendering. Each run has
-a bounded timeout (50–10,000 ms), stdout is capped before decoding, and the
-displayed value is ANSI/control-character sanitized and width-bounded (1–256
-columns). A timeout, non-zero exit, or launch failure leaves the last value in
-place; when no value exists, the segment shows a placeholder and records a
-bounded logger diagnostic. The normal status-line `maxRows` layout still owns
-final row fitting and overflow behavior.
+The command and its active-segment opt-in are read from the user/global settings
+layer only; project-scoped settings cannot cause a command to execute. The
+command runs in the configured shell from the project directory. GJC starts it
+in the background and renders the last successful value while the next refresh
+is pending, so a slow command cannot block TUI rendering. Each run has a bounded
+timeout (50–10,000 ms), stdout is capped before decoding, and the displayed
+value is ANSI/control-character sanitized and width-bounded (1–256 columns). A
+timeout, non-zero exit, or launch failure leaves the last value in place; when
+no value exists, the segment shows a placeholder and records a bounded logger
+diagnostic. The normal status-line `maxRows` layout still owns final row fitting
+and overflow behavior.
 
-This is an explicit arbitrary-command execution boundary: review commands in
-project and user configuration before enabling the segment. The command is not
-executed unless `command` is present in an active `leftSegments` or
+This is an explicit arbitrary-command execution boundary: review the command in
+user/global configuration before enabling the segment. The command is not
+executed unless `command` is present in the user/global active `leftSegments` or
 `rightSegments` list.
 
 ## Optional tokens

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,9 +8,10 @@
 - SDK session tails now preserve authoritative transcript revisions in item identity and lifecycle ordering, close the pre-checkpoint live/replay dedupe race, and recover held live frames across reconnect replay without losing ordered delivery.
 - `/model` provider-tab refreshes now reuse the already loaded static catalog and update only the selected provider's discovery state, avoiding repeated signed preset registry work while retaining full-catalog refresh behavior for static configuration changes.
 - Added the `command` status-line segment for user-produced HUD content. It runs
-  configured shell commands in the background with cached refreshes, bounded
-  timeout/output, ANSI sanitization, placeholder degradation, and custom-editor
-  configuration while preserving synchronous TUI rendering.
+  configured user/global shell commands in the background with scheduled cached
+  refreshes, bounded timeout/output, ANSI sanitization, placeholder degradation,
+  disposal cancellation, and custom-editor configuration while preserving
+  synchronous TUI rendering; project-scoped settings cannot trigger execution.
 
 ## [0.16.1] - 2026-09-03
 - Broker-launched SDK sessions now activate an already-cached default model profile before refreshing provider catalogs in the background, preventing redundant online discovery from consuming the fixed semantic-readiness window while preserving strict refresh fallback when cached profile resolution fails.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Fixed the steer-triggered bash fold being skipped under `toolInterruptPolicy: finish_tools`: a composer steer over a long foreground `bash` was aborted instead of folded because the fold gate wrongly treated the policy as an exclusion. `finish_tools` governs sibling tools in the batch, not the fold; the fold kills nothing and now applies under both policies. A tmux dogfood driver (`scripts/dogfood/steer-fold-tmux.sh`) proves the real binary folds, answers the steer in the same turn, and wakes on completion.
 - SDK session tails now preserve authoritative transcript revisions in item identity and lifecycle ordering, close the pre-checkpoint live/replay dedupe race, and recover held live frames across reconnect replay without losing ordered delivery.
 - `/model` provider-tab refreshes now reuse the already loaded static catalog and update only the selected provider's discovery state, avoiding repeated signed preset registry work while retaining full-catalog refresh behavior for static configuration changes.
+- Added the `command` status-line segment for user-produced HUD content. It runs
+  configured shell commands in the background with cached refreshes, bounded
+  timeout/output, ANSI sanitization, placeholder degradation, and custom-editor
+  configuration while preserving synchronous TUI rendering.
 
 ## [0.16.1] - 2026-09-03
 - Broker-launched SDK sessions now activate an already-cached default model profile before refreshing provider catalogs in the background, preventing redundant online discovery from consuming the fixed semantic-readiness window while preserving strict refresh fallback when cached profile resolution fails.

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -111,7 +111,8 @@ export type StatusLineSegmentId =
 	| "cache_read"
 	| "cache_write"
 	| "session_name"
-	| "usage";
+	| "usage"
+	| "command";
 
 /** Submenu choice metadata. */
 export type SubmenuOption<V extends string = string> = {

--- a/packages/coding-agent/src/modes/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/components/settings-selector.ts
@@ -215,6 +215,8 @@ function mergeSegmentOptions(
 		git: base?.git || overrides?.git ? { ...(base?.git ?? {}), ...(overrides?.git ?? {}) } : undefined,
 		time: base?.time || overrides?.time ? { ...(base?.time ?? {}), ...(overrides?.time ?? {}) } : undefined,
 		usage: base?.usage || overrides?.usage ? { ...(base?.usage ?? {}), ...(overrides?.usage ?? {}) } : undefined,
+		command:
+			base?.command || overrides?.command ? { ...(base?.command ?? {}), ...(overrides?.command ?? {}) } : undefined,
 	};
 }
 
@@ -424,6 +426,22 @@ class StatusLineCustomEditor extends Container {
 						),
 				});
 			}
+			if (id === "command") {
+				items.push({
+					id: "option.command.command",
+					label: "Command: command",
+					description: "Shell command whose sanitized stdout is shown in the status line.",
+					currentValue: this.#draft.segmentOptions.command?.command ?? "",
+					submenu: (currentValue, done) =>
+						new TextInputSubmenu(
+							"Status line command",
+							"Runs in the configured shell with a short timeout and cached refreshes.",
+							currentValue,
+							value => done(value),
+							() => done(),
+						),
+				});
+			}
 		}
 
 		items.push(
@@ -592,6 +610,12 @@ class StatusLineCustomEditor extends Container {
 				this.#draft.segmentOptions.usage = {
 					...(this.#draft.segmentOptions.usage ?? {}),
 					mode: value === "remaining" ? "remaining" : "used",
+				};
+				break;
+			case "command.command":
+				this.#draft.segmentOptions.command = {
+					...(this.#draft.segmentOptions.command ?? {}),
+					command: value,
 				};
 				break;
 		}

--- a/packages/coding-agent/src/modes/components/status-line/command.ts
+++ b/packages/coding-agent/src/modes/components/status-line/command.ts
@@ -110,6 +110,7 @@ export async function runStatusLineCommand(
 		shellArgs: readonly string[];
 		env: Record<string, string>;
 		timeoutMs: number;
+		signal?: AbortSignal;
 	},
 ): Promise<StatusLineCommandResult> {
 	const proc = Bun.spawn([options.shell, ...options.shellArgs, command], {
@@ -122,13 +123,25 @@ export async function runStatusLineCommand(
 		...(process.platform === "win32" ? { windowsHide: true } : {}),
 	});
 
-	const killProcessGroup = (): void => {
-		try {
-			if (process.platform !== "win32" && proc.pid) {
-				process.kill(-proc.pid, "SIGKILL");
-			} else {
-				proc.kill();
+	let timedOut = false;
+	let termination: Promise<void> | undefined;
+	const terminateProcessTree = async (): Promise<void> => {
+		if (process.platform === "win32" && proc.pid) {
+			try {
+				const taskkill = Bun.spawn(["taskkill", "/pid", String(proc.pid), "/t", "/f"], {
+					stdout: "ignore",
+					stderr: "ignore",
+					windowsHide: true,
+				});
+				await taskkill.exited;
+				return;
+			} catch {
+				// Fall through to the direct kill if taskkill is unavailable.
 			}
+		}
+		try {
+			if (process.platform !== "win32" && proc.pid) process.kill(-proc.pid, "SIGKILL");
+			else proc.kill();
 		} catch {
 			try {
 				proc.kill();
@@ -137,27 +150,41 @@ export async function runStatusLineCommand(
 			}
 		}
 	};
-
-	let timedOut = false;
+	const terminate = (): void => {
+		termination ??= terminateProcessTree();
+	};
+	let aborted = false;
+	const onAbort = (): void => {
+		aborted = true;
+		terminate();
+	};
+	if (options.signal?.aborted) onAbort();
+	else options.signal?.addEventListener("abort", onAbort, { once: true });
 	const timeout = setTimeout(() => {
 		timedOut = true;
-		killProcessGroup();
+		terminate();
 	}, options.timeoutMs);
 
 	try {
+		const exitCodePromise = proc.exited.then(async exitCode => {
+			if (termination) await termination;
+			return exitCode;
+		});
 		const [stdout, stderr, exitCode] = await Promise.all([
 			readBounded(proc.stdout, STATUS_LINE_COMMAND_MAX_OUTPUT_BYTES),
 			readBounded(proc.stderr, STATUS_LINE_COMMAND_MAX_DIAGNOSTIC_BYTES),
-			proc.exited,
+			exitCodePromise,
 		]);
+		if (termination) await termination;
 		return {
 			stdout: stdout.text,
 			stderr: boundedDiagnostic(stderr.text),
 			exitCode: exitCode ?? 1,
-			timedOut,
+			timedOut: timedOut || aborted,
 			outputTruncated: stdout.truncated,
 		};
 	} finally {
 		clearTimeout(timeout);
+		options.signal?.removeEventListener("abort", onAbort);
 	}
 }

--- a/packages/coding-agent/src/modes/components/status-line/command.ts
+++ b/packages/coding-agent/src/modes/components/status-line/command.ts
@@ -1,0 +1,163 @@
+const DEFAULT_TIMEOUT_MS = 500;
+const MIN_TIMEOUT_MS = 50;
+const MAX_TIMEOUT_MS = 10_000;
+const DEFAULT_REFRESH_MS = 5_000;
+const MIN_REFRESH_MS = 250;
+const MAX_REFRESH_MS = 60_000;
+export const STATUS_LINE_COMMAND_DEFAULT_MAX_LENGTH = 80;
+export const STATUS_LINE_COMMAND_MAX_LENGTH = 256;
+const STATUS_LINE_COMMAND_MAX_OUTPUT_BYTES = 16 * 1024;
+const STATUS_LINE_COMMAND_MAX_DIAGNOSTIC_BYTES = 1_024;
+
+export interface StatusLineCommandOptions {
+	command?: string;
+	timeoutMs?: number;
+	refreshMs?: number;
+	maxLength?: number;
+}
+
+export interface ResolvedStatusLineCommandOptions {
+	command: string;
+	timeoutMs: number;
+	refreshMs: number;
+	maxLength: number;
+}
+
+export interface StatusLineCommandResult {
+	stdout: string;
+	stderr: string;
+	exitCode: number;
+	timedOut: boolean;
+	outputTruncated: boolean;
+}
+
+interface BoundedReadResult {
+	text: string;
+	truncated: boolean;
+}
+
+function finiteNumber(value: unknown, fallback: number): number {
+	return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function clampInteger(value: unknown, fallback: number, min: number, max: number): number {
+	return Math.max(min, Math.min(max, Math.trunc(finiteNumber(value, fallback))));
+}
+
+export function normalizeStatusLineCommandOptions(value: unknown): ResolvedStatusLineCommandOptions {
+	const record = value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+	return {
+		command: typeof record.command === "string" ? record.command.trim() : "",
+		timeoutMs: clampInteger(record.timeoutMs, DEFAULT_TIMEOUT_MS, MIN_TIMEOUT_MS, MAX_TIMEOUT_MS),
+		refreshMs: clampInteger(record.refreshMs, DEFAULT_REFRESH_MS, MIN_REFRESH_MS, MAX_REFRESH_MS),
+		maxLength: clampInteger(
+			record.maxLength,
+			STATUS_LINE_COMMAND_DEFAULT_MAX_LENGTH,
+			1,
+			STATUS_LINE_COMMAND_MAX_LENGTH,
+		),
+	};
+}
+
+async function readBounded(stream: ReadableStream<Uint8Array>, maxBytes: number): Promise<BoundedReadResult> {
+	const reader = stream.getReader();
+	const chunks: Uint8Array[] = [];
+	let retainedBytes = 0;
+	let truncated = false;
+
+	try {
+		while (true) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			if (!(value instanceof Uint8Array)) continue;
+			if (retainedBytes >= maxBytes) {
+				truncated = true;
+				continue;
+			}
+			const remaining = maxBytes - retainedBytes;
+			const retained = value.byteLength <= remaining ? value : value.slice(0, remaining);
+			chunks.push(retained);
+			retainedBytes += retained.byteLength;
+			if (retained.byteLength < value.byteLength) truncated = true;
+		}
+	} finally {
+		reader.releaseLock();
+	}
+
+	const bytes = new Uint8Array(retainedBytes);
+	let offset = 0;
+	for (const chunk of chunks) {
+		bytes.set(chunk, offset);
+		offset += chunk.byteLength;
+	}
+	return { text: new TextDecoder().decode(bytes), truncated };
+}
+
+function boundedDiagnostic(text: string): string {
+	return text.replace(/\s+/gu, " ").trim().slice(0, STATUS_LINE_COMMAND_MAX_DIAGNOSTIC_BYTES);
+}
+
+/**
+ * Run a configured status-line command without making the synchronous render
+ * path wait on it. The streams are drained with a hard byte cap and the whole
+ * process group is killed when the timeout expires.
+ */
+export async function runStatusLineCommand(
+	command: string,
+	options: {
+		cwd: string;
+		shell: string;
+		shellArgs: readonly string[];
+		env: Record<string, string>;
+		timeoutMs: number;
+	},
+): Promise<StatusLineCommandResult> {
+	const proc = Bun.spawn([options.shell, ...options.shellArgs, command], {
+		cwd: options.cwd,
+		env: options.env,
+		stdin: "ignore",
+		stdout: "pipe",
+		stderr: "pipe",
+		detached: process.platform !== "win32",
+		...(process.platform === "win32" ? { windowsHide: true } : {}),
+	});
+
+	const killProcessGroup = (): void => {
+		try {
+			if (process.platform !== "win32" && proc.pid) {
+				process.kill(-proc.pid, "SIGKILL");
+			} else {
+				proc.kill();
+			}
+		} catch {
+			try {
+				proc.kill();
+			} catch {
+				// The process already exited.
+			}
+		}
+	};
+
+	let timedOut = false;
+	const timeout = setTimeout(() => {
+		timedOut = true;
+		killProcessGroup();
+	}, options.timeoutMs);
+
+	try {
+		const [stdout, stderr, exitCode] = await Promise.all([
+			readBounded(proc.stdout, STATUS_LINE_COMMAND_MAX_OUTPUT_BYTES),
+			readBounded(proc.stderr, STATUS_LINE_COMMAND_MAX_DIAGNOSTIC_BYTES),
+			proc.exited,
+		]);
+		return {
+			stdout: stdout.text,
+			stderr: boundedDiagnostic(stderr.text),
+			exitCode: exitCode ?? 1,
+			timedOut,
+			outputTruncated: stdout.truncated,
+		};
+	} finally {
+		clearTimeout(timeout);
+	}
+}

--- a/packages/coding-agent/src/modes/components/status-line/index.ts
+++ b/packages/coding-agent/src/modes/components/status-line/index.ts
@@ -1,3 +1,4 @@
+export * from "./command";
 export * from "./presets";
 export * from "./segments";
 export * from "./separators";

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -1,12 +1,13 @@
 import * as os from "node:os";
 import * as path from "node:path";
 import { ThinkingLevel } from "@gajae-code/agent-core";
-import { TERMINAL } from "@gajae-code/tui";
+import { TERMINAL, truncateToWidth } from "@gajae-code/tui";
 import { formatDuration, formatNumber, getProjectDir, pathIsWithin, relativePathWithinRoot } from "@gajae-code/utils";
 import { type ThemeColor, theme } from "../../../modes/theme/theme";
 import { shortenPath } from "../../../tools/render-utils";
 import { getSessionAccentAnsi, getSessionAccentHex } from "../../../utils/session-color";
 import { sanitizeStatusText } from "../../shared";
+import { normalizeStatusLineCommandOptions } from "./command";
 import { getContextUsageLevel, getContextUsageThemeColor } from "./context-thresholds";
 import { shortenModelId } from "./model-name";
 import type { RenderedSegment, SegmentContext, StatusLineSegment, StatusLineSegmentId } from "./types";
@@ -523,6 +524,26 @@ const cacheWriteSegment: StatusLineSegment = {
 	},
 };
 
+const commandSegment: StatusLineSegment = {
+	id: "command",
+	render(ctx) {
+		const state = ctx.command;
+		if (!state) return { content: theme.fg("dim", "?"), visible: true };
+
+		if (typeof state.output === "string") {
+			const text = truncateToWidth(
+				sanitizeStatusText(state.output),
+				normalizeStatusLineCommandOptions(ctx.options.command).maxLength,
+			);
+			if (text) return { content: theme.fg("statusLineOutput", text), visible: true };
+		}
+
+		if (state.failed) return { content: theme.fg("dim", "?"), visible: true };
+		if (state.pending) return { content: theme.fg("dim", "…"), visible: true };
+		return { content: "", visible: false };
+	},
+};
+
 const sessionNameSegment: StatusLineSegment = {
 	id: "session_name",
 	render(ctx) {
@@ -611,16 +632,22 @@ export const SEGMENTS: Record<StatusLineSegmentId, StatusLineSegment> = {
 	hostname: hostnameSegment,
 	cache_read: cacheReadSegment,
 	cache_write: cacheWriteSegment,
+	command: commandSegment,
 	session_name: sessionNameSegment,
 	usage: usageSegment,
 };
 
 export function renderSegment(id: StatusLineSegmentId, ctx: SegmentContext): RenderedSegment {
-	const segment = SEGMENTS[id];
-	if (!segment) {
-		return { content: "", visible: false };
+	const segment = typeof id === "string" ? SEGMENTS[id] : undefined;
+	if (!segment || typeof segment.render !== "function") {
+		const label = truncateToWidth(sanitizeStatusText(String(id)), 20);
+		return { content: theme.fg("warning", `?unknown:${label || "segment"}`), visible: true };
 	}
-	return segment.render(ctx);
+	try {
+		return segment.render(ctx);
+	} catch {
+		return { content: theme.fg("dim", "?"), visible: true };
+	}
 }
 
 export const ALL_SEGMENT_IDS: StatusLineSegmentId[] = Object.keys(SEGMENTS) as StatusLineSegmentId[];

--- a/packages/coding-agent/src/modes/components/status-line/types.ts
+++ b/packages/coding-agent/src/modes/components/status-line/types.ts
@@ -64,6 +64,11 @@ export interface SegmentContext {
 			resetUnit?: "m" | "h";
 		}>;
 	} | null;
+	command?: {
+		output: string | null;
+		failed: boolean;
+		pending: boolean;
+	};
 }
 
 export interface RenderedSegment {

--- a/packages/coding-agent/src/modes/components/tool-status-header.ts
+++ b/packages/coding-agent/src/modes/components/tool-status-header.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 
 import { type Component, truncateToWidth, visibleWidth } from "@gajae-code/tui";
 import { formatCount, getProjectDir, logger } from "@gajae-code/utils";
+import { getShellConfig } from "@gajae-code/utils/shell-config";
 import {
 	type AppKeybinding,
 	KEYBINDINGS,
@@ -214,6 +215,8 @@ export class StatusLineComponent implements Component {
 	#commandFailed = false;
 	#commandFetchedAt = 0;
 	#commandInFlightKey: string | undefined;
+	#commandAbortController: AbortController | undefined;
+	#commandRefreshTimer: ReturnType<typeof setTimeout> | undefined;
 	#commandDiagnosticKey: string | undefined;
 
 	constructor(
@@ -322,6 +325,8 @@ export class StatusLineComponent implements Component {
 		this.#disposed = true;
 		this.#onBranchChange = null;
 		this.#onUpdate = null;
+		this.#cancelCommandExecution();
+		this.#clearCommandRefreshTimer();
 		if (this.#gitWatcher) {
 			this.#gitWatcher.close();
 			this.#gitWatcher = null;
@@ -339,10 +344,64 @@ export class StatusLineComponent implements Component {
 		logger.warn(message, details);
 	}
 
+	#clearCommandRefreshTimer(): void {
+		if (this.#commandRefreshTimer) {
+			clearTimeout(this.#commandRefreshTimer);
+			this.#commandRefreshTimer = undefined;
+		}
+	}
+
+	#cancelCommandExecution(): void {
+		this.#commandAbortController?.abort();
+		this.#commandAbortController = undefined;
+		this.#commandInFlightKey = undefined;
+	}
+
+	#disableCommandSegment(): void {
+		this.#clearCommandRefreshTimer();
+		this.#cancelCommandExecution();
+		this.#commandConfigKey = undefined;
+		this.#commandOutput = null;
+		this.#commandFailed = false;
+		this.#commandFetchedAt = 0;
+		this.#commandDiagnosticKey = undefined;
+	}
+
+	#armCommandRefreshTimer(key: string, refreshMs: number): void {
+		this.#clearCommandRefreshTimer();
+		if (this.#disposed || this.#commandConfigKey !== key) return;
+		this.#commandRefreshTimer = setTimeout(
+			() => {
+				this.#commandRefreshTimer = undefined;
+				if (this.#disposed || this.#commandConfigKey !== key) return;
+				this.#notifyUpdate();
+			},
+			Math.max(0, refreshMs),
+		);
+		this.#commandRefreshTimer.unref?.();
+	}
+
+	#trustedCommandOptions(): StatusLineCommandOptions | undefined {
+		const globalLeft = this.session.settings.getGlobal("statusLine.leftSegments");
+		const globalRight = this.session.settings.getGlobal("statusLine.rightSegments");
+		const includesCommand = (value: unknown): boolean => Array.isArray(value) && value.includes("command");
+		if (!includesCommand(globalLeft) && !includesCommand(globalRight)) return undefined;
+
+		const globalSegmentOptions = this.session.settings.getGlobal("statusLine.segmentOptions");
+		if (!globalSegmentOptions || typeof globalSegmentOptions !== "object" || Array.isArray(globalSegmentOptions)) {
+			return undefined;
+		}
+		const commandOptions = (globalSegmentOptions as Record<string, unknown>).command;
+		const resolved = normalizeStatusLineCommandOptions(commandOptions);
+		return resolved.command ? resolved : undefined;
+	}
+
 	#refreshCommandInBackground(options: StatusLineCommandOptions | undefined): string {
 		const resolved = normalizeStatusLineCommandOptions(options);
 		const key = JSON.stringify(resolved);
 		if (this.#commandConfigKey !== key) {
+			this.#clearCommandRefreshTimer();
+			this.#cancelCommandExecution();
 			this.#commandConfigKey = key;
 			this.#commandOutput = null;
 			this.#commandFailed = false;
@@ -358,19 +417,31 @@ export class StatusLineComponent implements Component {
 		}
 
 		const now = Date.now();
-		if (this.#commandInFlightKey === key || now - this.#commandFetchedAt < resolved.refreshMs) return key;
+		if (this.#commandInFlightKey === key) return key;
+		const elapsed = now - this.#commandFetchedAt;
+		if (this.#commandFetchedAt > 0 && elapsed < resolved.refreshMs) {
+			this.#armCommandRefreshTimer(key, resolved.refreshMs - elapsed);
+			return key;
+		}
+		this.#clearCommandRefreshTimer();
 
 		this.#commandInFlightKey = key;
+		const abortController = new AbortController();
+		this.#commandAbortController = abortController;
 		let shellConfig: { shell: string; args: string[]; env: Record<string, string> };
 		try {
-			shellConfig = this.session.settings.getShellConfig();
+			shellConfig = getShellConfig(this.session.settings.getGlobal("shellPath"));
 		} catch (error) {
-			this.#commandInFlightKey = undefined;
+			if (this.#commandInFlightKey === key && this.#commandAbortController === abortController) {
+				this.#commandInFlightKey = undefined;
+				this.#commandAbortController = undefined;
+			}
 			this.#commandFailed = true;
 			this.#commandFetchedAt = Date.now();
 			this.#logCommandDiagnostic(key, "Status line command shell configuration failed", {
 				error: sanitizeStatusText(error instanceof Error ? error.message : String(error)).slice(0, 256),
 			});
+			this.#armCommandRefreshTimer(key, resolved.refreshMs);
 			return key;
 		}
 
@@ -380,6 +451,7 @@ export class StatusLineComponent implements Component {
 			shellArgs: shellConfig.args,
 			env: shellConfig.env,
 			timeoutMs: resolved.timeoutMs,
+			signal: abortController.signal,
 		})
 			.then(result => {
 				if (this.#disposed || this.#commandConfigKey !== key) return;
@@ -411,7 +483,10 @@ export class StatusLineComponent implements Component {
 				this.#notifyUpdate();
 			})
 			.finally(() => {
-				if (this.#commandInFlightKey === key) this.#commandInFlightKey = undefined;
+				if (this.#commandInFlightKey !== key || this.#commandAbortController !== abortController) return;
+				this.#commandInFlightKey = undefined;
+				this.#commandAbortController = undefined;
+				this.#armCommandRefreshTimer(key, resolved.refreshMs);
 			});
 		return key;
 	}
@@ -745,8 +820,9 @@ export class StatusLineComponent implements Component {
 			effectiveSettings.leftSegments.includes("pr") || effectiveSettings.rightSegments.includes("pr");
 		const commandSegmentActive =
 			effectiveSettings.leftSegments.includes("command") || effectiveSettings.rightSegments.includes("command");
-		const commandOptions = normalizeStatusLineCommandOptions(effectiveSettings.segmentOptions.command);
-		const commandKey = commandSegmentActive ? this.#refreshCommandInBackground(commandOptions) : undefined;
+		const commandOptions = commandSegmentActive ? this.#trustedCommandOptions() : undefined;
+		const commandKey = commandOptions ? this.#refreshCommandInBackground(commandOptions) : undefined;
+		if (!commandKey) this.#disableCommandSegment();
 
 		return {
 			session: this.session,
@@ -935,6 +1011,7 @@ export class StatusLineComponent implements Component {
 		const left: string[] = [];
 		const leftSegIds: StatusLineSegmentId[] = [];
 		for (const segId of effectiveSettings.leftSegments) {
+			if (segId === "command" && !ctx.command) continue;
 			const rendered = renderSegment(segId, ctx);
 			if (rendered.visible && rendered.content) {
 				left.push(highlightSegment(segId, rendered.content));
@@ -955,6 +1032,7 @@ export class StatusLineComponent implements Component {
 						this.#keyDisplayContext,
 					);
 		for (const segId of effectiveSettings.rightSegments) {
+			if (segId === "command" && !ctx.command) continue;
 			const rendered = renderSegment(segId, ctx);
 			if (rendered.visible && rendered.content) {
 				right.push(highlightSegment(segId, rendered.content));

--- a/packages/coding-agent/src/modes/components/tool-status-header.ts
+++ b/packages/coding-agent/src/modes/components/tool-status-header.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 
 import { type Component, truncateToWidth, visibleWidth } from "@gajae-code/tui";
-import { formatCount, getProjectDir } from "@gajae-code/utils";
+import { formatCount, getProjectDir, logger } from "@gajae-code/utils";
 import {
 	type AppKeybinding,
 	KEYBINDINGS,
@@ -19,6 +19,11 @@ import type { ActionRegistry, FocusDomain } from "../action-registry";
 import { EMPTY_JOBS_SNAPSHOT, type JobsSnapshot } from "../jobs-observer";
 import { sanitizeStatusText } from "../shared";
 import { renderSkillHudBar } from "./skill-hud/render";
+import {
+	normalizeStatusLineCommandOptions,
+	runStatusLineCommand,
+	type StatusLineCommandOptions,
+} from "./status-line/command";
 import { lookupCurrentPrCached } from "./status-line/gh";
 import {
 	canReuseCachedPr,
@@ -40,6 +45,7 @@ export interface StatusLineSegmentOptions {
 	git?: { showBranch?: boolean; showStaged?: boolean; showUnstaged?: boolean; showUntracked?: boolean };
 	time?: { format?: "12h" | "24h"; showSeconds?: boolean };
 	usage?: { mode?: "used" | "remaining" };
+	command?: StatusLineCommandOptions;
 }
 
 export interface StatusLineSettings {
@@ -62,6 +68,7 @@ export interface StatusLineComponentOptions {
 	getKeybindings?: () => KeybindingsManager;
 	focusDomain?: FocusDomain;
 	keyDisplayContext?: KeyDisplayContext;
+	onUpdate?: () => void;
 }
 
 export interface StatusLineActionHint {
@@ -155,6 +162,8 @@ export class StatusLineComponent implements Component {
 	#branchInFlight = false;
 	#gitWatcher: fs.FSWatcher | null = null;
 	#onBranchChange: (() => void) | null = null;
+	#onUpdate: (() => void) | null = null;
+	#disposed = false;
 	#autoCompactEnabled: boolean = true;
 	#hookStatuses: Map<string, string> = new Map();
 	#subagentCount: number = 0;
@@ -198,6 +207,15 @@ export class StatusLineComponent implements Component {
 	#usageFetchedAt = 0;
 	#usageInFlight = false;
 
+	// Configured command segment cache. Command execution is always backgrounded;
+	// rendering only reads these bounded, last-known values.
+	#commandConfigKey: string | undefined;
+	#commandOutput: string | null = null;
+	#commandFailed = false;
+	#commandFetchedAt = 0;
+	#commandInFlightKey: string | undefined;
+	#commandDiagnosticKey: string | undefined;
+
 	constructor(
 		private readonly session: AgentSession,
 		options: StatusLineComponentOptions = {},
@@ -218,6 +236,7 @@ export class StatusLineComponent implements Component {
 		this.#getKeybindings = options.getKeybindings;
 		this.#focusDomain = options.focusDomain ?? "composer";
 		this.#keyDisplayContext = options.keyDisplayContext;
+		this.#onUpdate = options.onUpdate ?? null;
 	}
 
 	updateSettings(settings: StatusLineSettings): void {
@@ -300,10 +319,101 @@ export class StatusLineComponent implements Component {
 	}
 
 	dispose(): void {
+		this.#disposed = true;
+		this.#onBranchChange = null;
+		this.#onUpdate = null;
 		if (this.#gitWatcher) {
 			this.#gitWatcher.close();
 			this.#gitWatcher = null;
 		}
+	}
+
+	#notifyUpdate(): void {
+		if (this.#onUpdate) this.#onUpdate();
+		else this.#onBranchChange?.();
+	}
+
+	#logCommandDiagnostic(key: string, message: string, details: Record<string, unknown> = {}): void {
+		if (this.#commandDiagnosticKey === key) return;
+		this.#commandDiagnosticKey = key;
+		logger.warn(message, details);
+	}
+
+	#refreshCommandInBackground(options: StatusLineCommandOptions | undefined): string {
+		const resolved = normalizeStatusLineCommandOptions(options);
+		const key = JSON.stringify(resolved);
+		if (this.#commandConfigKey !== key) {
+			this.#commandConfigKey = key;
+			this.#commandOutput = null;
+			this.#commandFailed = false;
+			this.#commandFetchedAt = 0;
+			this.#commandDiagnosticKey = undefined;
+			this.#renderedRowsCache = undefined;
+		}
+
+		if (!resolved.command) {
+			this.#commandFailed = true;
+			this.#logCommandDiagnostic(key, "Status line command segment is configured without a command");
+			return key;
+		}
+
+		const now = Date.now();
+		if (this.#commandInFlightKey === key || now - this.#commandFetchedAt < resolved.refreshMs) return key;
+
+		this.#commandInFlightKey = key;
+		let shellConfig: { shell: string; args: string[]; env: Record<string, string> };
+		try {
+			shellConfig = this.session.settings.getShellConfig();
+		} catch (error) {
+			this.#commandInFlightKey = undefined;
+			this.#commandFailed = true;
+			this.#commandFetchedAt = Date.now();
+			this.#logCommandDiagnostic(key, "Status line command shell configuration failed", {
+				error: sanitizeStatusText(error instanceof Error ? error.message : String(error)).slice(0, 256),
+			});
+			return key;
+		}
+
+		void runStatusLineCommand(resolved.command, {
+			cwd: getProjectDir(),
+			shell: shellConfig.shell,
+			shellArgs: shellConfig.args,
+			env: shellConfig.env,
+			timeoutMs: resolved.timeoutMs,
+		})
+			.then(result => {
+				if (this.#disposed || this.#commandConfigKey !== key) return;
+				this.#commandFetchedAt = Date.now();
+				if (result.timedOut || result.exitCode !== 0) {
+					this.#commandFailed = true;
+					this.#logCommandDiagnostic(key, "Status line command failed", {
+						exitCode: result.exitCode,
+						timedOut: result.timedOut,
+						stderr: result.stderr,
+						outputTruncated: result.outputTruncated,
+					});
+				} else {
+					this.#commandOutput = result.stdout;
+					this.#commandFailed = false;
+					this.#commandDiagnosticKey = undefined;
+				}
+				this.#renderedRowsCache = undefined;
+				this.#notifyUpdate();
+			})
+			.catch(error => {
+				if (this.#disposed || this.#commandConfigKey !== key) return;
+				this.#commandFetchedAt = Date.now();
+				this.#commandFailed = true;
+				this.#logCommandDiagnostic(key, "Status line command could not start", {
+					error: sanitizeStatusText(error instanceof Error ? error.message : String(error)).slice(0, 256),
+				});
+				this.#renderedRowsCache = undefined;
+				this.#notifyUpdate();
+			})
+			.finally(() => {
+				if (this.#commandInFlightKey === key) this.#commandInFlightKey = undefined;
+			});
+		return key;
 	}
 
 	invalidate(): void {
@@ -633,6 +743,10 @@ export class StatusLineComponent implements Component {
 		// treats a null value as hidden, so gating here is behavior-identical.
 		const prSegmentActive =
 			effectiveSettings.leftSegments.includes("pr") || effectiveSettings.rightSegments.includes("pr");
+		const commandSegmentActive =
+			effectiveSettings.leftSegments.includes("command") || effectiveSettings.rightSegments.includes("command");
+		const commandOptions = normalizeStatusLineCommandOptions(effectiveSettings.segmentOptions.command);
+		const commandKey = commandSegmentActive ? this.#refreshCommandInBackground(commandOptions) : undefined;
 
 		return {
 			session: this.session,
@@ -654,6 +768,13 @@ export class StatusLineComponent implements Component {
 				pr: prSegmentActive ? this.#lookupPr() : null,
 			},
 			usage: this.#cachedUsage,
+			command: commandKey
+				? {
+						output: this.#commandOutput,
+						failed: this.#commandFailed,
+						pending: this.#commandInFlightKey === commandKey,
+					}
+				: undefined,
 		};
 	}
 

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -745,6 +745,10 @@ export class InteractiveMode implements InteractiveModeContext {
 			version: this.#version,
 			focusDomain: "composer",
 			keyDisplayContext: this.#keyDisplayContext,
+			onUpdate: () => {
+				this.updateEditorChrome();
+				this.ui.requestRender();
+			},
 		});
 		this.statusLine.setAutoCompactEnabled(session.autoCompactionEnabled);
 

--- a/packages/coding-agent/src/sdk/bus/slack-daemon.ts
+++ b/packages/coding-agent/src/sdk/bus/slack-daemon.ts
@@ -1496,7 +1496,11 @@ export class SlackNotificationDaemon {
 				updatedAt: this.#now(),
 			});
 		});
-		return sessionId && receipt ? { key, endpoint, sessionId, receipt } : undefined;
+		if (!sessionId || !receipt) {
+			await this.#journal.terminalize(effectId, { status: "rejected" });
+			return undefined;
+		}
+		return { key, endpoint, sessionId, receipt };
 	}
 
 	async #dispatchInbound(claim: {
@@ -2020,7 +2024,8 @@ export class SlackNotificationDaemon {
 				current.seenEventIds.includes(routing.eventId) ||
 				current.seenInteractionIds.includes(routing.interactionId) ||
 				current.seenRetryKeys.includes(routing.retryKey) ||
-				(routing.kind === "action" && replyableActionId(current.pendingActionId) !== routing.actionId)
+				(routing.kind === "action" && replyableActionId(current.pendingActionId) !== routing.actionId) ||
+				(routing.kind === "message" && replyableActionId(current.pendingActionId) !== undefined)
 			)
 				return current;
 			receipt = {

--- a/packages/coding-agent/test/status-line-command.test.ts
+++ b/packages/coding-agent/test/status-line-command.test.ts
@@ -97,41 +97,62 @@ describe("status line command segment", () => {
 
 	it("does not block the render while a slow command is running", async () => {
 		const component = makeComponent("sleep 0.2; printf too-late", { timeoutMs: 50 });
-		const started = performance.now();
-		const initial = Bun.stripANSI(component.render(120).join("\n"));
-		const elapsed = performance.now() - started;
+		try {
+			const started = performance.now();
+			const initial = Bun.stripANSI(component.render(120).join("\n"));
+			const elapsed = performance.now() - started;
 
-		expect(elapsed).toBeLessThan(100);
-		expect(initial).toContain("…");
+			expect(elapsed).toBeLessThan(100);
+			expect(initial).toContain("…");
 
-		await Bun.sleep(150);
-		const afterTimeout = Bun.stripANSI(component.render(120).join("\n"));
-		expect(afterTimeout).toContain("?");
-		expect(afterTimeout).not.toContain("too-late");
+			const afterTimeout = await waitForRendered(component, rendered => rendered.includes("?"));
+			expect(afterTimeout).toContain("?");
+			expect(afterTimeout).not.toContain("too-late");
+		} finally {
+			component.dispose();
+		}
 	});
 
 	it("keeps command failures out of the status row", async () => {
 		const component = makeComponent("printf leaked-error >&2; exit 7");
-		component.render(120);
+		try {
+			component.render(120);
 
-		await Bun.sleep(100);
-		const rendered = Bun.stripANSI(component.render(120).join("\n"));
-
-		expect(rendered).toContain("?");
-		expect(rendered).not.toContain("leaked-error");
+			const rendered = await waitForRendered(component, rendered => rendered.includes("?"));
+			expect(rendered).toContain("?");
+			expect(rendered).not.toContain("leaked-error");
+		} finally {
+			component.dispose();
+		}
 	});
 
 	it("renders successful command output asynchronously", async () => {
 		const component = makeComponent("printf 'custom-hud-value'");
-		const initial = Bun.stripANSI(component.render(120).join("\n"));
-		expect(initial).not.toContain("custom-hud-value");
+		try {
+			const initial = Bun.stripANSI(component.render(120).join("\n"));
+			expect(initial).not.toContain("custom-hud-value");
 
-		await Bun.sleep(100);
-		const rendered = Bun.stripANSI(component.render(120).join("\n"));
-		expect(rendered).toContain("custom-hud-value");
-		component.dispose();
+			const rendered = await waitForRendered(component, rendered => rendered.includes("custom-hud-value"));
+			expect(rendered).toContain("custom-hud-value");
+		} finally {
+			component.dispose();
+		}
 	});
 });
+
+async function waitForRendered(
+	component: StatusLineComponent,
+	predicate: (rendered: string) => boolean,
+): Promise<string> {
+	const deadline = Date.now() + 1500;
+	let rendered = "";
+	while (Date.now() < deadline) {
+		rendered = Bun.stripANSI(component.render(120).join("\n"));
+		if (predicate(rendered)) return rendered;
+		await Bun.sleep(10);
+	}
+	return rendered;
+}
 
 function makeComponent(command: string, overrides: { timeoutMs?: number } = {}): StatusLineComponent {
 	const component = new StatusLineComponent({

--- a/packages/coding-agent/test/status-line-command.test.ts
+++ b/packages/coding-agent/test/status-line-command.test.ts
@@ -1,6 +1,9 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
 import { visibleWidth } from "@gajae-code/tui";
-import { resetSettingsForTest, Settings, settings } from "../src/config/settings";
+import { resetSettingsForTest, Settings } from "../src/config/settings";
 import type { StatusLineSegmentId } from "../src/config/settings-schema";
 import {
 	normalizeStatusLineCommandOptions,
@@ -138,6 +141,86 @@ describe("status line command segment", () => {
 			component.dispose();
 		}
 	});
+
+	it("refreshes an idle command without another incidental render", async () => {
+		const marker = path.join(os.tmpdir(), `gjc-status-line-refresh-${Date.now()}.txt`);
+		const quotedMarker = marker.replaceAll("'", "'\\''");
+		const command =
+			`count=0; if [ -f '${quotedMarker}' ]; then count=$(cat '${quotedMarker}'); fi; ` +
+			`count=$((count + 1)); printf '%s' "$count" > '${quotedMarker}'; printf 'refresh-%s' "$count"`;
+		let component: StatusLineComponent | undefined;
+		try {
+			component = makeComponent(command, { refreshMs: 100 }, undefined, () => {
+				component?.render(120);
+			});
+			component.render(120);
+			const deadline = Date.now() + 2_000;
+			let fileText = "";
+			while (Date.now() < deadline) {
+				fileText = await Bun.file(marker)
+					.text()
+					.catch(() => "");
+				if (fileText === "2") break;
+				await Bun.sleep(10);
+			}
+			expect(fileText).toBe("2");
+		} finally {
+			component?.dispose();
+			await fs.rm(marker, { force: true });
+		}
+	});
+
+	it("does not execute a command supplied only by project-scoped status settings", async () => {
+		const projectDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-status-line-project-"));
+		const marker = path.join(os.tmpdir(), `gjc-status-line-project-command-${Date.now()}.txt`);
+		const quotedMarker = marker.replaceAll("'", "'\\''");
+		const command = `printf project-command > '${quotedMarker}'`;
+		await fs.mkdir(path.join(projectDir, ".gjc"), { recursive: true });
+		await Bun.write(
+			path.join(projectDir, ".gjc", "config.yml"),
+			`statusLine:\n  preset: custom\n  leftSegments:\n    - command\n  segmentOptions:\n    command:\n      command: ${JSON.stringify(command)}\n`,
+		);
+		const sessionSettings = await Settings.loadForScope({
+			cwd: projectDir,
+			agentDir: path.join(projectDir, "agent"),
+		});
+		const component = makeComponent(command, {}, sessionSettings);
+		try {
+			component.render(120);
+			await Bun.sleep(150);
+			expect(
+				await Bun.file(marker)
+					.text()
+					.catch(() => ""),
+			).toBe("");
+		} finally {
+			component.dispose();
+			await sessionSettings.close();
+			await fs.rm(marker, { force: true });
+			await fs.rm(projectDir, { recursive: true, force: true });
+		}
+	});
+
+	it("cancels an active command when the status component is disposed", async () => {
+		const marker = path.join(os.tmpdir(), `gjc-status-line-dispose-${Date.now()}.txt`);
+		const quotedMarker = marker.replaceAll("'", "'\\''");
+		const component = makeComponent(`sleep 1; printf disposed-command > '${quotedMarker}'`, {
+			timeoutMs: 5_000,
+		});
+		try {
+			component.render(120);
+			component.dispose();
+			await Bun.sleep(1_200);
+			expect(
+				await Bun.file(marker)
+					.text()
+					.catch(() => ""),
+			).toBe("");
+		} finally {
+			component.dispose();
+			await fs.rm(marker, { force: true });
+		}
+	});
 });
 
 async function waitForRendered(
@@ -154,26 +237,47 @@ async function waitForRendered(
 	return rendered;
 }
 
-function makeComponent(command: string, overrides: { timeoutMs?: number } = {}): StatusLineComponent {
-	const component = new StatusLineComponent({
-		state: { messages: [] },
-		settings,
-		isStreaming: false,
-		isFastModeActive: () => false,
-		modelRegistry: { isUsingOAuth: () => false },
-		sessionManager: {
-			getUsageStatistics: () => ({
-				input: 0,
-				output: 0,
-				cacheRead: 0,
-				cacheWrite: 0,
-				premiumRequests: 0,
-				cost: 0,
-			}),
-			getSessionName: () => "command-test",
-		},
-		getAsyncJobSnapshot: () => ({ running: [] }),
-	} as unknown as ConstructorParameters<typeof StatusLineComponent>[0]);
+function makeComponent(
+	command: string,
+	overrides: { timeoutMs?: number; refreshMs?: number } = {},
+	sessionSettings?: Settings,
+	onUpdate?: () => void,
+): StatusLineComponent {
+	const resolvedSettings =
+		sessionSettings ??
+		Settings.isolated({
+			"statusLine.leftSegments": ["command"],
+			"statusLine.segmentOptions": {
+				command: {
+					command,
+					timeoutMs: overrides.timeoutMs,
+					refreshMs: overrides.refreshMs ?? 250,
+					maxLength: 40,
+				},
+			},
+		});
+	const component = new StatusLineComponent(
+		{
+			state: { messages: [] },
+			settings: resolvedSettings,
+			isStreaming: false,
+			isFastModeActive: () => false,
+			modelRegistry: { isUsingOAuth: () => false },
+			sessionManager: {
+				getUsageStatistics: () => ({
+					input: 0,
+					output: 0,
+					cacheRead: 0,
+					cacheWrite: 0,
+					premiumRequests: 0,
+					cost: 0,
+				}),
+				getSessionName: () => "command-test",
+			},
+			getAsyncJobSnapshot: () => ({ running: [] }),
+		} as unknown as ConstructorParameters<typeof StatusLineComponent>[0],
+		{ onUpdate },
+	);
 	component.updateSettings({
 		preset: "custom",
 		leftSegments: ["command" as StatusLineSegmentId],
@@ -186,7 +290,7 @@ function makeComponent(command: string, overrides: { timeoutMs?: number } = {}):
 			command: {
 				command,
 				timeoutMs: overrides.timeoutMs,
-				refreshMs: 250,
+				refreshMs: overrides.refreshMs ?? 250,
 				maxLength: 40,
 			},
 		},

--- a/packages/coding-agent/test/status-line-command.test.ts
+++ b/packages/coding-agent/test/status-line-command.test.ts
@@ -1,0 +1,174 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { visibleWidth } from "@gajae-code/tui";
+import { resetSettingsForTest, Settings, settings } from "../src/config/settings";
+import type { StatusLineSegmentId } from "../src/config/settings-schema";
+import {
+	normalizeStatusLineCommandOptions,
+	STATUS_LINE_COMMAND_MAX_LENGTH,
+} from "../src/modes/components/status-line/command";
+import { renderSegment } from "../src/modes/components/status-line/segments";
+import type { SegmentContext } from "../src/modes/components/status-line/types";
+import { StatusLineComponent } from "../src/modes/components/tool-status-header";
+import { EMPTY_JOBS_SNAPSHOT } from "../src/modes/jobs-observer";
+import { initTheme } from "../src/modes/theme/theme";
+
+beforeAll(async () => {
+	resetSettingsForTest();
+	await Settings.init({ inMemory: true });
+	await initTheme();
+});
+
+afterAll(() => {
+	resetSettingsForTest();
+});
+
+function commandContext(output: string): SegmentContext {
+	return {
+		session: {
+			state: {},
+			modelRegistry: { isUsingOAuth: () => false },
+		} as unknown as SegmentContext["session"],
+		width: 120,
+		options: { command: { maxLength: 40 } },
+		planMode: null,
+		goalMode: null,
+		usageStats: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			premiumRequests: 0,
+			cost: 0,
+			tokensPerSecond: null,
+		},
+		contextPercent: null,
+		contextWindow: 0,
+		autoCompactEnabled: false,
+		subagentCount: 0,
+		jobs: EMPTY_JOBS_SNAPSHOT,
+		sessionStartTime: Date.now(),
+		git: { branch: null, status: null, pr: null },
+		usage: null,
+		command: { output, failed: false, pending: false },
+	} as unknown as SegmentContext;
+}
+
+describe("status line command segment", () => {
+	it("reproduces the missing user-produced status content path", () => {
+		const rendered = renderSegment("command" as StatusLineSegmentId, commandContext("deploy-ready"));
+
+		expect(rendered.visible).toBe(true);
+		expect(Bun.stripANSI(rendered.content)).toContain("deploy-ready");
+	});
+
+	it("sanitizes terminal controls and bounds user output before layout", () => {
+		const rendered = renderSegment(
+			"command" as StatusLineSegmentId,
+			commandContext("\x1b[31msecret\x1b[0m\tvalue\nthat-is-too-long"),
+		);
+		const text = Bun.stripANSI(rendered.content);
+
+		expect(rendered.visible).toBe(true);
+		expect(text).toContain("secret value");
+		expect(text).not.toContain("\x1b[");
+		expect(text).not.toContain("\n");
+		expect(visibleWidth(text)).toBeLessThanOrEqual(40);
+	});
+
+	it("shows a bounded diagnostic for an unknown configured segment", () => {
+		const rendered = renderSegment("not-a-real-segment" as StatusLineSegmentId, commandContext("unused"));
+		const text = Bun.stripANSI(rendered.content);
+
+		expect(rendered.visible).toBe(true);
+		expect(text).toContain("?unknown:not-a-real-seg");
+		expect(visibleWidth(text)).toBeLessThanOrEqual(31);
+	});
+
+	it("clamps command execution settings to safe bounds", () => {
+		expect(
+			normalizeStatusLineCommandOptions({
+				command: "  printf ok  ",
+				timeoutMs: Number.POSITIVE_INFINITY,
+				refreshMs: 1,
+				maxLength: STATUS_LINE_COMMAND_MAX_LENGTH + 100,
+			}),
+		).toEqual({ command: "printf ok", timeoutMs: 500, refreshMs: 250, maxLength: STATUS_LINE_COMMAND_MAX_LENGTH });
+	});
+
+	it("does not block the render while a slow command is running", async () => {
+		const component = makeComponent("sleep 0.2; printf too-late", { timeoutMs: 50 });
+		const started = performance.now();
+		const initial = Bun.stripANSI(component.render(120).join("\n"));
+		const elapsed = performance.now() - started;
+
+		expect(elapsed).toBeLessThan(100);
+		expect(initial).toContain("…");
+
+		await Bun.sleep(150);
+		const afterTimeout = Bun.stripANSI(component.render(120).join("\n"));
+		expect(afterTimeout).toContain("?");
+		expect(afterTimeout).not.toContain("too-late");
+	});
+
+	it("keeps command failures out of the status row", async () => {
+		const component = makeComponent("printf leaked-error >&2; exit 7");
+		component.render(120);
+
+		await Bun.sleep(100);
+		const rendered = Bun.stripANSI(component.render(120).join("\n"));
+
+		expect(rendered).toContain("?");
+		expect(rendered).not.toContain("leaked-error");
+	});
+
+	it("renders successful command output asynchronously", async () => {
+		const component = makeComponent("printf 'custom-hud-value'");
+		const initial = Bun.stripANSI(component.render(120).join("\n"));
+		expect(initial).not.toContain("custom-hud-value");
+
+		await Bun.sleep(100);
+		const rendered = Bun.stripANSI(component.render(120).join("\n"));
+		expect(rendered).toContain("custom-hud-value");
+		component.dispose();
+	});
+});
+
+function makeComponent(command: string, overrides: { timeoutMs?: number } = {}): StatusLineComponent {
+	const component = new StatusLineComponent({
+		state: { messages: [] },
+		settings,
+		isStreaming: false,
+		isFastModeActive: () => false,
+		modelRegistry: { isUsingOAuth: () => false },
+		sessionManager: {
+			getUsageStatistics: () => ({
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				premiumRequests: 0,
+				cost: 0,
+			}),
+			getSessionName: () => "command-test",
+		},
+		getAsyncJobSnapshot: () => ({ running: [] }),
+	} as unknown as ConstructorParameters<typeof StatusLineComponent>[0]);
+	component.updateSettings({
+		preset: "custom",
+		leftSegments: ["command" as StatusLineSegmentId],
+		rightSegments: [],
+		showSkillHud: false,
+		showHookStatus: false,
+		showActionHints: false,
+		sessionAccent: false,
+		segmentOptions: {
+			command: {
+				command,
+				timeoutMs: overrides.timeoutMs,
+				refreshMs: 250,
+				maxLength: 40,
+			},
+		},
+	});
+	return component;
+}


### PR DESCRIPTION
## What

Add a `command` status-line segment that renders bounded, sanitized output from a configured shell command without blocking the TUI.

## Why

Fixes #5246. The existing custom status-line layout supported only built-in segments, so users could not surface their own HUD data as requested.

## Testing

- `bun test test/status-line-command.test.ts test/status-line-cache.test.ts test/status-line-cache-redteam.test.ts test/status-line-overflow.test.ts test/modes/components/settings-selector-status-line-custom.test.ts test/gjc-ui-redesign.test.ts`
- `bun --bun run check` in `packages/coding-agent` (the repository's package check; the host Node 12 launcher cannot run its Node-shebang binaries directly)

## Risk classification

- [ ] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [x] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:83f2c55f0a15280060253ae2081940b536d227b0e9a9a4b8ad667aac31b83fff reviewer:human reviewer-id:snowykr evidence:97 focused status-line tests and coding-agent check passed; exact head 9d2480dfd5be54896bdda8de4026d4538d3253af rebased onto live dev cdbf15d021f3bc002af9efa643ade3cd4df0b7c6
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken
