### PR TITLE
fix(status-line): paint only authoritative active-provider usage

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- The status-line usage segment now paints only the active model's provider, so switching to Grok no longer keeps a stale Claude 5h/7d pair. Grok/xAI weekly windows render for any matching report, and Grok's monthly credits window is omitted so it is not mislabeled as `7d`.
 
 - Mid-run OpenAI remote-compaction fallback failures now stop before another provider request, surface the local summarization error through ACP/SDK terminal handling, and leave the uncompacted context unsubmitted. Successful local fallback still commits the compaction and resumes normally.
 - Opening `/model` now renders the preset landing before constructing the full model browser catalog. Canonical search indexing, sorting, and the redundant offline registry refresh are deferred until the user searches or chooses a browse action, while the lightweight preset-availability check remains immediate and scoped or direct-search selectors still load immediately.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 ### Fixed
 
-- The status-line usage segment now paints only the active model's provider, so switching to Grok no longer keeps a stale Claude 5h/7d pair. Grok/xAI weekly windows render for any matching report, and Grok's monthly credits window is omitted so it is not mislabeled as `7d`.
+- The status-line usage segment now paints only the active model's provider, so switching to Grok no longer keeps a stale Claude 5h/7d pair. Canonical Grok Build reports render only their authoritative weekly window, while monthly credits are omitted instead of being mislabeled as `7d`.
 
 - Mid-run OpenAI remote-compaction fallback failures now stop before another provider request, surface the local summarization error through ACP/SDK terminal handling, and leave the uncompacted context unsubmitted. Successful local fallback still commits the compaction and resumes normally.
 - Opening `/model` now renders the preset landing before constructing the full model browser catalog. Canonical search indexing, sorting, and the redundant offline registry refresh are deferred until the user searches or chooses a browse action, while the lightweight preset-availability check remains immediate and scoped or direct-search selectors still load immediately.

--- a/packages/coding-agent/src/modes/components/tool-status-header.ts
+++ b/packages/coding-agent/src/modes/components/tool-status-header.ts
@@ -205,6 +205,8 @@ export class StatusLineComponent implements Component {
 
 	// Provider usage caching (5-min TTL, OAuth/sub only)
 	#cachedUsage: SegmentContext["usage"] = null;
+	#cachedUsageReports: unknown = null;
+	#cachedUsageProvider: string | undefined;
 	#usageFetchedAt = 0;
 	#usageInFlight = false;
 
@@ -687,6 +689,8 @@ export class StatusLineComponent implements Component {
 		void fetcher
 			.call(this.session)
 			.then(reports => {
+				this.#cachedUsageReports = reports;
+				this.#cachedUsageProvider = this.#activeUsageProvider();
 				this.#cachedUsage = this.#normalizeUsageReports(reports);
 				this.#usageFetchedAt = Date.now();
 				if (this.#onBranchChange) {
@@ -706,6 +710,8 @@ export class StatusLineComponent implements Component {
 	}
 
 	#normalizeUsageReports(reports: unknown): SegmentContext["usage"] {
+		const activeProvider = this.#activeUsageProvider();
+
 		if (!Array.isArray(reports)) return null;
 		const windows: NonNullable<SegmentContext["usage"]>["windows"] = [];
 		const seen = new Set<string>();
@@ -741,6 +747,7 @@ export class StatusLineComponent implements Component {
 			if (!report || typeof report !== "object") continue;
 			const provider = (report as { provider?: unknown }).provider;
 			const providerId = typeof provider === "string" ? provider : undefined;
+			if (activeProvider && providerId !== activeProvider) continue;
 			const limits = (report as { limits?: unknown }).limits;
 			if (!Array.isArray(limits)) continue;
 			for (const limit of limits) {
@@ -769,15 +776,29 @@ export class StatusLineComponent implements Component {
 					}
 				} else if (windowId === "5h" && !tier) {
 					pushWindow(`${providerId ?? "provider"}:5h`, "5h", fraction, resetsAt, "m");
-				} else if (windowId === "7d" && !tier) {
+				} else if (windowId === "7d" && !tier && providerId !== "grok-build" && providerId !== "xai") {
 					pushWindow(`${providerId ?? "provider"}:7d`, "7d", fraction, resetsAt, "h");
-				} else if (providerId === "grok-build" && windowId === "weekly" && !tier) {
-					pushWindow("grok-build:weekly", "weekly", fraction, resetsAt, "h");
+				} else if (windowId === "weekly" && !tier) {
+					pushWindow(`${providerId ?? "provider"}:weekly`, "weekly", fraction, resetsAt, "h");
 				}
 			}
 		}
 
 		return windows.length > 0 ? { windows } : null;
+	}
+
+	#activeUsageProvider(): string | undefined {
+		const model = this.session.state.model ?? this.session.model;
+		if (!model || typeof model !== "object") return undefined;
+		const provider = (model as { provider?: unknown }).provider;
+		return typeof provider === "string" && provider.length > 0 ? provider : undefined;
+	}
+
+	#syncCachedUsageForActiveProvider(): void {
+		const activeProvider = this.#activeUsageProvider();
+		if (this.#cachedUsageProvider === activeProvider) return;
+		this.#cachedUsageProvider = activeProvider;
+		this.#cachedUsage = this.#normalizeUsageReports(this.#cachedUsageReports);
 	}
 
 	#buildSegmentContext(
@@ -789,7 +810,7 @@ export class StatusLineComponent implements Component {
 	): SegmentContext {
 		const state = this.session.state;
 
-		// Trigger background fetch (5-min TTL); render uses cached value
+		this.#syncCachedUsageForActiveProvider();
 		this.refreshUsageInBackground();
 
 		// Get usage statistics

--- a/packages/coding-agent/src/modes/components/tool-status-header.ts
+++ b/packages/coding-agent/src/modes/components/tool-status-header.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs";
 
+import { resolveOAuthStorageProvider } from "@gajae-code/ai/core";
 import { type Component, truncateToWidth, visibleWidth } from "@gajae-code/tui";
 import { formatCount, getProjectDir, logger } from "@gajae-code/utils";
 import { getShellConfig } from "@gajae-code/utils/shell-config";
@@ -712,7 +713,7 @@ export class StatusLineComponent implements Component {
 	#normalizeUsageReports(reports: unknown): SegmentContext["usage"] {
 		const activeProvider = this.#activeUsageProvider();
 
-		if (!Array.isArray(reports)) return null;
+		if (!activeProvider || !Array.isArray(reports)) return null;
 		const windows: NonNullable<SegmentContext["usage"]>["windows"] = [];
 		const seen = new Set<string>();
 		const now = Date.now();
@@ -746,21 +747,24 @@ export class StatusLineComponent implements Component {
 		for (const report of reports) {
 			if (!report || typeof report !== "object") continue;
 			const provider = (report as { provider?: unknown }).provider;
-			const providerId = typeof provider === "string" ? provider : undefined;
-			if (activeProvider && providerId !== activeProvider) continue;
+			const providerId = typeof provider === "string" ? resolveOAuthStorageProvider(provider) : undefined;
+			if (providerId !== activeProvider) continue;
 			const limits = (report as { limits?: unknown }).limits;
 			if (!Array.isArray(limits)) continue;
 			for (const limit of limits) {
 				if (!limit || typeof limit !== "object") continue;
 				const l = limit as {
 					id?: unknown;
-					scope?: { windowId?: string; tier?: string; modelId?: string };
+					scope?: { provider?: unknown; windowId?: string; tier?: string; modelId?: string };
 					window?: { id?: string; resetsAt?: number };
 					amount?: { usedFraction?: number };
 				};
 				const fraction = l.amount?.usedFraction;
 				if (typeof fraction !== "number") continue;
 				const id = typeof l.id === "string" ? l.id : "";
+				const scopeProvider =
+					typeof l.scope?.provider === "string" ? resolveOAuthStorageProvider(l.scope.provider) : undefined;
+				if (scopeProvider !== undefined && scopeProvider !== providerId) continue;
 				const windowId = l.scope?.windowId ?? l.window?.id;
 				const tier = l.scope?.tier;
 				const modelId = l.scope?.modelId;
@@ -778,8 +782,8 @@ export class StatusLineComponent implements Component {
 					pushWindow(`${providerId ?? "provider"}:5h`, "5h", fraction, resetsAt, "m");
 				} else if (windowId === "7d" && !tier && providerId !== "grok-build" && providerId !== "xai") {
 					pushWindow(`${providerId ?? "provider"}:7d`, "7d", fraction, resetsAt, "h");
-				} else if (windowId === "weekly" && !tier) {
-					pushWindow(`${providerId ?? "provider"}:weekly`, "weekly", fraction, resetsAt, "h");
+				} else if (providerId === "grok-build" && id === "grok-build:weekly" && windowId === "weekly" && !tier) {
+					pushWindow("grok-build:weekly", "weekly", fraction, resetsAt, "h");
 				}
 			}
 		}
@@ -791,7 +795,7 @@ export class StatusLineComponent implements Component {
 		const model = this.session.state.model ?? this.session.model;
 		if (!model || typeof model !== "object") return undefined;
 		const provider = (model as { provider?: unknown }).provider;
-		return typeof provider === "string" && provider.length > 0 ? provider : undefined;
+		return typeof provider === "string" && provider.length > 0 ? resolveOAuthStorageProvider(provider) : undefined;
 	}
 
 	#syncCachedUsageForActiveProvider(): void {

--- a/packages/coding-agent/test/status-line-usage.test.ts
+++ b/packages/coding-agent/test/status-line-usage.test.ts
@@ -36,6 +36,11 @@ function makeSession(
 	} as unknown as AgentSession;
 }
 
+function setSessionModel(session: AgentSession, model: { id: string; provider?: string; contextWindow: number }): void {
+	(session.state as unknown as { model: typeof model }).model = model;
+	(session as unknown as { model: typeof model }).model = model;
+}
+
 async function waitForUsageText(component: StatusLineComponent): Promise<string> {
 	let text = "";
 	for (let i = 0; i < 20; i++) {
@@ -268,7 +273,7 @@ describe("status line usage segment", () => {
 		component.dispose();
 	});
 
-	it("renders xAI weekly quota with the same weekly label as Grok Build", async () => {
+	it("does not infer authoritative Grok usage from an xAI report", async () => {
 		const now = Date.now();
 		const session = makeSession(
 			async () => [
@@ -298,13 +303,14 @@ describe("status line usage segment", () => {
 
 		const text = await waitForUsageText(component);
 
-		expect(text).toContain("weekly 12% (6d)");
+		expect(text).not.toContain("weekly");
 		expect(text).not.toContain("7d");
+		expect(text).not.toContain("12%");
 		expect(text).not.toContain("40%");
 		component.dispose();
 	});
 
-	it("hides unrelated provider windows when the active model is xAI", async () => {
+	it("reprojects cached reports after switching the active provider", async () => {
 		const now = Date.now();
 		const session = makeSession(
 			async () => [
@@ -327,37 +333,169 @@ describe("status line usage segment", () => {
 					],
 				},
 				{
-					provider: "xai",
+					provider: "grok-build",
 					fetchedAt: now,
 					limits: [
 						{
-							id: "xai:weekly",
-							scope: { provider: "xai", windowId: "weekly" },
+							id: "grok-build:weekly",
+							scope: { provider: "grok-build", windowId: "weekly" },
 							window: { id: "weekly", resetsAt: now + 56 * 3_600_000 },
 							amount: { usedFraction: 0.18, unit: "percent" },
-						},
-						{
-							id: "xai:7d",
-							scope: { provider: "xai", windowId: "7d" },
-							window: { id: "7d", resetsAt: now + 26 * 24 * 3_600_000 },
-							amount: { usedFraction: 0, unit: "percent" },
 						},
 					],
 				},
 			],
-			{ id: "grok-4.6", provider: "xai", contextWindow: 200_000 },
+			{ id: "claude-sonnet-4-5", provider: "anthropic", contextWindow: 200_000 },
+		);
+		const component = new StatusLineComponent(session);
+		component.updateSettings({ preset: "custom", leftSegments: [], rightSegments: ["usage"], showSkillHud: false });
+
+		const anthropicText = await waitForUsageText(component);
+		expect(anthropicText).toContain("5h 100%");
+
+		const grokModel = { id: "grok-build", provider: "grok-build", contextWindow: 200_000 };
+		setSessionModel(session, grokModel);
+		const grokText = stripAnsi(component.getTopBorder(120).content);
+
+		expect(grokText).toContain("weekly 18%");
+		expect(grokText).not.toContain("5h");
+		expect(grokText).not.toContain("100%");
+		component.dispose();
+	});
+
+	it("clears cached usage when the switched-to provider has no report", async () => {
+		const now = Date.now();
+		const session = makeSession(
+			async () => [
+				{
+					provider: "anthropic",
+					fetchedAt: now,
+					limits: [
+						{
+							id: "anthropic:5h",
+							scope: { provider: "anthropic", windowId: "5h" },
+							window: { id: "5h", resetsAt: now + 90 * 60_000 },
+							amount: { usedFraction: 0.4, unit: "percent" },
+						},
+					],
+				},
+			],
+			{ id: "claude-sonnet-4-5", provider: "anthropic", contextWindow: 200_000 },
+		);
+		const component = new StatusLineComponent(session);
+		component.updateSettings({ preset: "custom", leftSegments: [], rightSegments: ["usage"], showSkillHud: false });
+
+		const anthropicText = await waitForUsageText(component);
+		expect(anthropicText).toContain("5h 40%");
+
+		setSessionModel(session, { id: "grok-build", provider: "grok-build", contextWindow: 200_000 });
+		const grokText = stripAnsi(component.getTopBorder(120).content);
+
+		expect(grokText).not.toContain("5h");
+		expect(grokText).not.toContain("40%");
+		component.dispose();
+	});
+
+	it("does not aggregate usage reports when no active provider is resolved", async () => {
+		const now = Date.now();
+		const session = makeSession(
+			async () => [
+				{
+					provider: "anthropic",
+					fetchedAt: now,
+					limits: [
+						{
+							id: "anthropic:5h",
+							scope: { provider: "anthropic", windowId: "5h" },
+							window: { id: "5h", resetsAt: now + 90 * 60_000 },
+							amount: { usedFraction: 0.4, unit: "percent" },
+						},
+					],
+				},
+			],
+			{ id: "unresolved", contextWindow: 200_000 },
 		);
 		const component = new StatusLineComponent(session);
 		component.updateSettings({ preset: "custom", leftSegments: [], rightSegments: ["usage"], showSkillHud: false });
 
 		const text = await waitForUsageText(component);
 
-		expect(text).toContain("weekly 18%");
-		expect(text).not.toContain("7d");
 		expect(text).not.toContain("5h");
-		expect(text).not.toContain("100%");
-		expect(text).not.toContain("44%");
-		expect(text).not.toContain("0%");
+		expect(text).not.toContain("40%");
+		component.dispose();
+	});
+
+	it("uses the active fallback model in the session state over a stale session model", async () => {
+		const now = Date.now();
+		const session = makeSession(
+			async () => [
+				{
+					provider: "anthropic",
+					fetchedAt: now,
+					limits: [
+						{
+							id: "anthropic:5h",
+							scope: { provider: "anthropic", windowId: "5h" },
+							window: { id: "5h", resetsAt: now + 90 * 60_000 },
+							amount: { usedFraction: 0.4, unit: "percent" },
+						},
+					],
+				},
+				{
+					provider: "openai-codex",
+					fetchedAt: now,
+					limits: [
+						{
+							id: "openai-codex:primary",
+							scope: { provider: "openai-codex", windowId: "5h" },
+							window: { id: "5h", resetsAt: now + 90 * 60_000 },
+							amount: { usedFraction: 0.8, unit: "percent" },
+						},
+					],
+				},
+			],
+			{ id: "claude-sonnet-4-5", provider: "anthropic", contextWindow: 200_000 },
+		);
+		(session as unknown as { model: { id: string; provider: string; contextWindow: number } }).model = {
+			id: "gpt-5",
+			provider: "openai-codex",
+			contextWindow: 200_000,
+		};
+		const component = new StatusLineComponent(session);
+		component.updateSettings({ preset: "custom", leftSegments: [], rightSegments: ["usage"], showSkillHud: false });
+
+		const text = await waitForUsageText(component);
+
+		expect(text).toContain("5h 40%");
+		expect(text).not.toContain("80%");
+		component.dispose();
+	});
+
+	it("matches the OpenAI Codex device provider alias to its canonical report", async () => {
+		const now = Date.now();
+		const session = makeSession(
+			async () => [
+				{
+					provider: "openai-codex",
+					fetchedAt: now,
+					limits: [
+						{
+							id: "openai-codex:primary",
+							scope: { provider: "openai-codex", windowId: "5h", tier: "pro" },
+							window: { id: "5h", resetsAt: now + 180 * 60_000 },
+							amount: { usedFraction: 0.24, unit: "percent" },
+						},
+					],
+				},
+			],
+			{ id: "gpt-5", provider: "openai-codex-device", contextWindow: 200_000 },
+		);
+		const component = new StatusLineComponent(session);
+		component.updateSettings({ preset: "custom", leftSegments: [], rightSegments: ["usage"], showSkillHud: false });
+
+		const text = await waitForUsageText(component);
+
+		expect(text).toContain("5h 24%");
 		component.dispose();
 	});
 });

--- a/packages/coding-agent/test/status-line-usage.test.ts
+++ b/packages/coding-agent/test/status-line-usage.test.ts
@@ -8,15 +8,22 @@ function stripAnsi(text: string): string {
 	return text.replace(/\x1b\[[0-9;]*m/g, "");
 }
 
-function makeSession(fetchUsageReports: () => Promise<unknown>): AgentSession {
+function makeSession(
+	fetchUsageReports: () => Promise<unknown>,
+	model: { id: string; provider?: string; contextWindow: number } = {
+		id: "openai-codex/gpt-5",
+		provider: "openai-codex",
+		contextWindow: 200_000,
+	},
+): AgentSession {
 	const usageStats = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, premiumRequests: 0, cost: 0 };
 	return {
-		state: { messages: [], model: { id: "openai-codex/gpt-5", contextWindow: 200_000 } },
+		state: { messages: [], model },
 		messages: [],
 		systemPrompt: [],
 		agent: { state: { tools: [] } },
 		skills: [],
-		model: { id: "openai-codex/gpt-5", contextWindow: 200_000 },
+		model,
 		modelRegistry: { isUsingOAuth: () => false },
 		isStreaming: false,
 		isFastModeActive: () => false,
@@ -193,26 +200,29 @@ describe("status line usage segment", () => {
 
 	it("keeps rendering non-tiered Anthropic usage windows", async () => {
 		const now = Date.now();
-		const session = makeSession(async () => [
-			{
-				provider: "anthropic",
-				fetchedAt: now,
-				limits: [
-					{
-						id: "anthropic:5h",
-						scope: { provider: "anthropic", windowId: "5h" },
-						window: { id: "5h", resetsAt: now + 90 * 60_000 },
-						amount: { usedFraction: 0.4, unit: "percent" },
-					},
-					{
-						id: "anthropic:7d:opus",
-						scope: { provider: "anthropic", windowId: "7d", tier: "opus" },
-						window: { id: "7d", resetsAt: now + 12 * 3_600_000 },
-						amount: { usedFraction: 0.9, unit: "percent" },
-					},
-				],
-			},
-		]);
+		const session = makeSession(
+			async () => [
+				{
+					provider: "anthropic",
+					fetchedAt: now,
+					limits: [
+						{
+							id: "anthropic:5h",
+							scope: { provider: "anthropic", windowId: "5h" },
+							window: { id: "5h", resetsAt: now + 90 * 60_000 },
+							amount: { usedFraction: 0.4, unit: "percent" },
+						},
+						{
+							id: "anthropic:7d:opus",
+							scope: { provider: "anthropic", windowId: "7d", tier: "opus" },
+							window: { id: "7d", resetsAt: now + 12 * 3_600_000 },
+							amount: { usedFraction: 0.9, unit: "percent" },
+						},
+					],
+				},
+			],
+			{ id: "claude-sonnet-4-5", provider: "anthropic", contextWindow: 200_000 },
+		);
 		const component = new StatusLineComponent(session);
 		component.updateSettings({ preset: "custom", leftSegments: [], rightSegments: ["usage"], showSkillHud: false });
 
@@ -225,26 +235,29 @@ describe("status line usage segment", () => {
 
 	it("renders Grok weekly quota without admitting unrelated tiered windows", async () => {
 		const now = Date.now();
-		const session = makeSession(async () => [
-			{
-				provider: "grok-build",
-				fetchedAt: now,
-				limits: [
-					{
-						id: "grok-build:weekly",
-						scope: { provider: "grok-build", windowId: "weekly" },
-						window: { id: "weekly", resetsAt: now + 6 * 24 * 3_600_000 },
-						amount: { usedFraction: 0.06, unit: "percent" },
-					},
-					{
-						id: "grok-build:weekly:heavy",
-						scope: { provider: "grok-build", windowId: "weekly", tier: "heavy" },
-						window: { id: "weekly", resetsAt: now + 24 * 3_600_000 },
-						amount: { usedFraction: 0.99, unit: "percent" },
-					},
-				],
-			},
-		]);
+		const session = makeSession(
+			async () => [
+				{
+					provider: "grok-build",
+					fetchedAt: now,
+					limits: [
+						{
+							id: "grok-build:weekly",
+							scope: { provider: "grok-build", windowId: "weekly" },
+							window: { id: "weekly", resetsAt: now + 6 * 24 * 3_600_000 },
+							amount: { usedFraction: 0.06, unit: "percent" },
+						},
+						{
+							id: "grok-build:weekly:heavy",
+							scope: { provider: "grok-build", windowId: "weekly", tier: "heavy" },
+							window: { id: "weekly", resetsAt: now + 24 * 3_600_000 },
+							amount: { usedFraction: 0.99, unit: "percent" },
+						},
+					],
+				},
+			],
+			{ id: "grok-build", provider: "grok-build", contextWindow: 200_000 },
+		);
 		const component = new StatusLineComponent(session);
 		component.updateSettings({ preset: "custom", leftSegments: [], rightSegments: ["usage"], showSkillHud: false });
 
@@ -252,6 +265,99 @@ describe("status line usage segment", () => {
 
 		expect(text).toContain("weekly 6% (6d)");
 		expect(text).not.toContain("99%");
+		component.dispose();
+	});
+
+	it("renders xAI weekly quota with the same weekly label as Grok Build", async () => {
+		const now = Date.now();
+		const session = makeSession(
+			async () => [
+				{
+					provider: "xai",
+					fetchedAt: now,
+					limits: [
+						{
+							id: "xai:weekly",
+							scope: { provider: "xai", windowId: "weekly" },
+							window: { id: "weekly", resetsAt: now + 6 * 24 * 3_600_000 },
+							amount: { usedFraction: 0.12, unit: "percent" },
+						},
+						{
+							id: "xai:7d",
+							scope: { provider: "xai", windowId: "7d" },
+							window: { id: "7d", resetsAt: now + 20 * 24 * 3_600_000 },
+							amount: { usedFraction: 0.4, unit: "percent" },
+						},
+					],
+				},
+			],
+			{ id: "grok-4.6", provider: "xai", contextWindow: 200_000 },
+		);
+		const component = new StatusLineComponent(session);
+		component.updateSettings({ preset: "custom", leftSegments: [], rightSegments: ["usage"], showSkillHud: false });
+
+		const text = await waitForUsageText(component);
+
+		expect(text).toContain("weekly 12% (6d)");
+		expect(text).not.toContain("7d");
+		expect(text).not.toContain("40%");
+		component.dispose();
+	});
+
+	it("hides unrelated provider windows when the active model is xAI", async () => {
+		const now = Date.now();
+		const session = makeSession(
+			async () => [
+				{
+					provider: "anthropic",
+					fetchedAt: now,
+					limits: [
+						{
+							id: "anthropic:5h",
+							scope: { provider: "anthropic", windowId: "5h" },
+							window: { id: "5h", resetsAt: now + 90 * 60_000 },
+							amount: { usedFraction: 1, unit: "percent" },
+						},
+						{
+							id: "anthropic:7d",
+							scope: { provider: "anthropic", windowId: "7d" },
+							window: { id: "7d", resetsAt: now + 68 * 3_600_000 },
+							amount: { usedFraction: 0.44, unit: "percent" },
+						},
+					],
+				},
+				{
+					provider: "xai",
+					fetchedAt: now,
+					limits: [
+						{
+							id: "xai:weekly",
+							scope: { provider: "xai", windowId: "weekly" },
+							window: { id: "weekly", resetsAt: now + 56 * 3_600_000 },
+							amount: { usedFraction: 0.18, unit: "percent" },
+						},
+						{
+							id: "xai:7d",
+							scope: { provider: "xai", windowId: "7d" },
+							window: { id: "7d", resetsAt: now + 26 * 24 * 3_600_000 },
+							amount: { usedFraction: 0, unit: "percent" },
+						},
+					],
+				},
+			],
+			{ id: "grok-4.6", provider: "xai", contextWindow: 200_000 },
+		);
+		const component = new StatusLineComponent(session);
+		component.updateSettings({ preset: "custom", leftSegments: [], rightSegments: ["usage"], showSkillHud: false });
+
+		const text = await waitForUsageText(component);
+
+		expect(text).toContain("weekly 18%");
+		expect(text).not.toContain("7d");
+		expect(text).not.toContain("5h");
+		expect(text).not.toContain("100%");
+		expect(text).not.toContain("44%");
+		expect(text).not.toContain("0%");
 		component.dispose();
 	});
 });


### PR DESCRIPTION
## What

The status-line usage segment now paints only the active model's provider and re-projects cached reports when the active provider changes. The fix-forward also canonicalizes the OpenAI Codex device provider alias and rejects mismatched limit scopes.

Canonical Grok Build reports render only their authoritative weekly window; monthly credits are omitted instead of being mislabeled as `7d`. The change remains display-only and does not add an xAI usage probe.

## Why

Fixes #5268. Switching from Claude to Grok left the cached Anthropic `5h`/`7d` pair on the status line. Grok's product usage source exposes a monthly credits window plus a canonical weekly window; only the latter is valid for this status-line display.

The original contributor commit remains intact. The follow-up commit is a review fix-forward for arbitrary weekly reports, no-active-provider aggregation, provider aliases, cached provider switches, and missing reports.

## Testing

```sh
bun test packages/coding-agent/test/status-line-usage.test.ts packages/coding-agent/test/status-line-cache.test.ts packages/ai/test/grok-cli-usage.test.ts packages/ai/test/auth-storage-grok-selection.test.ts packages/ai/test/auth-storage-switch-session-credential.test.ts packages/ai/test/auth-storage-session-selectors.test.ts packages/coding-agent/test/acp-builtins.test.ts packages/coding-agent/test/usage-report-columns.test.ts
bun --cwd=packages/coding-agent run check
bun --cwd=packages/coding-agent run build
```

136 focused assertions passed across 8 files; the coding-agent check and binary build passed.

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:1cacce5da6bc1fa90902994be70f978678c7f6d83fba6a5e612e8e19d630287e reviewer:human reviewer-id:Yeachan-Heo evidence:authenticated exact-head approval; focused usage regressions; coding-agent check; binary build
```

---

- [x] Target branch is `dev`
- [x] `bun --cwd=packages/coding-agent run check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head `1dea6f039b44c642082346ace96c75f1f6a28251`
- [x] Risk classification above matches the actual review path taken
