### PR TITLE
perf(models): cache preset availability between refreshes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - The status-line usage segment now paints only the active model's provider, so switching to Grok no longer keeps a stale Claude 5h/7d pair. Canonical Grok Build reports render only their authoritative weekly window, while monthly credits are omitted instead of being mislabeled as `7d`.
 
+- Moving the `/model` preset cursor now reuses the authentication snapshot produced by catalog and credential refreshes instead of resolving every profile against the full model catalog on each Up/Down keypress.
 - Mid-run OpenAI remote-compaction fallback failures now stop before another provider request, surface the local summarization error through ACP/SDK terminal handling, and leave the uncompacted context unsubmitted. Successful local fallback still commits the compaction and resumes normally.
 - Opening `/model` now renders the preset landing before constructing the full model browser catalog. Canonical search indexing, sorting, and the redundant offline registry refresh are deferred until the user searches or chooses a browse action, while the lightweight preset-availability check remains immediate and scoped or direct-search selectors still load immediately.
 - `/model` provider-tab refreshes now reuse the already loaded static catalog and update only the selected provider's discovery state, avoiding repeated signed preset registry work while retaining full-catalog refresh behavior for static configuration changes.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 - The status-line usage segment now paints only the active model's provider, so switching to Grok no longer keeps a stale Claude 5h/7d pair. Canonical Grok Build reports render only their authoritative weekly window, while monthly credits are omitted instead of being mislabeled as `7d`.
 
-- Moving the `/model` preset cursor now reuses the authentication snapshot produced by catalog and credential refreshes instead of resolving every profile against the full model catalog on each Up/Down keypress.
+- Moving the `/model` preset cursor now reuses the authentication snapshot produced by catalog and credential refreshes instead of resolving every profile against the full model catalog on each Up/Down keypress; auth-dependent preset actions remain blocked until the initial static refresh and the availability snapshot are complete.
 - Mid-run OpenAI remote-compaction fallback failures now stop before another provider request, surface the local summarization error through ACP/SDK terminal handling, and leave the uncompacted context unsubmitted. Successful local fallback still commits the compaction and resumes normally.
 - Opening `/model` now renders the preset landing before constructing the full model browser catalog. Canonical search indexing, sorting, and the redundant offline registry refresh are deferred until the user searches or chooses a browse action, while the lightweight preset-availability check remains immediate and scoped or direct-search selectors still load immediately.
 - `/model` provider-tab refreshes now reuse the already loaded static catalog and update only the selected provider's discovery state, avoiding repeated signed preset registry work while retaining full-catalog refresh behavior for static configuration changes.

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -3046,6 +3046,7 @@ export class ModelRegistry {
 		refreshGeneration = this.#catalogRefreshGeneration,
 		providerRefresh?: ProviderRefreshFence,
 	): Promise<void> {
+		const profileAvailabilityEvidenceBefore = this.#profileAvailabilityEvidenceFingerprint();
 		const disabledProviders = getDisabledProviderIdsFromSettings(this.#settings);
 		const selectedDiscoverableProviders = (
 			providerFilter
@@ -3252,12 +3253,32 @@ export class ModelRegistry {
 			});
 		}
 		if (discovered.length === 0) {
-			if (clearPublishedModelIds.size > 0) {
+			if (
+				clearPublishedModelIds.size > 0 ||
+				profileAvailabilityEvidenceBefore !== this.#profileAvailabilityEvidenceFingerprint()
+			) {
 				this.#rebuildCanonicalIndex();
 			}
 			return;
 		}
 		this.#mergeDiscoveredModels(discovered);
+	}
+
+	#profileAvailabilityEvidenceFingerprint(): string {
+		return JSON.stringify(
+			[...this.#descriptorDiscoveryEvidence.entries()]
+				.sort(([left], [right]) => left.localeCompare(right))
+				.map(([provider, evidence]) => [
+					provider,
+					evidence.fresh,
+					evidence.profileFresh,
+					evidence.authGeneration,
+					evidence.endpoint,
+					evidence.profileEndpoint,
+					[...evidence.modelIds].sort(),
+					evidence.profileModelIds === undefined ? undefined : [...evidence.profileModelIds].sort(),
+				]),
+		);
 	}
 
 	#mergeDiscoveredModels(discovered: readonly Model<Api>[]): void {

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -571,10 +571,15 @@ export class ModelSelectorComponent extends Container {
 			});
 		}
 
