### PR TITLE
fix(compaction): stop after failed local fallback

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Failed cooperative context maintenance now terminalizes the active run with its concrete maintenance error instead of advertising a continuation over unchanged context. Only committed prune, compaction, or promotion outcomes remain resumable.
+
 ## [0.16.3] - 2026-09-04
 
 ## [0.16.2] - 2026-09-04

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -89,6 +89,7 @@ import {
 	type AgentTool,
 	type AgentToolContext,
 	type AgentToolResult,
+	isContinuingMidRunMaintenanceOutcome,
 	type ManagedAttemptOutcome,
 	type StandaloneRunOwnership,
 	type StreamFn,
@@ -1260,13 +1261,12 @@ function publishAgentEnd(
 	event: Extract<AgentEvent, { type: "agent_end" }>,
 	scope?: AttemptScope,
 ): void {
-	// Aborted maintenance yields no continuation, so it is terminal for standalone
-	// ownership and resource sealing. The event itself keeps its `maintenance`
-	// stopReason so AgentSession can still report the aborted maintenance
-	// settlement to its consumers.
+	// Only maintenance that committed a context mutation can continue. Failed and
+	// aborted maintenance are terminal so the unchanged context is never resent.
 	const publishedEvent = scope ? { ...event, scope } : event;
 	const maintenanceContinues =
-		publishedEvent.stopReason === "maintenance" && publishedEvent.maintenanceOutcome !== "aborted";
+		publishedEvent.stopReason === "maintenance" &&
+		isContinuingMidRunMaintenanceOutcome(publishedEvent.maintenanceOutcome);
 	stream.push(publishedEvent);
 	const standalone = config.standaloneRunOwnership
 		? standaloneOwnershipStates.get(config.standaloneRunOwnership)
@@ -3739,6 +3739,16 @@ async function runLoopBody(
 				}
 
 				if (outcome !== "not-needed") {
+					if (outcome === "failed") {
+						const errorMessage =
+							maintenance.errorMessage ??
+							"Context maintenance failed before the next model request; the unchanged context was not resubmitted.";
+						const message = managedFailureMessage(new Error(errorMessage), config);
+						stream.push({ type: "message_start", message, scope: attemptScope });
+						stream.push({ type: "message_end", message, scope: attemptScope });
+						currentContext.messages.push(message);
+						newMessages.push(message);
+					}
 					publishAgentEnd(
 						stream,
 						config,

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -54,7 +54,7 @@ import type {
 	StreamFn,
 	ToolCallContext,
 } from "./types";
-import { setAgentTerminalOwnerContext } from "./types";
+import { isContinuingMidRunMaintenanceOutcome, setAgentTerminalOwnerContext } from "./types";
 
 /**
  * Closed runtime allowlist of failure-classifier codes. The public diagnostic
@@ -2147,12 +2147,15 @@ export class Agent {
 						}
 						this.#state.isStreaming = false;
 						this.#state.streamMessage = null;
-						// A maintenance checkpoint is only non-terminal while a continuation will
-						// follow. An aborted maintenance yields none, and because the loop runs with
+						// A maintenance checkpoint is only non-terminal while a committed rewrite
+						// will continue. Failed or aborted maintenance yields none. Because the loop runs with
 						// `resourceSealOwner: "caller"` it deliberately leaves sealing to us, so
 						// treating it as a checkpoint here would leave the run open forever and make
 						// every cancel report `run_not_sealed`.
-						if (event.stopReason === "maintenance" && event.maintenanceOutcome !== "aborted") {
+						if (
+							event.stopReason === "maintenance" &&
+							isContinuingMidRunMaintenanceOutcome(event.maintenanceOutcome)
+						) {
 							this.#managedLogicalRunOwner ??= managedLogicalRunOwner ?? runId;
 							maintenanceInterrupted = true;
 							this.#emit(event);

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -214,14 +214,19 @@ export type ManagedAttemptOutcomeHandler = (
  * Outcome of a cooperative mid-run context-maintenance checkpoint (see
  * {@link AgentLoopConfig.maintainContext}). Any value other than "not-needed"
  * means the checkpoint mutated (or attempted to mutate) durable context, so the
- * loop ends the current run without the lossy `agent_end` finalization and the
- * maintenance owner resumes the run on the rewritten context.
+ * loop ends the current run without lossy finalization. Committed maintenance
+ * resumes on rewritten context; failed or aborted maintenance terminalizes.
  */
 export type MidRunMaintenanceOutcome = "not-needed" | "pruned" | "compacted" | "promoted" | "failed" | "aborted";
 
 export interface ContextMaintenanceResult {
 	outcome: MidRunMaintenanceOutcome;
 	releaseCurrentContext?: boolean;
+	errorMessage?: string;
+}
+
+export function isContinuingMidRunMaintenanceOutcome(outcome: unknown): boolean {
+	return outcome === "pruned" || outcome === "compacted" || outcome === "promoted";
 }
 
 /**
@@ -438,9 +443,9 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
 	 * non-optional loop signal, and `awaitEventDrain(invocationSignal)` waits for
 	 * prior event consumer bodies with loop and invocation cancellation composed.
 	 * Any outcome other than "not-needed" ends the current run with
-	 * `agent_end.stopReason === "maintenance"` (NOT the lossy pause / completed
-	 * finalization); the callback's continuation owner resumes the run on the
-	 * rewritten context.
+	 * `agent_end.stopReason === "maintenance"`. Successful maintenance resumes
+	 * on rewritten context; `failed` and `aborted` are terminal and never resend
+	 * the unchanged context.
 	 */
 	maintainContext?: (
 		context: AgentContext,

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Mid-run OpenAI remote-compaction fallback failures now stop before another provider request, surface the local summarization error through ACP/SDK terminal handling, and leave the uncompacted context unsubmitted. Successful local fallback still commits the compaction and resumes normally.
 - `/model` provider-tab refreshes now reuse the already loaded static catalog and update only the selected provider's discovery state, avoiding repeated signed preset registry work while retaining full-catalog refresh behavior for static configuration changes.
 - Added the `command` status-line segment for user-produced HUD content. It runs
   configured user/global shell commands in the background with scheduled cached

--- a/packages/coding-agent/src/extensibility/shared-events.ts
+++ b/packages/coding-agent/src/extensibility/shared-events.ts
@@ -188,7 +188,7 @@ export interface AgentEndEvent {
 	sdkRunToken?: string;
 	/** Indicates whether the loop ended normally, suspended, cancelled, or entered maintenance. */
 	stopReason?: "completed" | "paused" | "cancelled" | "maintenance";
-	/** Present for maintenance checkpoints; non-aborted checkpoints are not terminal. */
+	/** Present for maintenance checkpoints; only committed maintenance outcomes are non-terminal. */
 	maintenanceOutcome?: MidRunMaintenanceOutcome;
 }
 

--- a/packages/coding-agent/src/sdk/host/session-runtime.test.ts
+++ b/packages/coding-agent/src/sdk/host/session-runtime.test.ts
@@ -2125,7 +2125,7 @@ describe("SessionSdkSessionRuntime", () => {
 			while (!transport.sent.some(frame => frame.id === "predecessor-prompt")) await Bun.sleep(10);
 			await handlers.get("agent_start")?.({}, ctx); // lifecycle epoch 1
 			await handlers.get("agent_end")?.(
-				{ type: "agent_end", stopReason: "maintenance", maintenanceOutcome: "completed" },
+				{ type: "agent_end", stopReason: "maintenance", maintenanceOutcome: "compacted" },
 				ctx,
 			);
 			transport.feed("client", {
@@ -2148,7 +2148,7 @@ describe("SessionSdkSessionRuntime", () => {
 			while (abortCalls < 1) await Bun.sleep(10);
 			await handlers.get("agent_end")?.({ type: "agent_end" }, ctx); // delayed predecessor
 			await handlers.get("agent_end")?.(
-				{ type: "agent_end", stopReason: "maintenance", maintenanceOutcome: "completed" },
+				{ type: "agent_end", stopReason: "maintenance", maintenanceOutcome: "compacted" },
 				ctx,
 			);
 			abortRelease.resolve();

--- a/packages/coding-agent/src/sdk/host/session-runtime.ts
+++ b/packages/coding-agent/src/sdk/host/session-runtime.ts
@@ -4,7 +4,7 @@ import * as crypto from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { promisify } from "node:util";
-import { ThinkingLevel } from "@gajae-code/agent-core";
+import { isContinuingMidRunMaintenanceOutcome, ThinkingLevel } from "@gajae-code/agent-core";
 import type { Api, ImageContent, Model } from "@gajae-code/ai/core";
 import { logger } from "@gajae-code/utils";
 import { AsyncJobManager } from "../../async";
@@ -4364,7 +4364,7 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 			};
 			void attempt().finally(() => skillTerminalRecoveryControllers.delete(recoveryKey));
 		};
-		if (type === "agent_end" && maintenanceOutcome !== undefined && maintenanceOutcome !== "aborted") {
+		if (type === "agent_end" && isContinuingMidRunMaintenanceOutcome(maintenanceOutcome)) {
 			try {
 				current.runtime.emitEvent({ type, sessionId: ctx.sessionManager.getSessionId() });
 			} catch {
@@ -4495,7 +4495,7 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 		} catch {
 			observed = false;
 		}
-		if (type === "agent_end" && maintenanceOutcome !== undefined && maintenanceOutcome !== "aborted") return;
+		if (type === "agent_end" && isContinuingMidRunMaintenanceOutcome(maintenanceOutcome)) return;
 		if (type === "agent_end") {
 			if (current.lifecycleEpoch !== eventLifecycleEpoch) {
 				// A successor agent_start won the lifecycle race while this event's

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -36,6 +36,7 @@ import {
 	canContinuePersistedHistory,
 	dispatchedToolIdentity,
 	getAgentTerminalOwnerContext,
+	isContinuingMidRunMaintenanceOutcome,
 	isNonDispatchedToolEvent,
 	type ManagedAttemptContinuationOwnership,
 	type ManagedAttemptDecision,
@@ -1044,7 +1045,7 @@ type AutoCompactionTerminalStatus =
 	| { kind: "compacted"; continuationScheduled?: boolean }
 	| { kind: "aborted"; source: "signal" | "hook" }
 	| { kind: "skipped"; continuationScheduled?: boolean }
-	| { kind: "failed" };
+	| { kind: "failed"; errorMessage: string };
 
 type ToolOutputPruneResult = {
 	prunedCount: number;
@@ -5918,7 +5919,9 @@ export class AgentSession {
 		const canonicalAdmission = this.#reserveCanonicalMessageAdmission(event);
 		const terminalOwner = event.type === "agent_end" ? getAgentTerminalOwnerContext(event) : undefined;
 		const maintenanceCheckpoint =
-			event.type === "agent_end" && event.stopReason === "maintenance" && event.maintenanceOutcome !== "aborted";
+			event.type === "agent_end" &&
+			event.stopReason === "maintenance" &&
+			isContinuingMidRunMaintenanceOutcome(event.maintenanceOutcome);
 		const terminalClaim =
 			maintenanceCheckpoint || !terminalOwner
 				? undefined
@@ -6196,9 +6199,13 @@ export class AgentSession {
 			this.#requestWorkerIntegrationAttempt();
 		}
 		// A maintenance agent_end is an internal checkpoint only while another
-		// continuation will follow. An aborted maintenance run is its terminal
-		// settlement and must reach public subscribers.
-		if (event.type === "agent_end" && event.stopReason === "maintenance" && event.maintenanceOutcome !== "aborted")
+		// continuation will follow. Failed or aborted maintenance is terminal and
+		// must reach public subscribers.
+		if (
+			event.type === "agent_end" &&
+			event.stopReason === "maintenance" &&
+			isContinuingMidRunMaintenanceOutcome(event.maintenanceOutcome)
+		)
 			return;
 
 		// Hold agent_end until the prompt's finally and all earlier async event work
@@ -6983,7 +6990,7 @@ export class AgentSession {
 
 		if (
 			event.type === "agent_end" &&
-			!(event.stopReason === "maintenance" && event.maintenanceOutcome !== "aborted")
+			!(event.stopReason === "maintenance" && isContinuingMidRunMaintenanceOutcome(event.maintenanceOutcome))
 		) {
 			this.#releaseDeferredSdkFollowUps();
 		}
@@ -6996,9 +7003,10 @@ export class AgentSession {
 			// the same run on the rewritten context (no synthetic prompt), skipping
 			// the goal-runtime / skill-state / retry / compaction finalization a
 			// normal agent_end runs — none of that applies to an in-progress run.
-			// "aborted" settles without resuming; the generation guard drops the
-			// continuation if a newer prompt/abort has moved the run on.
-			if (event.stopReason === "maintenance") {
+			// Failed and aborted outcomes fall through to terminal handling. The
+			// generation guard drops a successful continuation if a newer prompt/abort
+			// has moved the run on.
+			if (event.stopReason === "maintenance" && isContinuingMidRunMaintenanceOutcome(event.maintenanceOutcome)) {
 				this.#lastAssistantMessage = undefined;
 				const outcome = event.maintenanceOutcome;
 				if (
@@ -7083,6 +7091,13 @@ export class AgentSession {
 				return;
 			}
 			this.#lastSuccessfulYieldToolCallId = undefined;
+			if (event.stopReason === "maintenance" && event.maintenanceOutcome === "failed") {
+				// The maintenance error already terminalized the run. Retrying this
+				// synthetic assistant failure would resubmit the unchanged context that
+				// maintenance failed to rewrite.
+				this.#resolveRetry();
+				return;
+			}
 
 			// Check for retryable errors first (overloaded, rate limit, server errors)
 			if (this.#isRetryableError(msg)) {
@@ -8580,7 +8595,8 @@ export class AgentSession {
 					? this.#sdkRunTokensByAttemptScope.get(deliveryScope as AttemptScope)
 					: undefined;
 		const isTerminalAgentEnd =
-			event.type === "agent_end" && !(event.stopReason === "maintenance" && event.maintenanceOutcome !== "aborted");
+			event.type === "agent_end" &&
+			!(event.stopReason === "maintenance" && isContinuingMidRunMaintenanceOutcome(event.maintenanceOutcome));
 		const finishAttempt = () => {
 			if (!isTerminalAgentEnd) return;
 			// A merged wake batch whose flush fired while still streaming cleared its
@@ -18407,18 +18423,23 @@ export class AgentSession {
 	 * prune → promote → compact machinery and returns an explicit outcome.
 	 *
 	 * A non-"not-needed" outcome ends the current run losslessly
-	 * (`agent_end.stopReason === "maintenance"`); the `agent_end` handler is the
-	 * single continuation owner that resumes the run with no synthetic prompt.
-	 * This method never self-continues, runs goal-runtime hooks, clears skill
-	 * state, or emits a user-facing pause.
+	 * (`agent_end.stopReason === "maintenance"`). The `agent_end` handler resumes
+	 * committed maintenance with no synthetic prompt and terminalizes failed or
+	 * aborted maintenance. This method never self-continues, runs goal-runtime
+	 * hooks, clears skill state, or emits a user-facing pause.
 	 */
 	async #runMidRunMaintenance(
 		context: AgentContext,
 		lifecycle: MidRunMaintenanceLifecycle,
 	): Promise<ContextMaintenanceResult> {
-		const result = (outcome: MidRunMaintenanceOutcome, releaseCurrentContext = false): ContextMaintenanceResult => ({
+		const result = (
+			outcome: MidRunMaintenanceOutcome,
+			releaseCurrentContext = false,
+			errorMessage?: string,
+		): ContextMaintenanceResult => ({
 			outcome,
 			...(releaseCurrentContext ? { releaseCurrentContext: true } : {}),
+			...(errorMessage ? { errorMessage } : {}),
 		});
 		if (this.#isDisposed) return { outcome: "aborted" };
 		const invocationController = new AbortController();
@@ -18529,7 +18550,13 @@ export class AgentSession {
 			if (compactionStatus.kind === "aborted") {
 				return compactionStatus.source === "hook" ? result("not-needed") : result("aborted");
 			}
-			return result("failed");
+			return result(
+				"failed",
+				false,
+				compactionStatus.kind === "failed"
+					? compactionStatus.errorMessage
+					: "Context maintenance could not commit a compaction before the next model request.",
+			);
 		} finally {
 			this.#activeMidRunBarrierControllers.delete(invocationController);
 		}
@@ -20286,7 +20313,7 @@ export class AgentSession {
 						? `Context overflow recovery failed: ${errorMessage}`
 						: `Auto-compaction failed: ${errorMessage}`,
 			});
-			return { kind: "failed" };
+			return { kind: "failed", errorMessage };
 		} finally {
 			if (this.#autoCompactionAbortController === autoCompactionAbortController) {
 				this.#autoCompactionAbortController = undefined;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -7006,26 +7006,30 @@ export class AgentSession {
 			// Failed and aborted outcomes fall through to terminal handling. The
 			// generation guard drops a successful continuation if a newer prompt/abort
 			// has moved the run on.
-			if (event.stopReason === "maintenance" && isContinuingMidRunMaintenanceOutcome(event.maintenanceOutcome)) {
-				this.#lastAssistantMessage = undefined;
-				const outcome = event.maintenanceOutcome;
-				if (
-					outcome &&
-					outcome !== "aborted" &&
-					!maintenanceWasDisposed &&
-					!this.#isDisposed &&
-					maintenanceGeneration !== undefined &&
-					this.#promptGeneration === maintenanceGeneration
-				) {
-					this.#scheduleAgentContinue({
-						generation: maintenanceGeneration,
-						skipCompactionCheck: true,
-						resourceRunId: activePromptHandle,
-						maintenanceContinuation: true,
-						sdkRunToken: attemptScope ? this.#sdkRunTokensByAttemptScope.get(attemptScope) : undefined,
-					});
+			if (event.stopReason === "maintenance") {
+				if (isContinuingMidRunMaintenanceOutcome(event.maintenanceOutcome)) {
+					this.#lastAssistantMessage = undefined;
+					if (
+						!maintenanceWasDisposed &&
+						!this.#isDisposed &&
+						maintenanceGeneration !== undefined &&
+						this.#promptGeneration === maintenanceGeneration
+					) {
+						this.#scheduleAgentContinue({
+							generation: maintenanceGeneration,
+							skipCompactionCheck: true,
+							resourceRunId: activePromptHandle,
+							maintenanceContinuation: true,
+							sdkRunToken: attemptScope ? this.#sdkRunTokensByAttemptScope.get(attemptScope) : undefined,
+						});
+					}
+					return;
 				}
-				return;
+				// Cancellation already owns teardown and terminal publication. Running
+				// normal post-turn finalization here can deadlock abort/dispose while the
+				// maintenance barrier is unwinding. Failed maintenance alone carries the
+				// synthetic assistant error that must flow through terminal handling.
+				if (event.maintenanceOutcome === "aborted") return;
 			}
 			const usage = this.getSessionStats().tokens;
 			await this.#goalRuntime.onAgentEnd({

--- a/packages/coding-agent/test/agent-session-midrun-compaction.test.ts
+++ b/packages/coding-agent/test/agent-session-midrun-compaction.test.ts
@@ -22,7 +22,7 @@ import { AgentSession } from "@gajae-code/coding-agent/session/agent-session";
 import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
 import { convertToLlm } from "@gajae-code/coding-agent/session/messages";
 import { getLatestCompactionEntry, SessionManager } from "@gajae-code/coding-agent/session/session-manager";
-import { getProjectAgentDir, TempDir } from "@gajae-code/utils";
+import { getProjectAgentDir, hookFetch, TempDir } from "@gajae-code/utils";
 import * as z from "zod/v4";
 
 /**
@@ -441,6 +441,63 @@ describe("AgentSession mid-run compaction (issue #2035)", () => {
 				),
 			),
 		).toBe(false);
+	});
+
+	it("terminalizes a failed local fallback after remote compaction returns 404 (issue #5254)", async () => {
+		authStorage.setRuntimeApiKey("openai-codex", "test-key");
+		const bundledCodex = modelRegistry.find("openai-codex", "gpt-5.5");
+		if (!bundledCodex) throw new Error("Expected bundled openai-codex model");
+		const codexModel = { ...bundledCodex, contextWindow: 200_000, maxTokens: 32_768 };
+		const requestUrls: string[] = [];
+		using _hook = hookFetch(input => {
+			requestUrls.push(String(input instanceof Request ? input.url : input));
+			return new Response("not found", { status: 404, statusText: "Not Found" });
+		});
+		const loop = await buildLoopSession({
+			model: codexModel,
+			responder: call =>
+				call === 1
+					? assistantFor(codexModel, {
+							content: [{ type: "toolCall", id: "issue-5254", name: "noop", arguments: {} }],
+							totalTokens: THRESHOLD + 80_000,
+							stopReason: "toolUse",
+						})
+					: assistantFor(codexModel, {
+							content: [{ type: "text", text: "oversized context was resubmitted" }],
+							totalTokens: 200_000,
+							stopReason: "error",
+							errorMessage: "context_length_exceeded",
+						}),
+		});
+		await seedCompactableLoop(loop.session, codexModel);
+
+		await loop.session.prompt("go");
+		await loop.session.waitForIdle();
+
+		expect(requestUrls.filter(url => url.endsWith("/responses/compact")).length).toBeGreaterThan(0);
+		expect(requestUrls.some(url => !url.endsWith("/responses/compact"))).toBe(true);
+		expect(getLatestCompactionEntry(loop.session.sessionManager.getBranch())).toBeNull();
+		expect(loop.streamCallCount()).toBe(1);
+		const compactionFailure = loop.events.find(
+			(event): event is Extract<AgentSessionEvent, { type: "auto_compaction_end" }> =>
+				event.type === "auto_compaction_end" && event.errorMessage !== undefined,
+		);
+		expect(compactionFailure?.errorMessage).toContain("Summarization failed: not found");
+		expect(
+			loop.session.messages.some(
+				message =>
+					message.role === "assistant" && message.errorMessage?.includes("Summarization failed: not found"),
+			),
+		).toBe(true);
+		expect(
+			loop.agentEvents.filter(
+				event =>
+					event.type === "agent_end" &&
+					event.stopReason === "maintenance" &&
+					event.maintenanceOutcome === "failed",
+			),
+		).toHaveLength(1);
+		await loop.session.dispose();
 	});
 
 	it("without the maintenance hook, a long tool loop grows past the threshold into provider overflow", async () => {


### PR DESCRIPTION
## What

- Treat only committed mid-run maintenance outcomes (`pruned`, `compacted`, `promoted`) as resumable.
- Propagate a failed local summarization error into a terminal assistant message.
- Stop ACP/SDK lifecycle continuation before the unchanged oversized context can be submitted again.
- Preserve cancellation-owned teardown for aborted maintenance while failed maintenance enters terminal error handling.
- Add an integration regression for OpenAI Codex remote compaction returning 404 followed by local fallback failure.

## Why

Fixes #5254.

`compact()` correctly attempted local summarization after `/codex/responses/compact` returned 404, but a local fallback failure returned `maintenanceOutcome: "failed"` before `SessionManager.appendCompaction()` could run. The agent/session/SDK lifecycle classified every maintenance outcome except `aborted` as resumable, so it continued the same run with no compaction entry and resent the unchanged context.

Exact-head review found that the first fix also routed aborted maintenance through normal post-turn finalization, deadlocking abort/dispose while the maintenance barrier unwound. The follow-up preserves the existing cancellation-owned aborted path and terminalizes only failed maintenance.

## Current exact-head testing

- Baseline reproduction at exact dev `51201d3f366bbeae6ac3f95618a76430db9202ed`: issue #5254 regression failed with `Expected: 1, Received: 2` provider stream calls after remote-compaction 404 plus local fallback failure.
- `bun test packages/coding-agent/test/agent-session-midrun-compaction.test.ts --timeout 30000` (19 pass)
- `bun test packages/agent/test/agent-loop-maintain-context-lifecycle.test.ts packages/agent/test/agent-force-abort.test.ts packages/agent/src/heap-eviction-retainers.test.ts` (23 pass)
- `bun test packages/coding-agent/src/sdk/host/session-runtime.test.ts --timeout 30000` (126 pass)
- `bun --cwd=packages/agent run check` (passes with the pre-existing `Function` type Biome warning)
- `bun --cwd=packages/coding-agent run check`

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:42db617349b64f1d9ea16a4024427113753645653147c4094fde057944cc0670 reviewer:human reviewer-id:Yeachan-Heo evidence:exact-dev baseline reproduced; exact-head fallback terminal event, no-extra-call, aborted teardown, SDK lifecycle, affected suites, and package checks passed at 5d401fed2aa9532a969a91dee136aea08e730ebc
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes (not run; targeted package checks passed)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken