### PR TITLE
fix(session): claim tool cleanups before disposal

### DIFF
--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -5616,24 +5616,22 @@ export class AgentSession {
 
 	async #runToolSessionTransitionCleanups(): Promise<void> {
 		const cleanups = Array.from(this.#toolSessionTransitionCleanups);
+		this.#toolSessionTransitionCleanups.clear();
 		const results = await Promise.allSettled(cleanups.map(async cleanup => await cleanup()));
 		const failures: unknown[] = [];
-		for (let index = 0; index < results.length; index++) {
-			const result = results[index]!;
-			if (result.status === "fulfilled") this.#toolSessionTransitionCleanups.delete(cleanups[index]!);
-			else failures.push(result.reason);
+		for (const result of results) {
+			if (result.status === "rejected") failures.push(result.reason);
 		}
 		if (failures.length > 0) throw new AggregateError(failures, "Tool session transition cleanup failed.");
 	}
 
 	async #runToolSessionCleanups(): Promise<void> {
 		const cleanups = Array.from(this.#toolSessionCleanups);
+		this.#toolSessionCleanups.clear();
 		const results = await Promise.allSettled(cleanups.map(async cleanup => await cleanup()));
 		const failures: unknown[] = [];
-		for (let index = 0; index < results.length; index++) {
-			const result = results[index]!;
-			if (result.status === "fulfilled") this.#toolSessionCleanups.delete(cleanups[index]!);
-			else failures.push(result.reason);
+		for (const result of results) {
+			if (result.status === "rejected") failures.push(result.reason);
 		}
 		if (failures.length > 0) throw new AggregateError(failures, "Tool session cleanup failed.");
 	}


### PR DESCRIPTION
## What

Claim tool cleanup callbacks before invoking them so signal and graceful teardown cannot execute the same callback twice.

## Why

Main CI shard 8 consistently failed three signal teardown regressions. A timed-out or failed signal cleanup remained registered, then graceful disposal reran it, exceeding the disposal deadline or surfacing the same error twice.

## Testing

- Signal teardown suite: 10/10 repeated passes after latest dev merge
- `bun --cwd=packages/coding-agent run check`

## Risk classification

- [x] `low-risk` — narrow teardown ownership correction
- [ ] `regression-risk`
- [ ] `high-risk`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:bdfdf55a90848423598189eb8a30f5cc344d304f1eab7e202d47792620929494 reviewer:human reviewer-id:Yeachan-Heo evidence:local:10x-signal-teardown+coding-agent-check
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG unchanged
- [x] Verdict above matches the exact PR head
- [x] Risk classification matches the actual review path