### PR TITLE
fix(ai): make Cursor payload hooks JSON-safe

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Cursor payload hooks now receive protobuf requests as JSON-safe values, await asynchronous inspection or replacement, and validate replacement payloads before transport. Checkpoint state containing 64-bit protobuf fields no longer makes hook-side `JSON.stringify` fail on JavaScript `bigint` values.
+
 ## [0.16.1] - 2026-09-03
 
 ### Added

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -689,7 +689,7 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 			conversationUsageContextCache.set(conversationId, usageContext);
 			const reusableCachedState =
 				cachedState && canReuseCursorUsageContext(previousUsageContext, usageContext) ? cachedState : undefined;
-			const { requestBytes, conversationState } = buildGrpcRequest(model, context, options, {
+			const { requestBytes, conversationState } = await buildGrpcRequest(model, context, options, {
 				conversationId,
 				blobStore,
 				conversationState: reusableCachedState,
@@ -3459,7 +3459,7 @@ function extractImages(content: (TextContent | ImageContent)[]) {
 		);
 }
 
-function buildGrpcRequest(
+async function buildGrpcRequest(
 	model: Model<"cursor-agent">,
 	context: Context,
 	options: CursorOptions | undefined,
@@ -3468,11 +3468,11 @@ function buildGrpcRequest(
 		blobStore: Map<string, Uint8Array>;
 		conversationState?: ConversationStateStructure;
 	},
-): {
+): Promise<{
 	requestBytes: Uint8Array;
 	blobStore: Map<string, Uint8Array>;
 	conversationState: ConversationStateStructure;
-} {
+}> {
 	const blobStore = state.blobStore;
 
 	const systemPromptIds = buildCursorSystemPromptJsons(context.systemPrompt, model.id).map(json =>
@@ -3558,7 +3558,7 @@ function buildGrpcRequest(
 		displayName: model.name,
 	});
 
-	const runRequest = create(AgentRunRequestSchema, {
+	let runRequest = create(AgentRunRequestSchema, {
 		conversationState,
 		action,
 		modelDetails,
@@ -3573,7 +3573,13 @@ function buildGrpcRequest(
 			: {}),
 	});
 
-	options?.onPayload?.(runRequest, model, options?.attemptScope);
+	if (options?.onPayload) {
+		const payload = toJson(AgentRunRequestSchema, runRequest);
+		const replacement = await options.onPayload(payload, model, options.attemptScope);
+		if (replacement !== undefined) {
+			runRequest = fromJson(AgentRunRequestSchema, replacement as JsonValue);
+		}
+	}
 
 	// Tools are sent later via requestContext (exec handshake)
 

--- a/packages/ai/test/cursor-exec-handlers.test.ts
+++ b/packages/ai/test/cursor-exec-handlers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import * as http2 from "node:http2";
-import { create, fromBinary, toBinary } from "@bufbuild/protobuf";
+import { create, fromBinary, fromJson, type JsonValue, toBinary } from "@bufbuild/protobuf";
 import {
 	buildCursorHistoryForTest,
 	buildCursorRequestContextRules,
@@ -14,6 +14,7 @@ import type { AgentRunRequest, AgentServerMessage } from "../src/providers/curso
 import {
 	type AgentClientMessage,
 	AgentClientMessageSchema,
+	AgentRunRequestSchema,
 	AgentServerMessageSchema,
 	ConversationStateStructureSchema,
 	ConversationTokenDetailsSchema,
@@ -47,19 +48,16 @@ function captureCursorPayload(context: Context): Promise<AgentRunRequest> {
 	streamCursor(cursorModel, context, {
 		apiKey: "test-token",
 		onPayload: payload => {
-			if (isAgentRunRequest(payload)) {
-				resolve(payload);
-			} else {
-				reject(new Error("Cursor payload was not an AgentRunRequest"));
+			try {
+				JSON.stringify(payload);
+				resolve(fromJson(AgentRunRequestSchema, payload as JsonValue));
+			} catch (error) {
+				reject(error);
 			}
 			throw new Error("stop after capturing Cursor payload");
 		},
 	});
 	return promise;
-}
-
-function isAgentRunRequest(payload: unknown): payload is AgentRunRequest {
-	return !!payload && typeof payload === "object" && "$typeName" in payload;
 }
 
 function frameServerMessage(message: AgentServerMessage): Buffer {
@@ -140,7 +138,6 @@ function createReadSuccessResult(output: string) {
 		},
 	});
 }
-
 describe("Cursor resolveExecHandler execHandlers binding", () => {
 	it("invokes handler with correct this when passed as bound method", async () => {
 		const sentinel = { tag: "bound-correctly" };

--- a/packages/ai/test/cursor-exec-handlers.test.ts
+++ b/packages/ai/test/cursor-exec-handlers.test.ts
@@ -47,7 +47,8 @@ function captureCursorPayload(context: Context): Promise<AgentRunRequest> {
 	const { promise, resolve, reject } = Promise.withResolvers<AgentRunRequest>();
 	streamCursor(cursorModel, context, {
 		apiKey: "test-token",
-		onPayload: payload => {
+		onPayload: async payload => {
+			await Bun.sleep(1);
 			try {
 				JSON.stringify(payload);
 				resolve(fromJson(AgentRunRequestSchema, payload as JsonValue));


### PR DESCRIPTION
## What

- Expose Cursor request payload hooks as canonical protobuf JSON instead of live protobuf objects.
- Await asynchronous payload hooks and validate replacement payloads through protobuf decoding before transport.
- Cover JSON serializability and the asynchronous hook boundary.

## Why

Cursor checkpoint state can contain protobuf 64-bit fields represented as JavaScript `bigint`. Passing the live protobuf request to `onPayload` causes hooks or recorders using `JSON.stringify` to fail before transport with `JSON.stringify cannot serialize BigInt`.

## Testing

- `bun test packages/ai/test/cursor-exec-handlers.test.ts` — 27 passed, 0 failed.
- `bun --cwd=packages/ai run check` — passed (Biome reported two pre-existing informational diagnostics; TypeScript passed).
- `bun scripts/verify-gjc-state-writers.ts --fail` — passed.
- `git diff --check origin/dev...HEAD` — passed.

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:fd1651543904d5746c025dd68be610b693cbb34b753148d9d478cff24ecff54c reviewer:human reviewer-id:Yeachan-Heo evidence:bun-test-cursor-exec-handlers-and-packages-ai-check
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken
