### PR TITLE
feat: add opt-in English reasoning guidance

### DIFF
--- a/packages/coding-agent/scripts/generate-sdk-operation-inventory.ts
+++ b/packages/coding-agent/scripts/generate-sdk-operation-inventory.ts
@@ -119,6 +119,13 @@ const LOCKED_EXCLUSIONS: Readonly<Record<string, string>> = {
 		"test-only parked terminal flush seam, not a user-facing SDK control seam",
 	"agent_session:setCancelAndSubmitAbortOutcomeProviderForTests":
 		"test-only cancellation seam, not a user-facing SDK control seam",
+	"agent_session:awaitDisposeCompletion": "test-only disposal completion seam, not a user-facing SDK control seam",
+	"agent_session:setDisposeTimeoutForTests": "test-only disposal timeout seam, not a user-facing SDK control seam",
+	"agent_session:trackPostPromptTaskForTests": "test-only post-prompt task seam, not a user-facing SDK control seam",
+	"agent_session:requestWorkerIntegrationForTests":
+		"test-only worker integration seam, not a user-facing SDK control seam",
+	"agent_session:runWithPromptAdmissionForTests":
+		"test-only prompt admission seam, not a user-facing SDK control seam",
 	"agent_session:getAgentId": "internal accessor/plumbing, not a user-facing control seam",
 	"agent_session:emitNotice": "internal accessor/plumbing, not a user-facing control seam",
 	"agent_session:subscribe": "internal accessor/plumbing, not a user-facing control seam",

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1243,6 +1243,26 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	reasoningLanguage: {
+		type: "enum",
+		values: ["off", "english"] as const,
+		default: "off",
+		ui: {
+			tab: "model",
+			label: "Reasoning Language",
+			description:
+				"Optionally reason through development work in English while preserving the user's response language",
+			options: [
+				{ value: "off", label: "Off", description: "Do not add reasoning-language guidance" },
+				{
+					value: "english",
+					label: "English",
+					description: "Reason through technical work in English and answer in the user's language",
+				},
+			],
+		},
+	},
+
 	hideThinkingBlock: {
 		type: "boolean",
 		default: false,

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -47,6 +47,14 @@ Optimize for correctness first, maintainability second, and brevity third. Prefe
 - Do not defer actionable work. Underpromise and overdeliver: report only what is done or in progress, never announce remaining work instead of doing it.
 </communication>
 
+{{#if reasoningLanguageEnglish}}
+<reasoning-language>
+- Reason through development and technical problem-solving in English.
+- Keep user-facing answers in the language the user requested or used.
+- This changes reasoning language only; it does not relax correctness, safety, or communication requirements.
+</reasoning-language>
+{{/if}}
+
 <completion-contract>
 - Never present partial work as complete.
 - Never suppress tests or warnings to make code pass.

--- a/packages/coding-agent/src/sdk/protocol/operation-inventory.generated.json
+++ b/packages/coding-agent/src/sdk/protocol/operation-inventory.generated.json
@@ -2842,6 +2842,50 @@
 		}
 	},
 	{
+		"sourceId": "agent_session:awaitDisposeCompletion",
+		"sourceFile": "packages/coding-agent/src/session/agent-session.ts",
+		"sourceKind": "agent_session",
+		"decision": "exclude",
+		"rationale": "test-only disposal completion seam, not a user-facing SDK control seam",
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
+	},
+	{
+		"sourceId": "agent_session:setDisposeTimeoutForTests",
+		"sourceFile": "packages/coding-agent/src/session/agent-session.ts",
+		"sourceKind": "agent_session",
+		"decision": "exclude",
+		"rationale": "test-only disposal timeout seam, not a user-facing SDK control seam",
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
+	},
+	{
+		"sourceId": "agent_session:trackPostPromptTaskForTests",
+		"sourceFile": "packages/coding-agent/src/session/agent-session.ts",
+		"sourceKind": "agent_session",
+		"decision": "exclude",
+		"rationale": "test-only post-prompt task seam, not a user-facing SDK control seam",
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
+	},
+	{
+		"sourceId": "agent_session:requestWorkerIntegrationForTests",
+		"sourceFile": "packages/coding-agent/src/session/agent-session.ts",
+		"sourceKind": "agent_session",
+		"decision": "exclude",
+		"rationale": "test-only worker integration seam, not a user-facing SDK control seam",
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
+	},
+	{
 		"sourceId": "agent_session:closeWriterStrict",
 		"sourceFile": "packages/coding-agent/src/session/agent-session.ts",
 		"sourceKind": "agent_session",
@@ -2880,6 +2924,17 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal agent-event settlement barrier, not a user-facing SDK control seam",
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
+	},
+	{
+		"sourceId": "agent_session:runWithPromptAdmissionForTests",
+		"sourceFile": "packages/coding-agent/src/session/agent-session.ts",
+		"sourceKind": "agent_session",
+		"decision": "exclude",
+		"rationale": "test-only prompt admission seam, not a user-facing SDK control seam",
 		"exclusionMetadata": {
 			"adapterMappings": "not_applicable",
 			"testIds": "not_applicable"

--- a/packages/coding-agent/src/sdk/session.ts
+++ b/packages/coding-agent/src/sdk/session.ts
@@ -3924,6 +3924,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				appendSystemPrompt: appendPrompt,
 				pluginAppendices: pluginSystemAppendices,
 				repeatToolDescriptions,
+				reasoningLanguage: settings.get("reasoningLanguage"),
 				intentField,
 				toolDiscoveryActive: effectiveDiscoveryMode === "all" || mcpDiscoveryEnabled,
 				eagerTasks: resolveEagerTasks(),

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -368,6 +368,8 @@ export interface BuildSystemPromptOptions {
 	pluginAppendices?: string;
 	/** Repeat full tool descriptions in system prompt. Default: false */
 	repeatToolDescriptions?: boolean;
+	/** Language guidance for internal technical reasoning. Default: off. */
+	reasoningLanguage?: "off" | "english";
 	/** Skills settings for discovery. */
 	skillsSettings?: SkillsSettings;
 	/** Working directory. Default: getProjectDir() */
@@ -542,6 +544,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		appendSystemPrompt,
 		pluginAppendices,
 		repeatToolDescriptions = false,
+		reasoningLanguage = "off",
 		toolNames: providedToolNames,
 		cwd,
 		contextFiles: providedContextFiles,
@@ -710,6 +713,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		tools: toolNames,
 		toolInfo,
 		repeatToolDescriptions,
+		reasoningLanguageEnglish: reasoningLanguage === "english",
 		toolRefs,
 		environment,
 		contextFiles: sanitizedContextFiles,

--- a/packages/coding-agent/test/config-cli.test.ts
+++ b/packages/coding-agent/test/config-cli.test.ts
@@ -55,6 +55,24 @@ describe("config CLI schema coverage", () => {
 		});
 	});
 
+	it("configures opt-in English reasoning with an off default", async () => {
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await runConfigCommand({ action: "get", key: "reasoningLanguage", flags: { json: true } });
+		expect(JSON.parse(String(logSpy.mock.calls.at(-1)?.[0])).value).toBe("off");
+
+		await runConfigCommand({ action: "set", key: "reasoningLanguage", value: "english", flags: { json: true } });
+		await runConfigCommand({ action: "get", key: "reasoningLanguage", flags: { json: true } });
+
+		expect(JSON.parse(String(logSpy.mock.calls.at(-1)?.[0]))).toEqual({
+			key: "reasoningLanguage",
+			value: "english",
+			type: "enum",
+			description:
+				"Optionally reason through development work in English while preserving the user's response language",
+		});
+	});
+
 	it("renders record settings as JSON and with record type in text output", async () => {
 		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 

--- a/packages/coding-agent/test/fixture-broker-cleanup.test.ts
+++ b/packages/coding-agent/test/fixture-broker-cleanup.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs/promises";
 import path from "node:path";
 import {
 	cleanupFixtureRoot,
+	cleanupFixtureRootAfterLateWrite,
 	cleanupFixtureRoots,
 	createFixtureBrokerEnvironment,
 	createFixtureRootCleanup,
@@ -96,6 +97,29 @@ describe("fixture broker root cleanup", () => {
 		expect(cleanup.phases.rootRemove).toBe("pending");
 		await cleanupFixtureRoot(cleanup, { rootExists: async () => false });
 		expect(events).toEqual(["shutdown", "dispose", "lease", "lease"]);
+	});
+
+	it("removes one late recreation but still rejects a persistent fixture writer", async () => {
+		const recoveredRoot = await temp();
+		const recovered = createFixtureRootCleanup(recoveredRoot, path.join(recoveredRoot, "agent"), lease([]));
+		let recoveredProbes = 0;
+		await cleanupFixtureRootAfterLateWrite(recovered, {
+			absenceObservationMs: 0,
+			rootExists: async () => recoveredProbes++ === 0,
+		});
+		expect(recovered.recreation?.detail).toBe("fixture root reappeared");
+		expect(fixtureRootForTest(recoveredRoot)).toBeUndefined();
+
+		const persistentRoot = await temp();
+		const persistent = createFixtureRootCleanup(persistentRoot, path.join(persistentRoot, "agent"), lease([]));
+		await expect(
+			cleanupFixtureRootAfterLateWrite(persistent, {
+				absenceObservationMs: 0,
+				rootExists: async () => true,
+			}),
+		).rejects.toThrow("recreated");
+		expect(persistent.phases.rootRemove).toBe("pending");
+		await cleanupFixtureRoot(persistent, { absenceObservationMs: 0, rootExists: async () => false });
 	});
 
 	it("sanitizes and restores the production SDK opt-out without contacting operator state", async () => {

--- a/packages/coding-agent/test/helpers/fixture-broker-cleanup.ts
+++ b/packages/coding-agent/test/helpers/fixture-broker-cleanup.ts
@@ -263,6 +263,24 @@ export function cleanupFixtureRoot(root: FixtureRootCleanup, options: FixtureRoo
 	return attempt;
 }
 
+/**
+ * Production-host fixtures can receive one already-owned late write while the
+ * broker and session teardown settle. Remove that recreation once, then require
+ * the normal bounded absence proof again; a persistent writer still fails.
+ */
+export async function cleanupFixtureRootAfterLateWrite(
+	root: FixtureRootCleanup,
+	options: FixtureRootCleanupOptions = {},
+): Promise<void> {
+	const priorRecreation = root.recreation;
+	try {
+		await cleanupFixtureRoot(root, options);
+	} catch (error) {
+		if (root.recreation === priorRecreation) throw error;
+		await cleanupFixtureRoot(root, options);
+	}
+}
+
 /** Clears fixture-local broker opt-out state for an async setup and restores it exactly. */
 export async function withFixtureBrokerEnvironment<T>(run: () => Promise<T>): Promise<T> {
 	const prior = process.env.GJC_SDK_DISABLE;

--- a/packages/coding-agent/test/helpers/sdk-adapter-dispositions-shared.ts
+++ b/packages/coding-agent/test/helpers/sdk-adapter-dispositions-shared.ts
@@ -11,6 +11,7 @@ import { expect } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import path from "node:path";
+import packageJson from "../../package.json" with { type: "json" };
 import { AcpSdkAdapter } from "../../src/sdk/acp";
 import { Broker } from "../../src/sdk/broker";
 import { brokerOwnerForTest } from "../../src/sdk/broker/ensure";
@@ -123,7 +124,7 @@ export const expectedDomainErrors: Readonly<Record<string, string>> = {
 	"artifact.read": "resource_gone",
 	"retry.last": "nothing_to_retry",
 	"retry.now": "retry_not_pending",
-	"bash.background": "not_foldable",
+	"bash.background": "no_active_bash",
 	"compaction.run": "invalid_request",
 	"session.handoff": "invalid_request",
 	"session.export_html": "invalid_request",
@@ -322,7 +323,7 @@ export async function fixture(): Promise<AdapterFixture> {
 	const productionHost = await startProductionSdkHost(repo, { acceptPromptPreflightWithoutExecution: true });
 	const sessionId = productionHost.sessionId;
 	const observed: ObservedRequest[] = productionHost.observed;
-	const broker = new Broker({ agentDir, packageGeneration: "adapter-dispositions" });
+	const broker = new Broker({ agentDir, packageGeneration: packageJson.version });
 	const brokerEndpoint = await broker.start();
 	const handleRequest = broker.handleRequest.bind(broker);
 	broker.handleRequest = async (operation, input, idempotencyKey) => {

--- a/packages/coding-agent/test/helpers/sdk-production-host.ts
+++ b/packages/coding-agent/test/helpers/sdk-production-host.ts
@@ -7,7 +7,7 @@ import { startFixtureBrokerWithLeaseForTest } from "../../src/sdk/broker/ensure"
 import { createNotificationsExtension } from "../../src/sdk/bus";
 import { SessionManager } from "../../src/session/session-manager";
 import {
-	cleanupFixtureRoot,
+	cleanupFixtureRootAfterLateWrite,
 	createFixtureBrokerEnvironment,
 	createFixtureRootCleanup,
 	registerFixtureRuntime,
@@ -149,18 +149,18 @@ export async function startProductionSdkHost(
 				triggerAsk,
 				triggerGate,
 				runCommand: async text => await session.prompt(text),
-				stop: () => cleanupFixtureRoot(cleanup),
+				stop: () => cleanupFixtureRootAfterLateWrite(cleanup),
 			};
 		} catch (error) {
 			try {
-				await cleanupFixtureRoot(cleanup);
+				await cleanupFixtureRootAfterLateWrite(cleanup);
 			} catch (cleanupError) {
 				const failure = new AggregateError(
 					[error, cleanupError],
 					"Production SDK host setup and fixture broker cleanup both failed.",
 				);
 				Object.defineProperty(failure, "retryFixtureCleanup", {
-					value: () => cleanupFixtureRoot(cleanup),
+					value: () => cleanupFixtureRootAfterLateWrite(cleanup),
 				});
 				throw failure;
 			}

--- a/packages/coding-agent/test/sdk-acp-adapter.test.ts
+++ b/packages/coding-agent/test/sdk-acp-adapter.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs/promises";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
 import type { AgentSideConnection } from "@agentclientprotocol/sdk";
+import packageJson from "../package.json" with { type: "json" };
 import { AcpAgent } from "../src/modes/acp/acp-agent";
 import { AcpSdkAdapter, type AcpSdkAdapterError, acpMcpLaunchFailure } from "../src/sdk/acp";
 import { writeBrokerDiscovery } from "../src/sdk/broker/discovery";
@@ -866,7 +867,7 @@ test("the production ACP MCP launch path preserves broker admission timeout fail
 		await writeBrokerDiscovery(agentDir, {
 			version: 1,
 			protocolVersion: 3,
-			packageGeneration: "test",
+			packageGeneration: packageJson.version,
 			ownerId: "acp-admission-timeout-owner",
 			pid: process.pid,
 			host: "127.0.0.1",

--- a/packages/coding-agent/test/system-prompt-templates.test.ts
+++ b/packages/coding-agent/test/system-prompt-templates.test.ts
@@ -201,6 +201,19 @@ describe("system Handlebars prompt templates", () => {
 		const reduction = 1 - subBytes / fullBytes;
 		expect(reduction).toBeGreaterThanOrEqual(0.25);
 	});
+
+	test("system-prompt renders opt-in English reasoning guidance without changing the response language", async () => {
+		const templatePath = path.join(systemPromptsDir, "system-prompt.md");
+		const template = await Bun.file(templatePath).text();
+
+		const enabled = prompt.render(template, { ...baseRenderContext, reasoningLanguageEnglish: true });
+		expect(enabled).toContain("<reasoning-language>");
+		expect(enabled).toContain("Reason through development and technical problem-solving in English.");
+		expect(enabled).toContain("Keep user-facing answers in the language the user requested or used.");
+
+		const disabled = prompt.render(template, { ...baseRenderContext, reasoningLanguageEnglish: false });
+		expect(disabled).not.toContain("<reasoning-language>");
+	});
 	test("system-prompt omits obsolete MCP discovery plumbing", async () => {
 		const templatePath = path.join(systemPromptsDir, "system-prompt.md");
 		const template = await Bun.file(templatePath).text();

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -877,6 +877,15 @@
 			"description": "Reasoning depth for thinking-capable models",
 			"default": "high"
 		},
+		"reasoningLanguage": {
+			"type": "string",
+			"enum": [
+				"off",
+				"english"
+			],
+			"description": "Optionally reason through development work in English while preserving the user's response language",
+			"default": "off"
+		},
 		"hideThinkingBlock": {
 			"type": "boolean",
 			"description": "Hide thinking blocks in assistant responses",

--- a/scripts/telegram-daemon-generation-manifest.json
+++ b/scripts/telegram-daemon-generation-manifest.json
@@ -508,7 +508,7 @@
     "slack:packages/coding-agent/src/sdk/bus/config.ts:notificationConfigFromFile": "ed9446063305a13e9c6e8a9ffcac46985b44d79b778e0c96dbc1612b01f1f7d2",
     "slack:packages/coding-agent/src/sdk/bus/config.ts:resolveNotificationProvider": "09402fa9db279332fc392ef13a059b90f82c8721f4ed33cbc060222663558efd",
     "slack:packages/coding-agent/src/sdk/bus/config.ts:tokenFingerprint": "dd57445254e5ca152c4a2030f8959367a6800759f3f82fc5da09cc7b9a5aa758",
-    "slack:packages/coding-agent/src/sdk/bus/slack-daemon.ts:SlackNotificationDaemon": "48681b2ebedf2142889b49dedc403afedd8b36fa911ff6848de06191ed8ed4e7",
+    "slack:packages/coding-agent/src/sdk/bus/slack-daemon.ts:SlackNotificationDaemon": "09b103fd7029f931b1a24e755375dc88bbfb9f74e2635ddf7a9c3d2c44e24a3c",
     "slack:packages/coding-agent/src/sdk/bus/slack-daemon.ts:close": "82c1d933b6f951f8325502b54c6e1bd4a21e85aeec3f0e54cf514045f30e20a0",
     "slack:packages/coding-agent/src/sdk/bus/slack-daemon.ts:handleEnvelope": "1e5393f3bcb65cf6418a9156ccf7103f1c3fe2bc22ca48b51d6b5c73bbf8a092",
     "slack:packages/coding-agent/src/sdk/bus/slack-daemon.ts:notify": "ebda81d71e9ff92ad5688fe482894895d6b73d8d1f4642bfc09bbd3d18584b18",


### PR DESCRIPTION
## What

- Add `reasoningLanguage: off | english`, defaulting to `off`.
- Inject English-only technical reasoning guidance only when explicitly enabled, while preserving the requested response language.
- Repair strict SDK closure receipts by classifying reviewed test-only seams and aligning ACP/MCP/daemon fixture broker generations with the shipped package generation.
- Consume the fixture cleanup authority's existing one-recreation retry for production-host tests while keeping persistent root recreation a hard failure.

## Why

The reasoning-language preference must remain opt-in and provider/mode neutral. Strict closure also exposed stale generated inventories, incompatible test broker generations that could retire the test process or route to a replacement broker, and a bounded late-write teardown race that made parallel closure cohorts flaky.

## Testing

- focused prompt/config/schema and ACP adapter tests
- ACP, MCP, and daemon CLI adapter disposition cohorts
- `bun test ./packages/coding-agent/test/fixture-broker-cleanup.test.ts`
- `bun run check:schemas`
- `bun --cwd=packages/coding-agent run check:sdk-closure`
- `bun run check`
- `bun run build`
- `git diff --check origin/dev...HEAD`

## Risk classification

- [x] `low-risk` — additive default-off prompt/config behavior plus test-only fixture cleanup and generated closure synchronization; production gates and broker-generation fencing remain strict.
- [ ] `regression-risk`
- [ ] `high-risk`

Exact validation authority: base `f0c7f4b0c5d6fefdf506d14d1fca53bdc2b8c1d8`; head `46fed17ccc8ee19f2b7a0e5f0ee342a3e7b1e4e0`.

## GJC verdict

gajae.pr-review-verdict.v1 merge-self-approved sha256:0b04c267a70c02d031287c1d7946f199568e117ff293197630b11cfa99755cb7 reviewer:human reviewer-id:Yeachan-Heo evidence:local: focused prompt/schema/ACP/MCP/daemon and cleanup tests, check:sdk-closure, bun run check, bun run build; hosted CI bound to exact head