-		// Advisory drift only, and only while the smart-routing panel is mounted. This
-		// must not call refreshState: that would discard the user's unsaved draft.
+		// Proxy changes invalidate preset availability. Provider-order changes are
+		// advisory only while smart routing is mounted and must not discard its draft.
 		this.#unsubscribeProviderOrderChanged = this.#settings.onChanged?.(path => {
-			if (this.#disposed || path !== "modelProviderOrder") return;
+			if (this.#disposed) return;
+			if (path === "modelProfile.proxyProvider" || path === "modelProfile.proxyMode") {
+				if (this.#viewMode === "presets") void this.#refreshProviderAuth();
+				return;
+			}
+			if (path !== "modelProviderOrder") return;
 			if (this.#viewMode !== "smart-routing") return;
 			const panel = this.#smartRoutingPanel;
 			if (!panel) return;
@@ -2575,6 +2580,11 @@ export class ModelSelectorComponent extends Container {
 				this.#onSelectCallback({ kind: "deleteProfile", profileName: this.#previewProfileName });
 				return;
 			}
+			if (this.#providerAuthPending) {
+				this.#presetLoginHint = "Refreshing preset availability...";
+				this.#renderPresetLanding();
+				return;
+			}
 			const missing = this.#getMissingProviders(profile);
 			if (missing.length > 0) {
 				this.#presetLoginHint = `Run ${missing.map(provider => `/login ${provider}`).join(", ")}`;
@@ -2627,6 +2637,11 @@ export class ModelSelectorComponent extends Container {
 			return;
 		}
 		if (row.kind === "group") {
+			if (this.#providerAuthPending) {
+				this.#presetLoginHint = "Refreshing preset availability...";
+				this.#renderPresetLanding();
+				return;
+			}
 			// A group is a list of alternative presets; only surface a login hint
 			// when none of its members are usable. A partially-usable group stays
 			// navigable so the user can drill in and pick a usable member.
@@ -2647,6 +2662,11 @@ export class ModelSelectorComponent extends Container {
 				this.#expandSelectedPresetProvider();
 			}
 			this.#presetLoginHint = undefined;
+			this.#renderPresetLanding();
+			return;
+		}
+		if (this.#providerAuthPending && !isCustomUserProfile(row.profile)) {
+			this.#presetLoginHint = "Refreshing preset availability...";
 			this.#renderPresetLanding();
 			return;
 		}
@@ -2687,7 +2707,7 @@ export class ModelSelectorComponent extends Container {
 			this.#presetLoginHint = undefined;
 			this.#clampPresetCursor();
 		}
-		this.#renderPresetLanding();
+		void this.#refreshProviderAuth();
 		this.#tui.requestRender();
 	}
 

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -426,6 +426,8 @@ export class ModelSelectorComponent extends Container {
 	#presetScopeIndex: number = 0;
 	#providerAuthById = new Map<string, boolean>();
 	#bareProfileAuthByName = new Map<string, boolean>();
+	// Rebuilt with the provider and bare-selector snapshots on every catalog or credential refresh.
+	#profileAuthByName = new Map<string, boolean>();
 	#providerAuthPending: boolean = false;
 	#providerAuthRefreshGeneration = 0;
 	#presetLoginHint?: string;
@@ -1404,9 +1406,13 @@ export class ModelSelectorComponent extends Container {
 		return [...missing].sort((a, b) => a.localeCompare(b));
 	}
 
-	#isPresetAuthenticated(profileOrProfiles: ModelProfileDefinition | ModelProfileDefinition[]): boolean {
+	#isPresetAuthenticated(
+		profileOrProfiles: ModelProfileDefinition | ModelProfileDefinition[],
+		computeCurrent = false,
+	): boolean {
 		const profiles = Array.isArray(profileOrProfiles) ? profileOrProfiles : [profileOrProfiles];
 		return profiles.every(profile => {
+			if (!computeCurrent) return this.#profileAuthByName.get(profile.name) === true;
 			if (profile.source !== "user") {
 				if (inspectProxyProviderId(this.#settings).status === "invalid") return false;
 				const proxyProvider = tryResolveProxyProviderId(this.#settings);
@@ -1502,6 +1508,7 @@ export class ModelSelectorComponent extends Container {
 		const refreshGeneration = ++this.#providerAuthRefreshGeneration;
 		this.#providerAuthById = new Map();
 		this.#bareProfileAuthByName = new Map();
+		this.#profileAuthByName = new Map();
 		const availableModels = this.#getProfileAvailableModels();
 		const resolutionRegistry = this.#createProfileResolutionRegistry(availableModels);
 		const providers = new Set<string>();
@@ -1611,6 +1618,11 @@ export class ModelSelectorComponent extends Container {
 			)
 				return;
 			this.#bareProfileAuthByName = new Map(profileAuthEntries);
+			this.#profileAuthByName = new Map(
+				[...this.#getPresetGroups().values()]
+					.flat()
+					.map(profile => [profile.name, this.#isPresetAuthenticated(profile, true)]),
+			);
 		} finally {
 			if (
 				!this.#disposed &&

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -571,11 +571,15 @@ export class ModelSelectorComponent extends Container {
 			});
 		}
 
-		// Proxy changes invalidate preset availability. Provider-order changes are
+		// Proxy and provider-policy changes invalidate preset availability. Provider-order changes are
 		// advisory only while smart routing is mounted and must not discard its draft.
 		this.#unsubscribeProviderOrderChanged = this.#settings.onChanged?.(path => {
 			if (this.#disposed) return;
-			if (path === "modelProfile.proxyProvider" || path === "modelProfile.proxyMode") {
+			if (
+				path === "modelProfile.proxyProvider" ||
+				path === "modelProfile.proxyMode" ||
+				path === "disabledProviders"
+			) {
 				if (this.#viewMode === "presets") void this.#refreshProviderAuth();
 				return;
 			}

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -596,6 +596,7 @@ export class ModelSelectorComponent extends Container {
 			// The landing only needs profile definitions and provider authentication.
 			// Refresh static configuration without enumerating and canonicalizing the
 			// full browser catalog, then resolve preset authentication once.
+			this.#presetCatalogRefreshPending = true;
 			if ((this.#modelRegistry.getModelProfiles?.().size ?? 0) > 0) {
 				this.#renderPresetLanding();
 			} else {
@@ -1338,6 +1339,10 @@ export class ModelSelectorComponent extends Container {
 		return this.#modelRegistry.getModelProfile?.(name) ?? this.#modelRegistry.getModelProfiles?.().get(name);
 	}
 
+	#isPresetAvailabilityPending(): boolean {
+		return this.#presetCatalogRefreshPending || this.#providerAuthPending;
+	}
+
 	#isProviderAuthenticated(providerId: string): boolean | undefined {
 		return this.#providerAuthById.get(providerId);
 	}
@@ -2025,7 +2030,7 @@ export class ModelSelectorComponent extends Container {
 			}
 			if (row.kind === "group") {
 				const authenticated = this.#isPresetGroupUsable(row.profiles);
-				const mark = this.#providerAuthPending ? "…" : authenticated ? "✓" : "✗";
+				const mark = this.#isPresetAvailabilityPending() ? "…" : authenticated ? "✓" : "✗";
 				const containsActive =
 					this.#activeModelProfile !== undefined &&
 					row.profiles.some(profile => profile.name === this.#activeModelProfile);
@@ -2037,7 +2042,7 @@ export class ModelSelectorComponent extends Container {
 			}
 			const presentation = getModelProfilePresentation(row.profile);
 			const authenticated = this.#isPresetAuthenticated(row.profile);
-			const mark = this.#providerAuthPending ? "…" : authenticated ? "✓" : "✗";
+			const mark = this.#isPresetAvailabilityPending() ? "…" : authenticated ? "✓" : "✗";
 			const isActive = row.profile.name === this.#activeModelProfile;
 			const label = `  ${mark} ${presentation.displayName}`;
 			const renderedLabel = selected ? theme.fg("accent", label) : authenticated ? label : theme.fg("dim", label);
@@ -2580,7 +2585,7 @@ export class ModelSelectorComponent extends Container {
 				this.#onSelectCallback({ kind: "deleteProfile", profileName: this.#previewProfileName });
 				return;
 			}
-			if (this.#providerAuthPending) {
+			if (this.#isPresetAvailabilityPending()) {
 				this.#presetLoginHint = "Refreshing preset availability...";
 				this.#renderPresetLanding();
 				return;
@@ -2637,7 +2642,7 @@ export class ModelSelectorComponent extends Container {
 			return;
 		}
 		if (row.kind === "group") {
-			if (this.#providerAuthPending) {
+			if (this.#isPresetAvailabilityPending()) {
 				this.#presetLoginHint = "Refreshing preset availability...";
 				this.#renderPresetLanding();
 				return;
@@ -2665,7 +2670,7 @@ export class ModelSelectorComponent extends Container {
 			this.#renderPresetLanding();
 			return;
 		}
-		if (this.#providerAuthPending && !isCustomUserProfile(row.profile)) {
+		if (this.#isPresetAvailabilityPending() && !isCustomUserProfile(row.profile)) {
 			this.#presetLoginHint = "Refreshing preset availability...";
 			this.#renderPresetLanding();
 			return;

--- a/packages/coding-agent/test/model-profile-activation.test.ts
+++ b/packages/coding-agent/test/model-profile-activation.test.ts
@@ -330,6 +330,52 @@ describe("model profile activation", () => {
 		}
 	});
 
+	test("notifies mounted consumers when fresh discovery evidence changes from non-empty to empty", async () => {
+		const tempDir = TempDir.createSync("@gjc-profile-live-catalog-notify-");
+		const authStorage = await AuthStorage.create(`${tempDir.path()}/auth.db`);
+		try {
+			authStorage.setRuntimeApiKey("anthropic", "test-anthropic-key");
+			let discoveryCount = 0;
+			using _hook = hookFetch(input => {
+				const url = String(input);
+				if (url === "https://models.dev/api.json") {
+					return new Response(JSON.stringify({ anthropic: { models: {} } }), {
+						headers: { "Content-Type": "application/json" },
+					});
+				}
+				if (!url.endsWith("/models")) throw new Error(`Unexpected model discovery request: ${input}`);
+				discoveryCount += 1;
+				return new Response(JSON.stringify({ data: discoveryCount === 1 ? [{ id: "claude-opus-5" }] : [] }), {
+					headers: { "Content-Type": "application/json" },
+				});
+			});
+			const registry = new ModelRegistry(authStorage, `${tempDir.path()}/models.yml`);
+			let catalogNotifications = 0;
+			registry.onCatalogChanged(() => {
+				catalogNotifications += 1;
+			});
+
+			await registry.refreshProvider("anthropic", "online");
+			expect(
+				registry
+					.getAvailableForProfileActivation()
+					.some(candidate => candidate.provider === "anthropic" && candidate.id === "claude-opus-5"),
+			).toBe(true);
+			const notificationsAfterNonEmpty = catalogNotifications;
+
+			await registry.refreshProvider("anthropic", "online");
+			expect(catalogNotifications).toBeGreaterThan(notificationsAfterNonEmpty);
+			expect(
+				registry
+					.getAvailableForProfileActivation()
+					.some(candidate => candidate.provider === "anthropic" && candidate.id === "claude-opus-5"),
+			).toBe(false);
+		} finally {
+			authStorage.close();
+			tempDir.removeSync();
+		}
+	});
+
 	test("built-in claude-opus retains bundled Opus 5 after live catalog discovery fails", async () => {
 		const tempDir = TempDir.createSync("@gjc-profile-stale-catalog-");
 		const authStorage = await AuthStorage.create(`${tempDir.path()}/auth.db`);

--- a/packages/coding-agent/test/model-selector-profiles.test.ts
+++ b/packages/coding-agent/test/model-selector-profiles.test.ts
@@ -461,6 +461,45 @@ describe("model selector profiles", () => {
 		expect(rendered).toContain("✗ REGISTRY FALLBACK");
 	});
 
+	test("fences preset actions and rebuilds availability when disabled providers change", async () => {
+		installTestTheme();
+		const settings = Settings.isolated();
+		const profiles = new Map<string, ModelProfileDefinition>([[profile.name, profile]]);
+		const refreshGate = Promise.withResolvers<"key">();
+		let delayProviderAuth = false;
+		const registry = createRegistry() as unknown as TestModelRegistry & {
+			getAvailableForProfileActivation: () => Model[];
+			getApiKeyForProvider: (provider: string) => Promise<string>;
+		};
+		registry.getModelProfiles = () => new Map(profiles);
+		registry.getModelProfile = (name: string) => profiles.get(name);
+		registry.getAvailableModelProfileNames = () => [...profiles.keys()];
+		registry.getAvailableForProfileActivation = () =>
+			settings.get("disabledProviders").includes("provider-a") ? [] : [defaultModel, alternateModel];
+		registry.getApiKeyForProvider = async provider => {
+			if (delayProviderAuth && provider === "provider-a") return refreshGate.promise;
+			return "key";
+		};
+
+		const selector = createSelector(() => {}, { registry, settings });
+		await Bun.sleep(10);
+		expect(normalizeRenderedText(selector.render(220).join("\n"))).toContain("✓ CUSTOM");
+
+		delayProviderAuth = true;
+		settings.set("disabledProviders", ["provider-a"]);
+		let rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain("… CUSTOM");
+
+		selector.handleInput("\n");
+		rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain("Refreshing preset availability...");
+		expect(rendered).not.toContain("No available model matches this preset");
+
+		refreshGate.resolve("key");
+		await Bun.sleep(10);
+		expect(normalizeRenderedText(selector.render(220).join("\n"))).toContain("✗ CUSTOM");
+	});
+
 	beforeAll(async () => {
 		testTheme = await getThemeByName("red-claw");
 		installTestTheme();

--- a/packages/coding-agent/test/model-selector-profiles.test.ts
+++ b/packages/coding-agent/test/model-selector-profiles.test.ts
@@ -496,9 +496,13 @@ describe("model selector profiles", () => {
 
 	test("up and down navigation stays on provider rows while collapsed", async () => {
 		installTestTheme();
-		const selector = createSelector(() => {});
+		const registry = createRegistry();
+		const getAvailable = vi.fn(registry.getAvailable);
+		registry.getAvailable = getAvailable;
+		const selector = createSelector(() => {}, { registry });
 		await Bun.sleep(10);
 		installTestTheme();
+		getAvailable.mockClear();
 
 		let rendered = normalizeRenderedText(selector.render(220).join("\n"));
 		expect(rendered).toContain("CODEX");
@@ -519,6 +523,7 @@ describe("model selector profiles", () => {
 		expect(rendered).toContain("CODEX");
 		expect(rendered).not.toContain("Codex Eco");
 		expect(rendered).not.toContain("profile-a");
+		expect(getAvailable).not.toHaveBeenCalled();
 	});
 
 	test("landing header shows the session's current preset, model, and role assignments", async () => {

--- a/packages/coding-agent/test/model-selector-profiles.test.ts
+++ b/packages/coding-agent/test/model-selector-profiles.test.ts
@@ -443,16 +443,22 @@ describe("model selector profiles", () => {
 		registry.getConfiguredProviderIds = () => ["litellm"];
 		registry.getApiKeyForProvider = (async (provider: string) =>
 			provider === "provider-a" ? "direct-key" : undefined) as typeof registry.getApiKeyForProvider;
+		const settings = Settings.isolated({
+			"modelProfile.proxyProvider": "litellm",
+			"modelProfile.proxyMode": "fallback",
+		});
 		const selector = createSelector(() => {}, {
 			registry,
-			settings: Settings.isolated({
-				"modelProfile.proxyProvider": "litellm",
-				"modelProfile.proxyMode": "fallback",
-			}),
+			settings,
 		});
 		await Bun.sleep(10);
-		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		let rendered = normalizeRenderedText(selector.render(220).join("\n"));
 		expect(rendered).toContain("✓ REGISTRY FALLBACK");
+
+		settings.set("modelProfile.proxyMode", "always");
+		await Bun.sleep(10);
+		rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain("✗ REGISTRY FALLBACK");
 	});
 
 	beforeAll(async () => {
@@ -494,6 +500,29 @@ describe("model selector profiles", () => {
 		expect(rendered).not.toContain("Codex Eco");
 	});
 
+	test("defers authenticated preset actions while availability refresh is pending", async () => {
+		installTestTheme();
+		const gate = Promise.withResolvers<"key">();
+		const registry = createRegistry();
+		registry.getApiKeyForProvider = async () => gate.promise;
+		const selector = createSelector(() => {}, { registry });
+		await Bun.sleep(0);
+
+		let rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain("… CODEX");
+
+		selector.handleInput("\n");
+		rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain("Refreshing preset availability...");
+		expect(rendered).not.toContain("No available model matches this preset");
+
+		gate.resolve("key");
+		await Bun.sleep(10);
+		selector.handleInput("\n");
+		rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain("Codex Eco");
+	});
+
 	test("up and down navigation stays on provider rows while collapsed", async () => {
 		installTestTheme();
 		const registry = createRegistry();
@@ -524,6 +553,38 @@ describe("model selector profiles", () => {
 		expect(rendered).not.toContain("Codex Eco");
 		expect(rendered).not.toContain("profile-a");
 		expect(getAvailable).not.toHaveBeenCalled();
+	});
+
+	test("rebuilds preset availability after profiles change in place", async () => {
+		installTestTheme();
+		const profiles = new Map<string, ModelProfileDefinition>([[profile.name, profile]]);
+		const registry = createRegistry();
+		registry.getModelProfiles = () => new Map(profiles);
+		registry.getModelProfile = (name: string) => profiles.get(name);
+		let selected: ModelSelectorSelection | undefined;
+		const selector = createSelector(
+			selection => {
+				selected = selection;
+			},
+			{ registry },
+		);
+		await Bun.sleep(10);
+
+		const addedProfile: ModelProfileDefinition = {
+			name: "added-profile",
+			displayName: "Added Profile",
+			providerGroup: "ADDED",
+			requiredProviders: ["provider-a"],
+			modelMapping: { default: "provider-a/default" },
+			source: "user",
+		};
+		profiles.set(addedProfile.name, addedProfile);
+		selector.refreshPresetProfiles(addedProfile.name);
+		await Bun.sleep(10);
+
+		selector.handleInput("\n");
+		selector.handleInput("\n");
+		expect(selected).toEqual({ kind: "profile", profileName: "added-profile", setDefault: false });
 	});
 
 	test("landing header shows the session's current preset, model, and role assignments", async () => {

--- a/packages/coding-agent/test/model-selector-profiles.test.ts
+++ b/packages/coding-agent/test/model-selector-profiles.test.ts
@@ -523,6 +523,31 @@ describe("model selector profiles", () => {
 		expect(rendered).toContain("Codex Eco");
 	});
 
+	test("defers preset actions while the initial static catalog refresh is pending", async () => {
+		installTestTheme();
+		const gate = Promise.withResolvers<void>();
+		const registry = createRegistry() as unknown as TestModelRegistry & {
+			refreshStatic: () => Promise<void>;
+		};
+		registry.refreshStatic = () => gate.promise;
+		const selector = createSelector(() => {}, { registry });
+		await Bun.sleep(0);
+
+		let rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain("… CODEX");
+
+		selector.handleInput("\n");
+		rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain("Refreshing preset availability...");
+		expect(rendered).not.toContain("Run /login provider-a");
+
+		gate.resolve();
+		await Bun.sleep(10);
+		selector.handleInput("\n");
+		rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain("Codex Eco");
+	});
+
 	test("up and down navigation stays on provider rows while collapsed", async () => {
 		installTestTheme();
 		const registry = createRegistry();

--- a/scripts/ci-dev-affected.test.ts
+++ b/scripts/ci-dev-affected.test.ts
@@ -1382,6 +1382,12 @@ test("tab-worker graph changes always include install-methods and are Darwin rel
 		expect(tasks[2]?.command).toEqual(["bun", "run", "ci:test:smoke"]);
 		expect(keys.filter(key => key === "native-linux-x64")).toHaveLength(1);
 	});
+	test("model selector changes schedule adjacent preset and smart-routing regressions", () => {
+		const keys = targeted(["packages/coding-agent/src/modes/components/model-selector.ts"]).map(task => task.key);
+		expect(keys).toContain("test:packages/coding-agent/test/model-selector-profiles-redteam.test.ts");
+		expect(keys).toContain("test:packages/coding-agent/test/model-preset-landing-redteam-qa.test.ts");
+		expect(keys).toContain("test:packages/coding-agent/test/model-selector-smart-routing.integration.test.ts");
+	});
 	test("file-tool sources schedule their ACP and publication regression suites", () => {
 		const expected: Record<string, string> = {
 			"packages/coding-agent/src/tools/atomic-file-write.ts": "packages/coding-agent/test/file-tools-atomicity.test.ts",

--- a/scripts/ci-dev-affected.ts
+++ b/scripts/ci-dev-affected.ts
@@ -75,6 +75,11 @@ const BEHAVIORAL_OWNER_TESTS: Readonly<Record<string, readonly string[]>> = {
 	"packages/coding-agent/src/tools/write.ts": ["packages/coding-agent/test/write-acp-fs.test.ts"],
 	"packages/coding-agent/src/lsp/index.ts": ["packages/coding-agent/test/tools/lsp-batching.test.ts"],
 	"packages/coding-agent/src/config/model-registry.ts": ["packages/coding-agent/test/model-registry-runtime-provider.test.ts"],
+	"packages/coding-agent/src/modes/components/model-selector.ts": [
+		"packages/coding-agent/test/model-selector-profiles-redteam.test.ts",
+		"packages/coding-agent/test/model-preset-landing-redteam-qa.test.ts",
+		"packages/coding-agent/test/model-selector-smart-routing.integration.test.ts",
+	],
 	"packages/ai/src/providers/anthropic.ts": [
 		"packages/ai/test/anthropic-truncated-toolcall.test.ts",
 		"packages/ai/test/anthropic-stream-envelope.test.ts",


### PR DESCRIPTION
## What

Cache each model preset's authenticated availability when catalog, credential, profile, or proxy state refreshes. Up/Down cursor rendering now reads that snapshot instead of resolving every profile against the full available-model catalog.

Auth-dependent Enter actions wait while a refresh is pending. Profile additions and `modelProfile.proxyProvider` / `modelProfile.proxyMode` changes explicitly rebuild the snapshot.

## Why

`/model` cursor movement rebuilt the preset rows and synchronously re-resolved every qualified profile assignment on each keypress. On the affected configuration, one Up/Down transition took 1,312–1,350ms; a fresh HOME and agent directory still took 477–510ms.

This is separate from #5197 and #5251: those optimize authentication refresh collection and provider refresh respectively, while cursor movement calls neither path and repeatedly performs availability resolution during rendering.

With this change, the same tmux probe measured 103–106ms on the affected configuration and 110–121ms in the clean environment.

## Testing

- `bun test packages/coding-agent/test/model-selector-profiles.test.ts packages/coding-agent/test/model-selector-profiles-redteam.test.ts packages/coding-agent/test/model-selector-batch-thinking.test.ts packages/coding-agent/test/model-selector-controller-batch.test.ts packages/coding-agent/test/model-selector-role-badge-thinking.test.ts packages/coding-agent/test/model-selector-action-menu-role-binding.test.ts packages/coding-agent/test/model-selector-smart-routing.integration.test.ts packages/coding-agent/test/model-preset-landing-redteam-qa.test.ts packages/coding-agent/test/model-profile-activation.test.ts packages/coding-agent/test/model-profile-activation-redteam.test.ts scripts/ci-dev-affected.test.ts` — 367 passed, 0 failed
- `bun --cwd=packages/coding-agent run check` — passed
- `bun --cwd=packages/coding-agent run build` — passed
- `bun scripts/verify-gjc-state-writers.ts --fail` — 0 writes outside the sanctioned writer/allowlist
- tmux clean-agent latency probe — median 492ms before, 116ms after
- tmux configured-agent latency probe — median about 1,332ms before, 104ms after
- Authenticated review `5111157358` identified three P2 gaps. Fix-forward commit `e3a4d1f01fe5bfdc22e7a7febd822671d5a5b2c0` adds disabled-provider invalidation with pending fencing, zero-model discovery-evidence notification, and affected-CI mappings for the adjacent selector suites.

## Risk classification

- [ ] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [x] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:0e2765daf8ec7fedb73b2b2bf3c5ad3c718d881a1283a4ca7363b6931edf7068 reviewer:human reviewer-id:Yeachan-Heo evidence:authenticated-exact-head-review-5111885098-base-2ab64d68836-head-e3a4d1f01fe
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken
