### PR TITLE
test(coordinator): return valid empty replay in concurrency fixture

### DIFF
--- a/packages/coding-agent/test/coordinator-mcp/send-prompt-concurrency.test.ts
+++ b/packages/coding-agent/test/coordinator-mcp/send-prompt-concurrency.test.ts
@@ -117,7 +117,8 @@ describe("send_prompt same-session concurrency", () => {
 							const client: SessionRouterClient = {
 								onFrame: () => () => {},
 								request: async frame => {
-									if (frame.type === "event_replay") return {};
+									if (frame.type === "event_replay")
+										return { ok: true, generation: 1, lastSeq: 0, events: [] };
 									expect(frame.type).toBe("control_request");
 									expect(frame.operation).toBe("turn.prompt");
 									return { accepted: true, command_id: "runtime-command", turn_id: "runtime-turn" };


### PR DESCRIPTION
## What

Return a valid empty `event_replay` response from the coordinator concurrency fixture.

## Why

Main CI shard 9 failed because `{}` is malformed under the Router replay contract. The Router correctly retired the attachment, causing both prompts to return `endpoint_stale` before the per-session lock assertion.

## Testing

- Concurrency regression: 25/25 passes
- Related replay suites: 30 passes
- `bun --cwd=packages/coding-agent run check`

## Risk classification

- [x] `low-risk` — test-fixture-only correction
- [ ] `regression-risk`
- [ ] `high-risk`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:451452758980969c0fee5ea90bef3e5ac215c29eb07bf4823fac98552313f6b7 reviewer:human reviewer-id:Yeachan-Heo evidence:local:25x-concurrency+30-related+coding-agent-check
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG unchanged (test fixture only)
- [x] Verdict above matches the exact PR head
- [x] Risk classification matches the actual review path