### PR TITLE
fix(model-selector): defer full catalog loading

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Mid-run OpenAI remote-compaction fallback failures now stop before another provider request, surface the local summarization error through ACP/SDK terminal handling, and leave the uncompacted context unsubmitted. Successful local fallback still commits the compaction and resumes normally.
+- Opening `/model` now renders the preset landing before loading the full model browser catalog. Available-model enumeration, canonical search indexing, sorting, and the redundant offline registry refresh are deferred until the user searches or chooses a browse action, while scoped and direct-search selectors still load immediately.
 - `/model` provider-tab refreshes now reuse the already loaded static catalog and update only the selected provider's discovery state, avoiding repeated signed preset registry work while retaining full-catalog refresh behavior for static configuration changes.
 - Added the `command` status-line segment for user-produced HUD content. It runs
   configured user/global shell commands in the background with scheduled cached

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 - Mid-run OpenAI remote-compaction fallback failures now stop before another provider request, surface the local summarization error through ACP/SDK terminal handling, and leave the uncompacted context unsubmitted. Successful local fallback still commits the compaction and resumes normally.
-- Opening `/model` now renders the preset landing before loading the full model browser catalog. Available-model enumeration, canonical search indexing, sorting, and the redundant offline registry refresh are deferred until the user searches or chooses a browse action, while scoped and direct-search selectors still load immediately.
+- Opening `/model` now renders the preset landing before constructing the full model browser catalog. Canonical search indexing, sorting, and the redundant offline registry refresh are deferred until the user searches or chooses a browse action, while the lightweight preset-availability check remains immediate and scoped or direct-search selectors still load immediately.
 - `/model` provider-tab refreshes now reuse the already loaded static catalog and update only the selected provider's discovery state, avoiding repeated signed preset registry work while retaining full-catalog refresh behavior for static configuration changes.
 - Added the `command` status-line segment for user-produced HUD content. It runs
   configured user/global shell commands in the background with scheduled cached

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1835,6 +1835,25 @@ export class ModelRegistry {
 	/**
 	 * Reload models from disk (embedded + accepted registry + custom from models.yml).
 	 */
+	async refreshStatic(): Promise<void> {
+		if (this.#disposed) return;
+		await this.#enqueueCatalogMutation(async () => {
+			if (this.#disposed) return;
+			this.#catalogRefreshGeneration++;
+			this.#suspendRebuild();
+			try {
+				this.#reloadStaticModels();
+				this.#suppressedSelectors.clear();
+				this.#modelBindingsApplier.apply();
+			} finally {
+				this.#resumeRebuild();
+			}
+		});
+	}
+
+	/**
+	 * Reload models from disk and refresh runtime provider discovery state.
+	 */
 	async refresh(strategy: ModelRefreshStrategy = "online-if-uncached"): Promise<void> {
 		if (this.#disposed) return;
 		await this.#enqueueCatalogMutation(async () => {

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -410,6 +410,8 @@ export class ModelSelectorComponent extends Container {
 	#unsubscribeProviderOrderChanged: () => void = () => {};
 	#unsubscribeAuthGeneration: () => void = () => {};
 	#disposed = false;
+	#catalogLoaded = false;
+	#catalogLoadPromise?: Promise<void>;
 	/** Standalone smart-routing entry: cancel closes the selector instead of falling back to the preset landing. */
 	#smartRoutingOnly = false;
 
@@ -545,13 +547,16 @@ export class ModelSelectorComponent extends Container {
 			this.#unsubscribeCatalogChanged = this.#modelRegistry.onCatalogChanged(() => {
 				if (this.#disposed) return;
 				if (this.#viewMode === "presets") {
-					this.#refreshCatalogView();
+					this.#rebuildRoleModels();
 					this.#clampPresetCursor();
 					void this.#refreshProviderAuth();
 					this.#renderPresetLanding();
 					this.#tui.requestRender();
 					return;
 				}
+				// The in-flight load already consumes the latest registry snapshot. Avoid
+				// materializing the same catalog again from its own change notification.
+				if (!this.#catalogLoaded || this.#catalogLoadPromise) return;
 				if (this.#refreshCatalogView()) this.#tui.requestRender();
 			});
 		}
@@ -572,34 +577,16 @@ export class ModelSelectorComponent extends Container {
 				void this.#refreshProviderAuth();
 			}) ?? (() => {});
 
-		// Load models and do initial render
-		this.#loadModels().then(() => {
-			this.#buildProviderTabs();
-			if (this.#smartRoutingOnly) {
-				this.#enterSmartRoutingMode();
-				this.#tui.requestRender();
-				return;
-			}
-			if (this.#viewMode === "presets" && (this.#modelRegistry.getModelProfiles?.().size ?? 0) === 0) {
-				this.#viewMode = "models";
-			}
-			if (this.#viewMode === "presets") {
-				void this.#refreshProviderAuth();
-				this.#renderPresetLanding();
-			} else {
-				this.#updateTabBar();
-				// Always apply the current search query — the user may have typed
-				// while models were loading asynchronously.
-				const currentQuery = this.#searchInput.getValue();
-				if (currentQuery) {
-					this.#filterModels(currentQuery);
-				} else {
-					this.#updateList();
-				}
-			}
-			// Request re-render after models are loaded
+		if (this.#viewMode === "presets" && (this.#modelRegistry.getModelProfiles?.().size ?? 0) > 0) {
+			// The landing only needs profile definitions and provider authentication.
+			// Do not enumerate and canonicalize the full model catalog until browsing.
+			void this.#refreshProviderAuth();
+			this.#renderPresetLanding();
 			this.#tui.requestRender();
-		});
+		} else {
+			if (this.#viewMode === "presets") this.#viewMode = "models";
+			void this.#initializeCatalogView();
+		}
 	}
 
 	override dispose(): void {
@@ -1695,8 +1682,44 @@ export class ModelSelectorComponent extends Container {
 		this.#selectedIndex = 0;
 		this.#imageRoleFilter = options?.imageRoleFilter ?? false;
 		this.#setSearchInputValue(seed ?? this.#searchInput.getValue());
+		void this.#initializeCatalogView();
+	}
+
+	async #initializeCatalogView(): Promise<void> {
+		if (this.#catalogLoaded) {
+			this.#presentCatalogView();
+			return;
+		}
+		if (this.#catalogLoadPromise) return this.#catalogLoadPromise;
+
+		this.#headerContainer.clear();
+		this.#listContainer.clear();
+		this.#listContainer.addChild(new Text(theme.fg("muted", "Loading models..."), 0, 0));
+		this.#tui.requestRender();
+
+		const load = this.#loadModels().then(() => {
+			this.#catalogLoaded = true;
+			if (this.#disposed) return;
+			if (this.#smartRoutingOnly) {
+				this.#enterSmartRoutingMode();
+				return;
+			}
+			if (this.#viewMode === "models") this.#presentCatalogView();
+		});
+		this.#catalogLoadPromise = load;
+		try {
+			await load;
+		} finally {
+			if (this.#catalogLoadPromise === load) this.#catalogLoadPromise = undefined;
+		}
+	}
+
+	#presentCatalogView(): void {
+		this.#buildProviderTabs();
 		this.#updateTabBar();
+		// Apply the latest query: input remains responsive while the catalog loads.
 		this.#filterModels(this.#searchInput.getValue());
+		this.#tui.requestRender();
 	}
 
 	/**

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -1731,7 +1731,7 @@ export class ModelSelectorComponent extends Container {
 		try {
 			await load;
 		} catch (error) {
-			if (!this.#disposed && this.#viewMode === "models") {
+			if (!this.#disposed && (this.#viewMode === "models" || this.#viewMode === "smart-routing")) {
 				this.#errorMessage = error instanceof Error ? error.message : String(error);
 				this.#buildProviderTabs();
 				this.#updateTabBar();

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -412,6 +412,7 @@ export class ModelSelectorComponent extends Container {
 	#disposed = false;
 	#catalogLoaded = false;
 	#catalogLoadPromise?: Promise<void>;
+	#presetCatalogRefreshPending = false;
 	/** Standalone smart-routing entry: cancel closes the selector instead of falling back to the preset landing. */
 	#smartRoutingOnly = false;
 
@@ -547,6 +548,7 @@ export class ModelSelectorComponent extends Container {
 			this.#unsubscribeCatalogChanged = this.#modelRegistry.onCatalogChanged(() => {
 				if (this.#disposed) return;
 				if (this.#viewMode === "presets") {
+					if (this.#presetCatalogRefreshPending) return;
 					this.#rebuildRoleModels();
 					this.#clampPresetCursor();
 					void this.#refreshProviderAuth();
@@ -579,10 +581,11 @@ export class ModelSelectorComponent extends Container {
 
 		if (this.#viewMode === "presets" && (this.#modelRegistry.getModelProfiles?.().size ?? 0) > 0) {
 			// The landing only needs profile definitions and provider authentication.
-			// Do not enumerate and canonicalize the full model catalog until browsing.
-			void this.#refreshProviderAuth();
+			// Refresh static configuration without enumerating and canonicalizing the
+			// full browser catalog, then resolve preset authentication once.
 			this.#renderPresetLanding();
 			this.#tui.requestRender();
+			void this.#initializePresetLanding();
 		} else {
 			if (this.#viewMode === "presets") this.#viewMode = "models";
 			void this.#initializeCatalogView();
@@ -1671,6 +1674,24 @@ export class ModelSelectorComponent extends Container {
 		this.#searchInput.setValue(value);
 	}
 
+	async #initializePresetLanding(): Promise<void> {
+		this.#presetCatalogRefreshPending = true;
+		try {
+			const refreshStatic = this.#modelRegistry.refreshStatic;
+			if (typeof refreshStatic === "function") await refreshStatic.call(this.#modelRegistry);
+		} catch (error) {
+			this.#errorMessage = error instanceof Error ? error.message : String(error);
+		} finally {
+			this.#presetCatalogRefreshPending = false;
+		}
+		if (this.#disposed || this.#viewMode !== "presets") return;
+		this.#rebuildRoleModels();
+		this.#clampPresetCursor();
+		void this.#refreshProviderAuth();
+		this.#renderPresetLanding();
+		this.#tui.requestRender();
+	}
+
 	#switchToModelMode(seed?: string, options?: { imageRoleFilter?: boolean }): void {
 		this.#viewMode = "models";
 		this.#expandedPresetProviderId = undefined;
@@ -1709,6 +1730,14 @@ export class ModelSelectorComponent extends Container {
 		this.#catalogLoadPromise = load;
 		try {
 			await load;
+		} catch (error) {
+			if (!this.#disposed && this.#viewMode === "models") {
+				this.#errorMessage = error instanceof Error ? error.message : String(error);
+				this.#buildProviderTabs();
+				this.#updateTabBar();
+				this.#updateList();
+				this.#tui.requestRender();
+			}
 		} finally {
 			if (this.#catalogLoadPromise === load) this.#catalogLoadPromise = undefined;
 		}

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -2357,7 +2357,11 @@ export class ModelSelectorComponent extends Container {
 
 	handleInput(keyData: string): void {
 		if (this.#viewMode === "smart-routing") {
-			this.#smartRoutingPanel?.handleInput(keyData);
+			if (this.#smartRoutingPanel) {
+				this.#smartRoutingPanel.handleInput(keyData);
+			} else if (getKeybindings().matches(keyData, "tui.select.cancel")) {
+				this.#onCancelCallback();
+			}
 			return;
 		}
 		if (this.#assignmentState === "assigning") {

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -557,6 +557,7 @@ export class ModelSelectorComponent extends Container {
 					this.#tui.requestRender();
 					return;
 				}
+				if (this.#viewMode === "smart-routing" && this.#smartRoutingPanel) return;
 				// The in-flight load already consumes the latest registry snapshot. Avoid
 				// materializing the same catalog again from its own change notification.
 				if (this.#catalogLoadPromise) return;

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -413,6 +413,7 @@ export class ModelSelectorComponent extends Container {
 	#catalogLoaded = false;
 	#catalogLoadPromise?: Promise<void>;
 	#presetCatalogRefreshPending = false;
+	#openSmartRoutingAfterPresetRefresh = false;
 	/** Standalone smart-routing entry: cancel closes the selector instead of falling back to the preset landing. */
 	#smartRoutingOnly = false;
 
@@ -579,15 +580,18 @@ export class ModelSelectorComponent extends Container {
 				void this.#refreshProviderAuth();
 			}) ?? (() => {});
 
-		if (this.#viewMode === "presets" && (this.#modelRegistry.getModelProfiles?.().size ?? 0) > 0) {
+		if (this.#viewMode === "presets") {
 			// The landing only needs profile definitions and provider authentication.
 			// Refresh static configuration without enumerating and canonicalizing the
 			// full browser catalog, then resolve preset authentication once.
-			this.#renderPresetLanding();
+			if ((this.#modelRegistry.getModelProfiles?.().size ?? 0) > 0) {
+				this.#renderPresetLanding();
+			} else {
+				this.#listContainer.addChild(new Text(theme.fg("muted", "Loading model presets..."), 0, 0));
+			}
 			this.#tui.requestRender();
 			void this.#initializePresetLanding();
 		} else {
-			if (this.#viewMode === "presets") this.#viewMode = "models";
 			void this.#initializeCatalogView();
 		}
 	}
@@ -1676,17 +1680,32 @@ export class ModelSelectorComponent extends Container {
 
 	async #initializePresetLanding(): Promise<void> {
 		this.#presetCatalogRefreshPending = true;
+		let refreshFailed = false;
 		try {
 			const refreshStatic = this.#modelRegistry.refreshStatic;
 			if (typeof refreshStatic === "function") await refreshStatic.call(this.#modelRegistry);
+			this.#errorMessage = this.#modelRegistry.getError();
 		} catch (error) {
+			refreshFailed = true;
 			this.#errorMessage = error instanceof Error ? error.message : String(error);
 		} finally {
 			this.#presetCatalogRefreshPending = false;
 		}
 		if (this.#disposed || this.#viewMode !== "presets") return;
+		if ((this.#modelRegistry.getModelProfiles?.().size ?? 0) === 0) {
+			this.#viewMode = "models";
+			void this.#initializeCatalogView();
+			return;
+		}
 		this.#rebuildRoleModels();
 		this.#clampPresetCursor();
+		if (this.#openSmartRoutingAfterPresetRefresh) {
+			this.#openSmartRoutingAfterPresetRefresh = false;
+			if (!refreshFailed) {
+				this.#enterSmartRoutingMode();
+				return;
+			}
+		}
 		void this.#refreshProviderAuth();
 		this.#renderPresetLanding();
 		this.#tui.requestRender();
@@ -1931,6 +1950,12 @@ export class ModelSelectorComponent extends Container {
 		this.#headerContainer.addChild(new Text(theme.fg("accent", "Model presets"), 0, 0));
 		for (const line of this.#formatCurrentSessionLines()) {
 			this.#headerContainer.addChild(new Text(line, 0, 0));
+		}
+		if (this.#errorMessage) {
+			for (const line of String(this.#errorMessage).split("\n")) {
+				this.#listContainer.addChild(new Text(theme.fg("error", line), 0, 0));
+			}
+			this.#listContainer.addChild(new Spacer(1));
 		}
 		const rows = this.#getPresetRows();
 		for (let i = 0; i < rows.length; i++) {
@@ -2560,6 +2585,12 @@ export class ModelSelectorComponent extends Container {
 		const row = this.#getSelectedPresetRow();
 		if (!row) return;
 		if (row.kind === "smartRouting") {
+			if (this.#presetCatalogRefreshPending) {
+				this.#openSmartRoutingAfterPresetRefresh = true;
+				this.#presetLoginHint = "Refreshing model configuration...";
+				this.#renderPresetLanding();
+				return;
+			}
 			this.#enterSmartRoutingMode();
 			return;
 		}

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -559,7 +559,11 @@ export class ModelSelectorComponent extends Container {
 				}
 				// The in-flight load already consumes the latest registry snapshot. Avoid
 				// materializing the same catalog again from its own change notification.
-				if (!this.#catalogLoaded || this.#catalogLoadPromise) return;
+				if (this.#catalogLoadPromise) return;
+				if (!this.#catalogLoaded) {
+					void this.#initializeCatalogView();
+					return;
+				}
 				if (this.#refreshCatalogView()) this.#tui.requestRender();
 			});
 		}

--- a/packages/coding-agent/test/model-preset-landing-redteam-qa.test.ts
+++ b/packages/coding-agent/test/model-preset-landing-redteam-qa.test.ts
@@ -111,6 +111,7 @@ function createRegistry(
 	const profileMap = new Map(profiles.map(profile => [profile.name, profile]));
 	return {
 		refresh: vi.fn(async () => {}),
+		refreshStatic: vi.fn(async () => {}),
 		getError: () => undefined,
 		getAvailable: vi.fn(() => [
 			codexModel,
@@ -203,6 +204,7 @@ describe("preset landing adversarial QA", () => {
 		);
 
 		await rendered(selector);
+		expect(registry.refreshStatic).toHaveBeenCalledTimes(1);
 		expect(registry.refresh).not.toHaveBeenCalled();
 		expect(registry.getAvailable).not.toHaveBeenCalled();
 		expect(registry.getCanonicalModelSelections).not.toHaveBeenCalled();
@@ -214,6 +216,26 @@ describe("preset landing adversarial QA", () => {
 		expect(registry.getAvailable).toHaveBeenCalledTimes(1);
 		expect(registry.getCanonicalModelSelections).toHaveBeenCalledTimes(1);
 		expect(text).toContain("gpt-5.5");
+	});
+
+	test("renders deferred catalog refresh failures instead of hanging on the loading frame", async () => {
+		const registry = createRegistry(["openai-codex"]);
+		registry.refresh.mockRejectedValueOnce(new Error("offline refresh failed"));
+		const selector = new ModelSelectorComponent(
+			{ requestRender: vi.fn() } as unknown as TUI,
+			undefined,
+			Settings.isolated(),
+			registry as never,
+			[],
+			() => {},
+			() => {},
+		);
+
+		await rendered(selector);
+		selector.handleInput("g");
+		const text = await rendered(selector);
+		expect(text).toContain("offline refresh failed");
+		expect(text).not.toContain("Loading models...");
 	});
 	beforeAll(async () => {
 		testTheme = await getThemeByName("red-claw");

--- a/packages/coding-agent/test/model-preset-landing-redteam-qa.test.ts
+++ b/packages/coding-agent/test/model-preset-landing-redteam-qa.test.ts
@@ -237,6 +237,66 @@ describe("preset landing adversarial QA", () => {
 		expect(text).toContain("offline refresh failed");
 		expect(text).not.toContain("Loading models...");
 	});
+
+	test("renders static preset refresh failures on the landing", async () => {
+		const registry = createRegistry(["openai-codex"]);
+		registry.refreshStatic.mockRejectedValueOnce(new Error("static refresh failed"));
+		const selector = new ModelSelectorComponent(
+			{ requestRender: vi.fn() } as unknown as TUI,
+			undefined,
+			Settings.isolated(),
+			registry as never,
+			[],
+			() => {},
+			() => {},
+		);
+
+		const text = await rendered(selector);
+		expect(text).toContain("static refresh failed");
+		expect(text).toContain("Model presets");
+	});
+
+	test("re-evaluates preset versus browser mode after static refresh", async () => {
+		let profiles = new Map<string, ModelProfileDefinition>();
+		const addedRegistry = createRegistry(["openai-codex"], []);
+		addedRegistry.getModelProfiles = () => new Map(profiles);
+		addedRegistry.getModelProfile = (name: string) => profiles.get(name);
+		addedRegistry.refreshStatic.mockImplementation(async () => {
+			profiles = new Map([[codexEco.name, codexEco]]);
+		});
+		const added = new ModelSelectorComponent(
+			{ requestRender: vi.fn() } as unknown as TUI,
+			undefined,
+			Settings.isolated(),
+			addedRegistry as never,
+			[],
+			() => {},
+			() => {},
+		);
+		expect(await rendered(added)).toContain("Model presets");
+		expect(addedRegistry.refresh).not.toHaveBeenCalled();
+		expect(addedRegistry.getCanonicalModelSelections).not.toHaveBeenCalled();
+
+		profiles = new Map([[codexEco.name, codexEco]]);
+		const removedRegistry = createRegistry(["openai-codex"], [codexEco]);
+		removedRegistry.getModelProfiles = () => new Map(profiles);
+		removedRegistry.getModelProfile = (name: string) => profiles.get(name);
+		removedRegistry.refreshStatic.mockImplementation(async () => {
+			profiles.clear();
+		});
+		const removed = new ModelSelectorComponent(
+			{ requestRender: vi.fn() } as unknown as TUI,
+			undefined,
+			Settings.isolated(),
+			removedRegistry as never,
+			[],
+			() => {},
+			() => {},
+		);
+		const removedText = await rendered(removed);
+		expect(removedText).toContain("Models");
+		expect(removedRegistry.getAvailable).toHaveBeenCalledTimes(1);
+	});
 	beforeAll(async () => {
 		testTheme = await getThemeByName("red-claw");
 		installTestTheme();

--- a/packages/coding-agent/test/model-preset-landing-redteam-qa.test.ts
+++ b/packages/coding-agent/test/model-preset-landing-redteam-qa.test.ts
@@ -238,6 +238,34 @@ describe("preset landing adversarial QA", () => {
 		expect(text).not.toContain("Loading models...");
 	});
 
+	test("retries a failed deferred load when the catalog changes", async () => {
+		let notifyCatalogChanged = () => {};
+		const registry = Object.assign(createRegistry(["openai-codex"]), {
+			onCatalogChanged: (listener: () => void) => {
+				notifyCatalogChanged = listener;
+				return () => {};
+			},
+		});
+		registry.refresh.mockRejectedValueOnce(new Error("offline refresh failed"));
+		const selector = new ModelSelectorComponent(
+			{ requestRender: vi.fn() } as unknown as TUI,
+			undefined,
+			Settings.isolated(),
+			registry as never,
+			[],
+			() => {},
+			() => {},
+		);
+
+		await rendered(selector);
+		selector.handleInput("g");
+		expect(await rendered(selector)).toContain("offline refresh failed");
+		notifyCatalogChanged();
+		const recovered = await rendered(selector);
+		expect(recovered).toContain("gpt-5.5");
+		expect(recovered).not.toContain("offline refresh failed");
+	});
+
 	test("renders static preset refresh failures on the landing", async () => {
 		const registry = createRegistry(["openai-codex"]);
 		registry.refreshStatic.mockRejectedValueOnce(new Error("static refresh failed"));

--- a/packages/coding-agent/test/model-preset-landing-redteam-qa.test.ts
+++ b/packages/coding-agent/test/model-preset-landing-redteam-qa.test.ts
@@ -112,7 +112,7 @@ function createRegistry(
 	return {
 		refresh: vi.fn(async () => {}),
 		getError: () => undefined,
-		getAvailable: () => [
+		getAvailable: vi.fn(() => [
 			codexModel,
 			anthropicModel,
 			minimaxModel,
@@ -120,7 +120,7 @@ function createRegistry(
 			{ ...noSuffixModel, provider: "provider-b" },
 			...builtinCodexModels,
 			...builtinComboModels,
-		],
+		]),
 		getAll: () => [
 			codexModel,
 			anthropicModel,
@@ -133,7 +133,7 @@ function createRegistry(
 		hasConfiguredProviderAuth: (provider: string) => authenticatedProviders.includes(provider),
 		getDiscoverableProviders: () => [],
 		getCanonicalModels: () => [],
-		getCanonicalModelSelections: () => [],
+		getCanonicalModelSelections: vi.fn(() => []),
 		resolveCanonicalModel: () => undefined,
 		getModelProfiles: () => new Map(profileMap),
 		getModelProfile: (name: string) => profileMap.get(name),
@@ -187,6 +187,33 @@ function cursorRowLabel(selector: ModelSelectorComponent): string | undefined {
 }
 
 describe("preset landing adversarial QA", () => {
+	test("defers browser catalog materialization until model browsing starts", async () => {
+		const registry = Object.assign(createRegistry(["openai-codex"]), {
+			getAvailableForProfileActivation: vi.fn(() => [codexModel, ...builtinCodexModels]),
+		});
+		const ui = { requestRender: vi.fn() } as unknown as TUI;
+		const selector = new ModelSelectorComponent(
+			ui,
+			undefined,
+			Settings.isolated(),
+			registry as never,
+			[],
+			() => {},
+			() => {},
+		);
+
+		await rendered(selector);
+		expect(registry.refresh).not.toHaveBeenCalled();
+		expect(registry.getAvailable).not.toHaveBeenCalled();
+		expect(registry.getCanonicalModelSelections).not.toHaveBeenCalled();
+
+		selector.handleInput("g");
+		const text = await rendered(selector);
+		expect(registry.refresh).toHaveBeenCalledTimes(1);
+		expect(registry.getAvailable).toHaveBeenCalledTimes(1);
+		expect(registry.getCanonicalModelSelections).toHaveBeenCalledTimes(1);
+		expect(text).toContain("gpt-5.5");
+	});
 	beforeAll(async () => {
 		testTheme = await getThemeByName("red-claw");
 		installTestTheme();
@@ -229,7 +256,7 @@ describe("preset landing adversarial QA", () => {
 		selector.handleInput("\n");
 		selector.handleInput("\n");
 		selector.handleInput("g");
-		const text = normalizeRenderedText(selector.render(260).join("\n"));
+		const text = await rendered(selector);
 		expect(text).toContain("Models");
 		expect(text).toContain("gpt-5.5");
 		expect(text).not.toContain("Preset preview:");
@@ -247,6 +274,7 @@ describe("preset landing adversarial QA", () => {
 		expect(text).toContain("CODEX");
 		selector.handleInput("\x1b[A");
 		selector.handleInput("\n");
+		await rendered(selector);
 		selector.handleInput("\n");
 		text = normalizeRenderedText(selector.render(260).join("\n"));
 		expect(text).toContain("Action for:");

--- a/packages/coding-agent/test/model-preset-landing-redteam-qa.test.ts
+++ b/packages/coding-agent/test/model-preset-landing-redteam-qa.test.ts
@@ -206,6 +206,7 @@ describe("preset landing adversarial QA", () => {
 		expect(registry.refresh).not.toHaveBeenCalled();
 		expect(registry.getAvailable).not.toHaveBeenCalled();
 		expect(registry.getCanonicalModelSelections).not.toHaveBeenCalled();
+		expect(registry.getAvailableForProfileActivation).toHaveBeenCalled();
 
 		selector.handleInput("g");
 		const text = await rendered(selector);

--- a/packages/coding-agent/test/model-selector-profiles-redteam.test.ts
+++ b/packages/coding-agent/test/model-selector-profiles-redteam.test.ts
@@ -305,7 +305,7 @@ describe("model selector profile red-team", () => {
 
 		expect(selector.__testSelectedPresetRowIdentity()).toBe("browse");
 		selector.handleInput("\n");
-		const rendered = normalizeRenderedText(selector.render(240).join("\n"));
+		const rendered = await renderSelector(selector);
 
 		expect(rendered).toContain("Models");
 		expect(rendered).toContain("provider-a/default");

--- a/packages/coding-agent/test/model-selector-profiles.test.ts
+++ b/packages/coding-agent/test/model-selector-profiles.test.ts
@@ -204,6 +204,7 @@ describe("model selector profiles", () => {
 		expect(rendered).toContain("REGISTRY LIVE");
 		expect(rendered).not.toContain("Models (all)");
 		selector.handleInput("f");
+		await Bun.sleep(0);
 		rendered = normalizeRenderedText(selector.render(220).join("\n"));
 		expect(rendered).toContain("fresh-registry-model");
 	});

--- a/packages/coding-agent/test/model-selector-smart-routing.integration.test.ts
+++ b/packages/coding-agent/test/model-selector-smart-routing.integration.test.ts
@@ -62,6 +62,7 @@ function createContext(
 		noProfiles?: boolean;
 		providerOrder?: readonly string[];
 		refreshError?: Error;
+		refreshStaticGate?: Promise<void>;
 	} = {},
 ) {
 	const settings = options.settings ?? Settings.isolated();
@@ -72,6 +73,9 @@ function createContext(
 		getAvailable: () => catalog,
 		refresh: vi.fn(async () => {
 			if (options.refreshError) throw options.refreshError;
+		}),
+		refreshStatic: vi.fn(async () => {
+			await options.refreshStaticGate;
 		}),
 		getError: () => undefined,
 		getCanonicalModels: () => [],
@@ -293,6 +297,24 @@ describe("/model smart-routing panel integration", () => {
 		const { panel, selector } = await openPanel({ smartRoutingOnly: true, noProfiles: true });
 		expect(selector.__testViewMode()).toBe("smart-routing");
 		expect(renderText(panel)).toContain("Smart routing setup");
+	});
+
+	test("landing waits for static refresh before opening smart routing", async () => {
+		const gate = Promise.withResolvers<void>();
+		const { ctx, editorContainer } = createContext({ refreshStaticGate: gate.promise });
+		const controller = new SelectorController(ctx as never);
+		controller.showModelSelector();
+		const selector = editorContainer.addChild.mock.calls[0]?.[0] as ModelSelectorComponent;
+		for (let index = 0; index < 20 && selector.__testSelectedPresetRowIdentity() !== "smartRouting"; index++) {
+			selector.handleInput("\x1b[B");
+		}
+		selector.handleInput("\n");
+		expect(selector.__testGetSmartRoutingPanel()).toBeUndefined();
+		expect(renderText(selector)).toContain("Refreshing model configuration...");
+
+		gate.resolve();
+		await settle();
+		expect(selector.__testGetSmartRoutingPanel()).toBeDefined();
 	});
 
 	test("standalone /routing renders catalog refresh failures instead of hanging", async () => {

--- a/packages/coding-agent/test/model-selector-smart-routing.integration.test.ts
+++ b/packages/coding-agent/test/model-selector-smart-routing.integration.test.ts
@@ -61,6 +61,7 @@ function createContext(
 		settings?: Settings;
 		noProfiles?: boolean;
 		providerOrder?: readonly string[];
+		refreshError?: Error;
 	} = {},
 ) {
 	const settings = options.settings ?? Settings.isolated();
@@ -69,7 +70,9 @@ function createContext(
 	const registry = {
 		getAll: () => catalog,
 		getAvailable: () => catalog,
-		refresh: vi.fn(async () => {}),
+		refresh: vi.fn(async () => {
+			if (options.refreshError) throw options.refreshError;
+		}),
 		getError: () => undefined,
 		getCanonicalModels: () => [],
 		getCanonicalModelSelections: (query: { candidates?: Model[] } = {}) =>
@@ -290,6 +293,22 @@ describe("/model smart-routing panel integration", () => {
 		const { panel, selector } = await openPanel({ smartRoutingOnly: true, noProfiles: true });
 		expect(selector.__testViewMode()).toBe("smart-routing");
 		expect(renderText(panel)).toContain("Smart routing setup");
+	});
+
+	test("standalone /routing renders catalog refresh failures instead of hanging", async () => {
+		const { ctx, editorContainer } = createContext({
+			noProfiles: true,
+			refreshError: new Error("offline refresh failed"),
+		});
+		const controller = new SelectorController(ctx as never);
+		controller.showModelSelector({ smartRoutingOnly: true });
+		const selector = editorContainer.addChild.mock.calls[0]?.[0] as ModelSelectorComponent;
+		await settle();
+		installTheme();
+
+		const text = renderText(selector);
+		expect(text).toContain("offline refresh failed");
+		expect(text).not.toContain("Loading models...");
 	});
 
 	test("standalone panel cancel closes the selector instead of falling back to the preset landing", async () => {

--- a/packages/coding-agent/test/model-selector-smart-routing.integration.test.ts
+++ b/packages/coding-agent/test/model-selector-smart-routing.integration.test.ts
@@ -66,6 +66,7 @@ function createContext(
 	} = {},
 ) {
 	const settings = options.settings ?? Settings.isolated();
+	let notifyCatalogChanged = () => {};
 	const ui = { setFocus: vi.fn(), requestRender: vi.fn(), terminal: { rows: 40, columns: 120 } };
 	const editorContainer = { clear: vi.fn(), detachChild: vi.fn(), addChild: vi.fn() };
 	const registry = {
@@ -77,6 +78,10 @@ function createContext(
 		refreshStatic: vi.fn(async () => {
 			await options.refreshStaticGate;
 		}),
+		onCatalogChanged: (listener: () => void) => {
+			notifyCatalogChanged = listener;
+			return () => {};
+		},
 		getError: () => undefined,
 		getCanonicalModels: () => [],
 		getCanonicalModelSelections: (query: { candidates?: Model[] } = {}) =>
@@ -125,7 +130,7 @@ function createContext(
 		notifyConfigChanged: vi.fn(async () => {}),
 		restoreComposer: vi.fn(),
 	};
-	return { ctx, settings, session, editorContainer };
+	return { ctx, settings, session, editorContainer, notifyCatalogChanged: () => notifyCatalogChanged() };
 }
 
 async function settle(): Promise<void> {
@@ -140,8 +145,9 @@ async function openPanel(options: Parameters<typeof createContext>[0] & { smartR
 	panel: SmartRoutingPanelComponent;
 	settings: Settings;
 	ctx: ReturnType<typeof createContext>["ctx"];
+	notifyCatalogChanged: () => void;
 }> {
-	const { ctx, settings, editorContainer } = createContext(options);
+	const { ctx, settings, editorContainer, notifyCatalogChanged } = createContext(options);
 	const controller = new SelectorController(ctx as never);
 	controller.showModelSelector(options.smartRoutingOnly ? { smartRoutingOnly: true } : undefined);
 	const selector = editorContainer.addChild.mock.calls[0]?.[0] as ModelSelectorComponent;
@@ -160,7 +166,7 @@ async function openPanel(options: Parameters<typeof createContext>[0] & { smartR
 	await settle();
 	const panel = selector.__testGetSmartRoutingPanel();
 	if (!panel) throw new Error("Smart-routing landing row did not open the panel");
-	return { controller, selector, panel, settings, ctx };
+	return { controller, selector, panel, settings, ctx, notifyCatalogChanged };
 }
 
 describe("/model smart-routing panel integration", () => {
@@ -315,6 +321,17 @@ describe("/model smart-routing panel integration", () => {
 		gate.resolve();
 		await settle();
 		expect(selector.__testGetSmartRoutingPanel()).toBeDefined();
+	});
+
+	test("catalog changes preserve a landing-launched smart-routing draft", async () => {
+		const { panel, selector, notifyCatalogChanged } = await openPanel();
+		const editedProviders = [...panel.getProviderOrder()].reverse();
+		panel.__testSetProviders(editedProviders);
+
+		notifyCatalogChanged();
+		await settle();
+		expect(selector.__testGetSmartRoutingPanel()).toBe(panel);
+		expect(panel.getProviderOrder()).toEqual(editedProviders);
 	});
 
 	test("standalone /routing renders catalog refresh failures instead of hanging", async () => {

--- a/packages/coding-agent/test/model-selector-smart-routing.integration.test.ts
+++ b/packages/coding-agent/test/model-selector-smart-routing.integration.test.ts
@@ -309,6 +309,8 @@ describe("/model smart-routing panel integration", () => {
 		const text = renderText(selector);
 		expect(text).toContain("offline refresh failed");
 		expect(text).not.toContain("Loading models...");
+		selector.handleInput("\x1b");
+		expect(ctx.restoreComposer).toHaveBeenCalledTimes(1);
 	});
 
 	test("standalone panel cancel closes the selector instead of falling back to the preset landing", async () => {


### PR DESCRIPTION
## What

Defer `/model` browser catalog materialization until the user actually searches or browses models.

- render the preset landing without eagerly materializing the full browser catalog
- refresh static model/profile configuration without runtime provider discovery
- load and index models only when search/browse mode is entered
- skip redundant catalog refresh while a load is already in flight
- render deferred refresh failures for model browsing and standalone smart routing
- keep immediate loading for scoped, direct-search, and smart-routing selector entry points

## Why

On a credentialed installation, opening `/model` enumerated roughly 1,500 models and built the browser index even when the preset landing was the only visible surface. That caused noticeable UI stalls and high transient CPU/memory use.

## Testing

- `bun test packages/coding-agent/test/model-preset-landing-redteam-qa.test.ts packages/coding-agent/test/model-selector-profiles.test.ts packages/coding-agent/test/model-selector-profiles-redteam.test.ts packages/coding-agent/test/model-selector-smart-routing.integration.test.ts packages/coding-agent/test/model-selector-action-menu-role-binding.test.ts` (92 pass)
- `bun --cwd=packages/coding-agent run check`
- `bun scripts/verify-gjc-state-writers.ts --fail`
- focused call-count evidence proves the preset landing performs static/profile availability work without full registry refresh, available-model browser construction, canonical selection indexing, or sorting until browse/search starts

## Risk classification

<!-- Classify honestly; exactly one box must be checked — the exact-head gate fails closed on zero or multiple. The checked class selects the merge path (issue #4703). -->

- [ ] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [x] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

<!-- Paste one exact-head verdict. reviewer-id is the reviewer's GitHub login. merge-approved requires an authenticated exact-head APPROVED review from an identity distinct from the PR author — the author can never reach it. The repository owner may instead use merge-self-approved, the explicitly named solo force path for a low-risk change with a valid risk-record comment; its name records that no independent human reviewed. Otherwise write needs-human and stop. -->

```text
gajae.pr-review-verdict.v1 merge-approved sha256:c67cf00c38b87f6b8bfc6365f630908c4827787cb6d59c232e95a5add5dccdf2 reviewer:human reviewer-id:Yeachan-Heo evidence:owner exact-head GitHub APPROVED review on 2b8baa8847bb99536c197ecc3770ca3c7c652bb8; independent architect review; 92 focused selector tests; coding-agent check; state-writer gate
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken
