### PR TITLE
feat(install): add local dev binary shortcut

### DIFF
--- a/scripts/install-tests/install-sh-binary-upgrade.test.ts
+++ b/scripts/install-tests/install-sh-binary-upgrade.test.ts
@@ -139,11 +139,32 @@ function writeFailingBun(dir: string): void {
 	fs.chmodSync(bunPath, 0o755);
 }
 
+function writeRecordingBun(dir: string): void {
+	const bunPath = path.join(dir, "bun");
+	const shim = `#!/bin/sh
+printf '%s\n' "$*" >> "\${GJC_DEV_COMMAND_LOG:?}"
+printf '%s\n' "$(pwd)" >> "\${GJC_DEV_CWD_LOG:?}"
+case "$*" in
+  "run build"|"run install:dev:bin") exit 0 ;;
+  *) echo "unexpected bun command: $*" >&2; exit 98 ;;
+esac
+`;
+	fs.writeFileSync(bunPath, shim);
+	fs.chmodSync(bunPath, 0o755);
+}
+
+interface InstallerOptions {
+	cwd?: string;
+	script?: string;
+}
+
 async function runInstaller(
 	args: string[],
 	env: Record<string, string> = {},
+	options: InstallerOptions = {},
 ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
-	const proc = Bun.spawn(["sh", installScript, ...args], {
+	const proc = Bun.spawn(["sh", options.script ?? installScript, ...args], {
+		cwd: options.cwd ?? repoRoot,
 		env: {
 			...process.env,
 			PATH: `${sandbox.shimDir}:/usr/bin:/bin`,
@@ -156,6 +177,35 @@ async function runInstaller(
 		stdout: "pipe",
 		stderr: "pipe",
 	});
+	const [stdout, stderr, exitCode] = await Promise.all([
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+		proc.exited,
+	]);
+	return { exitCode, stdout, stderr };
+}
+
+async function runPipedInstaller(
+	args: string[],
+	env: Record<string, string> = {},
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+	const proc = Bun.spawn(["sh", "-s", "--", ...args], {
+		cwd: repoRoot,
+		stdin: "pipe",
+		env: {
+			...process.env,
+			PATH: `${sandbox.shimDir}:/usr/bin:/bin`,
+			GJC_INSTALL_DIR: sandbox.installDir,
+			HOME: sandbox.root,
+			GITHUB_TOKEN: "",
+			GH_TOKEN: "",
+			...env,
+		},
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	proc.stdin.write(await Bun.file(installScript).text());
+	proc.stdin.end();
 	const [stdout, stderr, exitCode] = await Promise.all([
 		new Response(proc.stdout).text(),
 		new Response(proc.stderr).text(),
@@ -198,6 +248,85 @@ describe("install.sh binary-first contract", () => {
 		expect(result.stderr).not.toContain("bun should not run");
 		expect(result.exitCode).toBe(0);
 		expect(fs.readFileSync(path.join(sandbox.installDir, "gjc"), "utf8")).toBe(payload);
+	});
+
+	test("documents --dev in installer help", async () => {
+		const result = await runInstaller(["--help"]);
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toContain("--dev");
+		expect(result.stdout).toContain("current checkout");
+	});
+
+	test("--dev runs the build and install shortcuts from the checkout root", async () => {
+		const commandLog = path.join(sandbox.root, "bun-commands.log");
+		const cwdLog = path.join(sandbox.root, "bun-cwds.log");
+		writeRecordingBun(sandbox.shimDir);
+
+		const result = await runInstaller(
+			["--dev"],
+			{
+				GJC_DEV_COMMAND_LOG: commandLog,
+				GJC_DEV_CWD_LOG: cwdLog,
+			},
+			{ cwd: sandbox.root },
+		);
+
+		expect(result.exitCode).toBe(0);
+		expect(fs.readFileSync(commandLog, "utf8").trim().split("\n")).toEqual(["run build", "run install:dev:bin"]);
+		expect(fs.readFileSync(cwdLog, "utf8").trim().split("\n")).toEqual([repoRoot, repoRoot]);
+	});
+
+	test("--dev rejects a non-checkout script without invoking Bun", async () => {
+		const script = path.join(sandbox.root, "not-a-checkout", "scripts", "install.sh");
+		fs.mkdirSync(path.dirname(script), { recursive: true });
+		fs.copyFileSync(installScript, script);
+		const commandLog = path.join(sandbox.root, "bun-commands.log");
+		writeRecordingBun(sandbox.shimDir);
+
+		const result = await runInstaller(
+			["--dev"],
+			{
+				GJC_DEV_COMMAND_LOG: commandLog,
+				GJC_DEV_CWD_LOG: path.join(sandbox.root, "bun-cwds.log"),
+			},
+			{ cwd: sandbox.root, script },
+		);
+
+		expect(result.exitCode).not.toBe(0);
+		expect(result.stderr + result.stdout).toContain("GJC checkout");
+		expect(fs.existsSync(commandLog)).toBe(false);
+	});
+
+	test("--dev rejects piped installers without invoking Bun", async () => {
+		const commandLog = path.join(sandbox.root, "bun-commands.log");
+		writeRecordingBun(sandbox.shimDir);
+
+		const result = await runPipedInstaller(["--dev"], {
+			GJC_DEV_COMMAND_LOG: commandLog,
+			GJC_DEV_CWD_LOG: path.join(sandbox.root, "bun-cwds.log"),
+		});
+
+		expect(result.exitCode).not.toBe(0);
+		expect(result.stderr + result.stdout).toContain("piped");
+		expect(fs.existsSync(commandLog)).toBe(false);
+	});
+
+	test("--dev requires Bun without falling back to a release download", async () => {
+		const result = await runInstaller(["--dev"], { PATH: "/usr/bin:/bin" });
+		expect(result.exitCode).not.toBe(0);
+		expect(result.stderr + result.stdout).toMatch(/requires an existing Bun/i);
+		expect(fs.readdirSync(sandbox.installDir)).toEqual([]);
+	});
+
+	test("--dev rejects release options that would be ignored", async () => {
+		for (const args of [
+			["--dev", "--ref", "v0.15.0"],
+			["--dev", "--channel", "nightly"],
+		]) {
+			const result = await runInstaller(args);
+			expect(result.exitCode).not.toBe(0);
+			expect(result.stderr + result.stdout).toContain("--dev cannot be combined");
+		}
 	});
 
 	test("root install.sh execs the canonical scripts/install.sh from a clone", async () => {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,16 +6,19 @@ set -e
 #   curl -fsSL https://raw.githubusercontent.com/Yeachan-Heo/gajae-code/main/scripts/install.sh | sh
 #   curl -fsSL https://raw.githubusercontent.com/Yeachan-Heo/gajae-code/main/scripts/install.sh | sh -s -- --channel nightly
 #   curl -fsSL https://raw.githubusercontent.com/Yeachan-Heo/gajae-code/main/scripts/install.sh | sh -s -- --ref v0.15.0
+#   sh scripts/install.sh --dev
 #
 # Options:
 #   --channel <stable|nightly>  Release channel (default: stable)
 #   --ref <tag> / -r <tag>      Exact GitHub release tag (binary assets required)
 #   --binary                    Explicit binary install (default; no-op alias)
 #   --source                    Development/source install via an existing Bun
+#   --dev                      Build and install the current checkout via Bun (local only)
 #   -h, --help                  Show this help
 #
 # Bun is never detected, installed, or invoked on the default path.
 # --source requires a preinstalled Bun and never downloads one.
+# --dev requires an on-disk GJC checkout and a preinstalled Bun.
 
 REPO="Yeachan-Heo/gajae-code"
 PACKAGE="@gajae-code/coding-agent"
@@ -36,6 +39,10 @@ AUTH_HDR=""
 BACKUP_PATH=""
 DEST_PATH=""
 SOURCE_CLONE_DIR=""
+DEV_REPO_ROOT=""
+DEV_REQUESTED=0
+SOURCE_REQUESTED=0
+BINARY_REQUESTED=0
 
 usage() {
     cat <<'EOF'
@@ -45,12 +52,14 @@ Usage:
   curl -fsSL https://raw.githubusercontent.com/Yeachan-Heo/gajae-code/main/scripts/install.sh | sh
   sh install.sh [--channel stable|nightly] [--ref <tag>]
   sh install.sh --source [--ref <tag>]
+  sh scripts/install.sh --dev
 
 Options:
   --channel <stable|nightly>  GitHub release channel (default: stable)
   --ref <tag>, -r <tag>       Exact GitHub release tag
   --binary                    Install the prebuilt binary (default)
   --source                    Source/development install; requires existing Bun
+  --dev                      Build and install the current checkout via Bun (local only)
   -h, --help                  Show this help
 
 Environment:
@@ -140,6 +149,28 @@ is_safe_channel() {
 
 has_bun() {
     command -v bun >/dev/null 2>&1
+}
+
+require_dev_checkout() {
+    case "$0" in
+        */scripts/install.sh | scripts/install.sh)
+            ;;
+        *)
+            die "--dev requires running the on-disk scripts/install.sh from a GJC checkout; piped installers cannot use --dev."
+            ;;
+    esac
+
+    script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" 2>/dev/null && pwd) ||
+        die "--dev could not resolve the on-disk installer path."
+    DEV_REPO_ROOT=$(CDPATH= cd -- "$script_dir/.." 2>/dev/null && pwd) ||
+        die "--dev could not resolve the GJC checkout root."
+
+    if [ ! -f "$script_dir/install.sh" ] || \
+        [ ! -f "$DEV_REPO_ROOT/package.json" ] || \
+        [ ! -f "$DEV_REPO_ROOT/bun.lock" ] || \
+        [ ! -f "$DEV_REPO_ROOT/packages/coding-agent/package.json" ]; then
+        die "--dev requires a GJC checkout containing scripts/install.sh, package.json, bun.lock, and packages/coding-agent/package.json."
+    fi
 }
 
 has_git() {
@@ -507,6 +538,16 @@ verify_installed_binary() {
     return 0
 }
 
+install_dev() {
+    echo "Building and installing GJC from the current checkout..."
+    cd "$DEV_REPO_ROOT" || die "--dev could not enter the GJC checkout at ${DEV_REPO_ROOT}."
+    bun run build || die "--dev build failed."
+    bun run install:dev:bin || die "--dev install failed."
+    echo ""
+    echo "Installed gjc development build from checkout"
+    echo "Run 'gjc' to get started!"
+}
+
 install_via_bun() {
     echo "Installing from source via existing bun..."
     if [ -n "$REF" ]; then
@@ -615,10 +656,17 @@ install_binary() {
 while [ $# -gt 0 ]; do
     case "$1" in
         --source)
+            SOURCE_REQUESTED=1
             MODE="source"
             shift
             ;;
+        --dev)
+            DEV_REQUESTED=1
+            MODE="dev"
+            shift
+            ;;
         --binary)
+            BINARY_REQUESTED=1
             MODE="binary"
             shift
             ;;
@@ -661,6 +709,14 @@ while [ $# -gt 0 ]; do
     esac
 done
 
+if [ "$DEV_REQUESTED" -eq 1 ]; then
+    if [ "$SOURCE_REQUESTED" -eq 1 ] || [ "$BINARY_REQUESTED" -eq 1 ]; then
+        die "--dev cannot be combined with --source or --binary."
+    fi
+    [ -z "$REF" ] || die "--dev cannot be combined with --ref; it uses the current checkout."
+    [ "$CHANNEL" = "stable" ] || die "--dev cannot be combined with --channel $CHANNEL; it uses the current checkout."
+fi
+
 case "$MODE" in
     source)
         if ! has_bun; then
@@ -670,6 +726,14 @@ Ordinary installs should omit --source and use the prebuilt binary."
         fi
         require_bun_version
         install_via_bun
+        ;;
+    dev)
+        require_dev_checkout
+        if ! has_bun; then
+            die "--dev requires an existing Bun on PATH.
+This installer never downloads Bun. Install it from https://bun.sh/docs/installation"
+        fi
+        install_dev
         ;;
     binary)
         install_binary


### PR DESCRIPTION
## What

Add `scripts/install.sh --dev` as a checkout-only shortcut that runs `bun run build` and then `bun run install:dev:bin` from the repository root.

## Why

Developers should not have to remember or partially execute the compiled dev-install sequence. Piped installers and release flags fail closed rather than silently doing the wrong installation.

## Testing

- Installer suite: 27 pass after latest dev merge
- `sh -n scripts/install.sh`
- Actual `bun run build && bun run install:dev:bin`
- `gjc --smoke-test`
- `bun run dev:doctor`

## Risk classification

- [x] `low-risk` — opt-in installer mode with isolated test coverage
- [ ] `regression-risk`
- [ ] `high-risk`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:22bf74a4b47fcc998a1e069c334641a8eb639b4bf14a8abb826cc5f4f058961f reviewer:human reviewer-id:Yeachan-Heo evidence:local:installer-27-pass+shell-syntax+dev-install-smoke
```

---

- [x] Target branch is `dev`
- [x] Focused checks pass
- [x] Tested locally
- [x] CHANGELOG unchanged (developer-only installer shortcut)
- [x] Verdict matches exact PR head
- [x] Risk classification matches review path