### PR TITLE
fix(sdk): bound pre-auth WebSocket admission

### DIFF
--- a/crates/gjc-sdk/src/discovery.rs
+++ b/crates/gjc-sdk/src/discovery.rs
@@ -70,11 +70,16 @@ impl EndpointRecord {
 	) -> Self {
 		let now = now_millis();
 		let host = host.to_owned();
+		let url_host = if host.contains(':') && !host.starts_with('[') {
+			format!("[{host}]")
+		} else {
+			host.clone()
+		};
 		Self {
 			version: 1,
 			session_id: session_id.into(),
 			pid: std::process::id(),
-			url: format!("ws://{host}:{port}"),
+			url: format!("ws://{url_host}:{port}"),
 			host,
 			port,
 			token: token.into(),
@@ -340,6 +345,16 @@ mod tests {
 		let json = serde_json::to_value(&rec).unwrap();
 		assert!(json.get("lifecycleRequestId").is_none());
 		assert!(json.get("startupPromptRef").is_none());
+	}
+
+	#[test]
+	fn endpoint_ipv6_url_uses_bracketed_host() {
+		let rec = EndpointRecord::new("sess-1", "::1", 5555, "secret-token");
+		assert_eq!(rec.host, "::1");
+		assert_eq!(rec.url, "ws://[::1]:5555");
+
+		let already_bracketed = EndpointRecord::new("sess-2", "[::1]", 5555, "secret-token");
+		assert_eq!(already_bracketed.url, "ws://[::1]:5555");
 	}
 
 	#[test]

--- a/crates/gjc-sdk/src/server.rs
+++ b/crates/gjc-sdk/src/server.rs
@@ -652,6 +652,48 @@ struct ServerState {
 	connection_sequence: AtomicU64,
 }
 
+struct ConnectionCleanup {
+	state:         Arc<ServerState>,
+	connection_id: String,
+	generation:    String,
+}
+
+impl ConnectionCleanup {
+	const fn new(state: Arc<ServerState>, connection_id: String, generation: String) -> Self {
+		Self { state, connection_id, generation }
+	}
+}
+
+impl Drop for ConnectionCleanup {
+	fn drop(&mut self) {
+		cleanup_connection(&self.state, &self.connection_id, &self.generation);
+	}
+}
+
+fn cleanup_connection(state: &ServerState, connection_id: &str, generation: &str) {
+	if state.connections.lock().remove(connection_id).is_none() {
+		return;
+	}
+	let _ = state.close_tx.send(connection_id.to_owned());
+	let mut acks = state.acks.lock();
+	let ids: Vec<_> = acks
+		.pending
+		.iter()
+		.filter(|(_, pending)| {
+			pending
+				.origin
+				.as_ref()
+				.is_some_and(|(origin_id, origin_generation)| {
+					origin_id == connection_id && origin_generation == generation
+				})
+		})
+		.map(|(id, _)| id.clone())
+		.collect();
+	for id in ids {
+		acks.finish_disconnect(&id);
+	}
+}
+
 /// An authenticated inbound message paired with its server-assigned connection
 /// id.
 #[derive(Debug)]
@@ -1884,6 +1926,8 @@ async fn handle_conn(ws: ConnectionWebSocket, state: Arc<ServerState>, cancel: C
 			queued_directed_frames: Arc::clone(&queued_directed_frames),
 			tx:                     direct_tx.clone(),
 		});
+	let _cleanup =
+		ConnectionCleanup::new(Arc::clone(&state), connection_id.clone(), generation.clone());
 
 	// Replay readiness before ask presentation; the ask itself is tailored by the
 	// connection task after insertion and never written before ClientHello policy.
@@ -1893,7 +1937,6 @@ async fn handle_conn(ws: ConnectionWebSocket, state: Arc<ServerState>, cancel: C
 			.await
 			.is_err()
 	{
-		state.connections.lock().remove(&connection_id);
 		return;
 	}
 	let _ = direct_tx.send(DirectCommand::ReevaluateAsk);
@@ -2094,21 +2137,6 @@ async fn handle_conn(ws: ConnectionWebSocket, state: Arc<ServerState>, cancel: C
 				}
 			},
 		}
-	}
-	state.connections.lock().remove(&connection_id);
-	let _ = state.close_tx.send(connection_id.clone());
-	let ids: Vec<_> = state
-		.acks
-		.lock()
-		.pending
-		.iter()
-		.filter(|(_, pending)| {
-			pending.origin.as_ref() == Some(&(connection_id.clone(), generation.clone()))
-		})
-		.map(|(id, _)| id.clone())
-		.collect();
-	for id in ids {
-		state.acks.lock().finish_disconnect(&id);
 	}
 }
 
@@ -3000,6 +3028,41 @@ mod tests {
 		.expect("connection joins must remain bounded");
 		assert!(handshakes.is_empty());
 		assert!(connections.is_empty());
+	}
+
+	#[tokio::test]
+	async fn aborted_connection_task_removes_state_and_notifies_close() {
+		let handle = start(ServerConfig::new("s", "secret")).await.unwrap();
+		let mut close_rx = handle.take_close_receiver().expect("close receiver");
+		let (tx, _rx) = mpsc::unbounded_channel();
+		let connection_id = "aborted-connection".to_owned();
+		handle
+			.state
+			.connections
+			.lock()
+			.insert(connection_id.clone(), Connection {
+				generation: "generation".into(),
+				capabilities: Vec::new(),
+				negotiation: Negotiation::Negotiated,
+				delivered: None,
+				queued_directed_frames: Arc::new(AtomicUsize::new(0)),
+				tx,
+			});
+
+		let cleanup = ConnectionCleanup::new(
+			Arc::clone(&handle.state),
+			connection_id.clone(),
+			"generation".into(),
+		);
+		let task = tokio::spawn(async move {
+			let _cleanup = cleanup;
+			std::future::pending::<()>().await;
+		});
+		task.abort();
+		assert!(task.await.expect_err("aborted task").is_cancelled());
+		assert!(!handle.state.connections.lock().contains_key(&connection_id));
+		assert_eq!(close_rx.recv().await.as_deref(), Some("aborted-connection"));
+		handle.stop_and_wait().await;
 	}
 
 	fn ask(id: &str) -> ActionNeeded {

--- a/crates/gjc-sdk/src/server.rs
+++ b/crates/gjc-sdk/src/server.rs
@@ -102,6 +102,14 @@ impl ServerConfig {
 /// its capabilities.
 const CLIENT_HELLO_GRACE: Duration = Duration::from_secs(1);
 
+/// Maximum concurrent TCP connections still completing token-authenticated
+/// WebSocket admission.
+const PREAUTH_HANDSHAKE_TASKS: usize = 16;
+
+/// Maximum time an accepted TCP connection may take to complete WebSocket
+/// admission.
+const HANDSHAKE_DEADLINE: Duration = Duration::from_secs(2);
+
 /// Grace period for connection tasks to observe server cancellation before
 /// forced abort.
 const CONNECTION_JOIN_GRACE: Duration = Duration::from_secs(1);
@@ -1657,28 +1665,51 @@ pub async fn start(config: ServerConfig) -> std::io::Result<ServerHandle> {
 
 async fn accept_loop(listener: TcpListener, state: Arc<ServerState>, cancel: CancellationToken) {
 	let mut connections = JoinSet::new();
+	let mut handshakes: JoinSet<Option<ConnectionWebSocket>> = JoinSet::new();
 	loop {
 		tokio::select! {
 			() = cancel.cancelled() => break,
 			joined = connections.join_next(), if !connections.is_empty() => {
 				let _ = joined;
 			},
+			joined = handshakes.join_next(), if !handshakes.is_empty() => {
+				if let Some(Ok(Some(ws))) = joined {
+					connections.spawn(handle_conn(ws, Arc::clone(&state), cancel.clone()));
+				}
+			},
 			accepted = listener.accept() => {
 				let Ok((stream, _peer)) = accepted else { continue };
-				connections.spawn(handle_conn(stream, Arc::clone(&state), cancel.clone()));
+				if handshakes.len() >= PREAUTH_HANDSHAKE_TASKS {
+					drop(stream);
+					continue;
+				}
+				handshakes.spawn(handshake_conn(stream, Arc::clone(&state), cancel.clone()));
 			}
 		}
 	}
 	cancel.cancel();
-	join_connection_tasks(&mut connections).await;
+	join_connection_tasks(&mut handshakes, &mut connections).await;
 }
 
-async fn join_connection_tasks(connections: &mut JoinSet<()>) {
-	if timeout(CONNECTION_JOIN_GRACE, async { while connections.join_next().await.is_some() {} })
-		.await
-		.is_err()
-	{
+type ConnectionWebSocket = tokio_tungstenite::WebSocketStream<TcpStream>;
+
+async fn join_connection_tasks<A: 'static, B: 'static>(
+	handshakes: &mut JoinSet<A>,
+	connections: &mut JoinSet<B>,
+) {
+	let joined = timeout(CONNECTION_JOIN_GRACE, async {
+		while !handshakes.is_empty() || !connections.is_empty() {
+			tokio::select! {
+				_ = handshakes.join_next(), if !handshakes.is_empty() => {},
+				_ = connections.join_next(), if !connections.is_empty() => {},
+			}
+		}
+	})
+	.await;
+	if joined.is_err() {
+		handshakes.abort_all();
 		connections.abort_all();
+		while handshakes.join_next().await.is_some() {}
 		while connections.join_next().await.is_some() {}
 	}
 }
@@ -1687,10 +1718,17 @@ async fn join_connection_tasks(connections: &mut JoinSet<()>) {
 	clippy::result_large_err,
 	reason = "ErrorResponse is the type mandated by tokio-tungstenite's accept_hdr_async callback"
 )]
-async fn handle_conn(stream: TcpStream, state: Arc<ServerState>, cancel: CancellationToken) {
+async fn handshake_conn(
+	stream: TcpStream,
+	state: Arc<ServerState>,
+	cancel: CancellationToken,
+) -> Option<ConnectionWebSocket> {
 	let expected = state.token.clone();
+	let authenticated = Arc::new(AtomicBool::new(false));
+	let authenticated_for_auth = Arc::clone(&authenticated);
 	let auth = move |req: &Request, resp: Response| -> Result<Response, ErrorResponse> {
 		if token_from_query(req.uri().query()).is_some_and(|t| tokens_match(&t, &expected)) {
+			authenticated_for_auth.store(true, Ordering::Release);
 			Ok(resp)
 		} else {
 			let body = ErrorResponse::new(Some("unauthorized".to_owned()));
@@ -1706,13 +1744,20 @@ async fn handle_conn(stream: TcpStream, state: Arc<ServerState>, cancel: Cancell
 		max_frame_size: Some(REQUEST_FRAME_BYTES),
 		..WebSocketConfig::default()
 	};
-	let ws = tokio::select! {
-		() = cancel.cancelled() => return,
-		accepted = tokio_tungstenite::accept_hdr_async_with_config(stream, auth, Some(ws_config)) => {
-			let Ok(ws) = accepted else { return };
-			ws
-		},
+	let accepted = tokio::select! {
+		() = cancel.cancelled() => return None,
+		accepted = timeout(
+			HANDSHAKE_DEADLINE,
+			tokio_tungstenite::accept_hdr_async_with_config(stream, auth, Some(ws_config)),
+		) => accepted,
 	};
+	match accepted {
+		Ok(Ok(ws)) if authenticated.load(Ordering::Acquire) => Some(ws),
+		Ok(Ok(_) | Err(_)) | Err(_) => None,
+	}
+}
+
+async fn handle_conn(ws: ConnectionWebSocket, state: Arc<ServerState>, cancel: CancellationToken) {
 	let connection_id =
 		format!("connection:{}", state.connection_sequence.fetch_add(1, Ordering::Relaxed));
 	let generation = "0".to_owned();
@@ -2342,6 +2387,7 @@ pub(crate) fn tokens_match(a: &str, b: &str) -> bool {
 #[cfg(test)]
 mod tests {
 	use futures_util::SinkExt;
+	use tokio::io::{AsyncReadExt, AsyncWriteExt};
 	use tokio_tungstenite::connect_async;
 
 	use super::*;
@@ -2352,6 +2398,166 @@ mod tests {
 	// Tokio's mock clock is process-global. Acquire the lock before constructing
 	// a paused runtime so concurrent libtest workers cannot share its clock.
 	static PAUSED_TIME_TEST_LOCK: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
+
+	async fn partial_handshake(handle: &ServerHandle) -> TcpStream {
+		let mut stream = TcpStream::connect(handle.addr()).await.unwrap();
+		stream
+			.write_all(b"GET /?token=secret HTTP/1.1\r\nHost: localhost\r\n")
+			.await
+			.unwrap();
+		stream
+	}
+
+	async fn observe_preauth_capacity(stalled: &mut Vec<TcpStream>, handle: &ServerHandle) {
+		let mut byte = [0_u8; 1];
+		for _ in 0..PREAUTH_HANDSHAKE_TASKS {
+			let mut probe = TcpStream::connect(handle.addr()).await.unwrap();
+			match timeout(Duration::from_millis(50), probe.read(&mut byte)).await {
+				Ok(Ok(0) | Err(_)) => return,
+				Ok(Ok(_)) => panic!("pre-auth connection returned unexpected bytes"),
+				Err(_) => stalled.push(probe),
+			}
+		}
+		panic!("pre-auth capacity was not observed within bounded probes");
+	}
+
+	#[tokio::test]
+	async fn preauth_capacity_drops_excess_and_recovers_after_deadline() {
+		let handle = start(ServerConfig::new("s", "secret")).await.unwrap();
+		let mut stalled = Vec::new();
+		for _ in 0..PREAUTH_HANDSHAKE_TASKS {
+			stalled.push(partial_handshake(&handle).await);
+		}
+		observe_preauth_capacity(&mut stalled, &handle).await;
+
+		tokio::time::sleep(HANDSHAKE_DEADLINE + Duration::from_millis(100)).await;
+		let mut expired = stalled
+			.pop()
+			.expect("at least one admitted partial handshake");
+		let mut byte = [0_u8; 1];
+		assert!(
+			matches!(
+				timeout(Duration::from_secs(1), expired.read(&mut byte)).await,
+				Ok(Ok(0) | Err(_))
+			),
+			"the original partial socket must close at the handshake deadline",
+		);
+		let mut ws = connect(&handle, "secret").await;
+		next_server_hello(&mut ws).await;
+		drop(stalled);
+		handle.stop_and_wait().await;
+	}
+
+	#[tokio::test]
+	async fn legitimate_partial_handshake_can_finish_just_before_deadline() {
+		let handle = start(ServerConfig::new("s", "secret")).await.unwrap();
+		let mut stream = partial_handshake(&handle).await;
+		tokio::time::sleep(HANDSHAKE_DEADLINE.saturating_sub(Duration::from_millis(500))).await;
+		stream
+			.write_all(
+				b"Upgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n",
+			)
+			.await
+			.unwrap();
+		let mut response = [0_u8; 512];
+		let read = timeout(Duration::from_secs(1), stream.read(&mut response))
+			.await
+			.expect("valid partial handshake completes before the deadline")
+			.expect("valid partial handshake response");
+		assert!(String::from_utf8_lossy(&response[..read]).starts_with("HTTP/1.1 101"));
+		handle.stop_and_wait().await;
+	}
+
+	#[tokio::test]
+	async fn authenticated_connection_survives_handshake_deadline() {
+		let handle = start(ServerConfig::new("s", "secret")).await.unwrap();
+		let mut ws = connect(&handle, "secret").await;
+		next_server_hello(&mut ws).await;
+		tokio::time::sleep(HANDSHAKE_DEADLINE + Duration::from_millis(100)).await;
+		ws.send(Message::Ping(Vec::new())).await.unwrap();
+		let pong = timeout(Duration::from_secs(1), ws.next())
+			.await
+			.expect("authenticated connection remains live")
+			.expect("websocket remains open")
+			.expect("pong frame");
+		assert!(matches!(pong, Message::Pong(_)));
+		handle.stop_and_wait().await;
+	}
+
+	#[tokio::test]
+	async fn bad_token_handshake_releases_preauth_capacity() {
+		let handle = start(ServerConfig::new("s", "secret")).await.unwrap();
+		let mut stalled = Vec::new();
+		for _ in 0..PREAUTH_HANDSHAKE_TASKS {
+			stalled.push(partial_handshake(&handle).await);
+		}
+		observe_preauth_capacity(&mut stalled, &handle).await;
+		drop(
+			stalled
+				.pop()
+				.expect("one admitted partial handshake can release its slot"),
+		);
+
+		let url = format!("ws://{}/?token=wrong", handle.addr());
+		let error = timeout(Duration::from_secs(1), async {
+			loop {
+				if let Err(error @ tokio_tungstenite::tungstenite::Error::Http(_)) =
+					connect_async(&url).await
+				{
+					break error;
+				}
+				tokio::task::yield_now().await;
+			}
+		})
+		.await
+		.expect("bad-token handshake must enter the released admission slot");
+		assert!(
+			matches!(error, tokio_tungstenite::tungstenite::Error::Http(response) if response.status() == StatusCode::UNAUTHORIZED)
+		);
+
+		let valid_url = format!("ws://{}/?token=secret", handle.addr());
+		let mut ws = timeout(Duration::from_secs(1), async {
+			loop {
+				if let Ok((ws, _response)) = connect_async(&valid_url).await {
+					break ws;
+				}
+				tokio::task::yield_now().await;
+			}
+		})
+		.await
+		.expect("bad-token handshake must release its admission slot");
+		next_server_hello(&mut ws).await;
+		drop(stalled);
+		handle.stop_and_wait().await;
+	}
+
+	#[tokio::test]
+	async fn authenticated_connections_are_not_subject_to_preauth_capacity() {
+		let handle = start(ServerConfig::new("s", "secret")).await.unwrap();
+		let mut connections = Vec::new();
+		for _ in 0..65 {
+			let mut ws = connect(&handle, "secret").await;
+			next_server_hello(&mut ws).await;
+			connections.push(ws);
+		}
+		assert_eq!(connections.len(), 65);
+		assert_eq!(handle.client_count(), 65);
+		handle.stop_and_wait().await;
+	}
+
+	#[tokio::test]
+	async fn awaited_stop_joins_split_handshake_and_connection_tasks() {
+		let handle = start(ServerConfig::new("s", "secret")).await.unwrap();
+		let half_open = partial_handshake(&handle).await;
+		let mut ws = connect(&handle, "secret").await;
+		next_server_hello(&mut ws).await;
+
+		timeout(CONNECTION_JOIN_GRACE + Duration::from_secs(1), handle.stop_and_wait())
+			.await
+			.expect("shutdown joins split handshake and connection tasks");
+		drop(half_open);
+		assert_eq!(handle.client_count(), 0);
+	}
 
 	#[test]
 	fn directed_frame_reservations_are_bounded_and_reusable() {
@@ -2693,14 +2899,17 @@ mod tests {
 
 	#[tokio::test]
 	async fn stalled_connection_tasks_are_aborted_after_shutdown_grace() {
+		let mut handshakes = JoinSet::new();
+		handshakes.spawn(async { std::future::pending::<()>().await });
 		let mut connections = JoinSet::new();
 		connections.spawn(async { std::future::pending::<()>().await });
 		tokio::time::timeout(
 			CONNECTION_JOIN_GRACE + Duration::from_secs(1),
-			join_connection_tasks(&mut connections),
+			join_connection_tasks(&mut handshakes, &mut connections),
 		)
 		.await
 		.expect("connection joins must remain bounded");
+		assert!(handshakes.is_empty());
 		assert!(connections.is_empty());
 	}
 

--- a/crates/gjc-sdk/src/server.rs
+++ b/crates/gjc-sdk/src/server.rs
@@ -110,6 +110,11 @@ const PREAUTH_HANDSHAKE_TASKS: usize = 16;
 /// admission.
 const HANDSHAKE_DEADLINE: Duration = Duration::from_secs(2);
 
+/// Delay before retrying a listener after a transient accept failure. In
+/// particular, this prevents an `EMFILE`/`ENFILE` loop from starving
+/// handshake and connection cleanup.
+const ACCEPT_ERROR_BACKOFF: Duration = Duration::from_millis(10);
+
 /// Grace period for connection tasks to observe server cancellation before
 /// forced abort.
 const CONNECTION_JOIN_GRACE: Duration = Duration::from_secs(1);
@@ -1666,6 +1671,11 @@ pub async fn start(config: ServerConfig) -> std::io::Result<ServerHandle> {
 async fn accept_loop(listener: TcpListener, state: Arc<ServerState>, cancel: CancellationToken) {
 	let mut connections = JoinSet::new();
 	let mut handshakes: JoinSet<Option<ConnectionWebSocket>> = JoinSet::new();
+	// Keep one descriptor available so an `EMFILE` accept failure can still
+	// drain one queued socket and return the listener to a state where it can
+	// make progress once a handshake task releases its descriptor.
+	let null_device = if cfg!(windows) { "NUL" } else { "/dev/null" };
+	let mut accept_spare = std::fs::File::open(null_device).ok();
 	loop {
 		tokio::select! {
 			() = cancel.cancelled() => break,
@@ -1678,17 +1688,94 @@ async fn accept_loop(listener: TcpListener, state: Arc<ServerState>, cancel: Can
 				}
 			},
 			accepted = listener.accept() => {
-				let Ok((stream, _peer)) = accepted else { continue };
-				if handshakes.len() >= PREAUTH_HANDSHAKE_TASKS {
-					drop(stream);
-					continue;
+				match accepted {
+					Ok((stream, _peer)) => {
+						if handshakes.len() >= PREAUTH_HANDSHAKE_TASKS {
+							match handshakes.try_join_next() {
+								Some(Ok(Some(ws))) => {
+									connections.spawn(handle_conn(ws, Arc::clone(&state), cancel.clone()));
+								},
+								Some(Ok(None) | Err(_)) => {},
+								None => {
+									drop(stream);
+									continue;
+								},
+							}
+						}
+						handshakes.spawn(handshake_conn(stream, Arc::clone(&state), cancel.clone()));
+					},
+					Err(error) if is_fd_exhaustion(&error) => {
+						if !drain_fd_exhausted_accept(
+							&listener,
+							&cancel,
+							null_device,
+							&mut accept_spare,
+						)
+						.await
+						{
+							break;
+			}
+					},
+					Err(_) => {
+						if !backoff_after_accept_error(&cancel).await {
+							break;
+			}
+					},
 				}
-				handshakes.spawn(handshake_conn(stream, Arc::clone(&state), cancel.clone()));
 			}
 		}
 	}
 	cancel.cancel();
 	join_connection_tasks(&mut handshakes, &mut connections).await;
+}
+
+async fn drain_fd_exhausted_accept(
+	listener: &TcpListener,
+	cancel: &CancellationToken,
+	null_device: &str,
+	accept_spare: &mut Option<std::fs::File>,
+) -> bool {
+	// With no spare descriptor, accepting another socket would fail repeatedly
+	// and leave queued clients ahead of future valid upgrades. Close the reserve,
+	// accept one socket for immediate disposal, then recreate the reserve.
+	drop(accept_spare.take());
+	let drained = tokio::select! {
+		() = cancel.cancelled() => return false,
+		accepted = listener.accept() => accepted,
+	};
+	match drained {
+		Ok((stream, _peer)) => drop(stream),
+		Err(_) => {
+			if !backoff_after_accept_error(cancel).await {
+				return false;
+			}
+		},
+	}
+	*accept_spare = std::fs::File::open(null_device).ok();
+	true
+}
+
+async fn backoff_after_accept_error(cancel: &CancellationToken) -> bool {
+	tokio::select! {
+		() = cancel.cancelled() => false,
+		() = sleep(ACCEPT_ERROR_BACKOFF) => true,
+	}
+}
+
+#[cfg(unix)]
+fn is_fd_exhaustion(error: &std::io::Error) -> bool {
+	matches!(error.raw_os_error(), Some(code) if code == libc::EMFILE || code == libc::ENFILE)
+}
+
+#[cfg(windows)]
+fn is_fd_exhaustion(error: &std::io::Error) -> bool {
+	// WSAEMFILE (the Winsock form of ERROR_TOO_MANY_OPEN_FILES).
+	matches!(error.raw_os_error(), Some(4 | 10024))
+}
+
+#[cfg(not(any(unix, windows)))]
+fn is_fd_exhaustion(_error: &std::io::Error) -> bool {
+	false
 }
 
 type ConnectionWebSocket = tokio_tungstenite::WebSocketStream<TcpStream>;
@@ -2386,6 +2473,8 @@ pub(crate) fn tokens_match(a: &str, b: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+	use std::net::Ipv6Addr;
+
 	use futures_util::SinkExt;
 	use tokio::io::{AsyncReadExt, AsyncWriteExt};
 	use tokio_tungstenite::connect_async;
@@ -3164,6 +3253,22 @@ mod tests {
 		assert_ne!(handle.addr().port(), 0);
 		assert!(handle.addr().ip().is_loopback());
 		handle.stop();
+	}
+
+	#[tokio::test]
+	async fn start_binds_ipv6_loopback_when_available() {
+		let mut config = ServerConfig::new("ipv6", "secret");
+		config.host = IpAddr::V6(Ipv6Addr::LOCALHOST);
+		let handle = match start(config).await {
+			Ok(handle) => handle,
+			Err(error) if error.kind() == std::io::ErrorKind::AddrNotAvailable => return,
+			Err(error) => panic!("IPv6 loopback bind failed: {error}"),
+		};
+		assert!(handle.addr().ip().is_loopback());
+		assert!(handle.addr().ip().is_ipv6());
+		let mut ws = connect(&handle, "secret").await;
+		assert!(matches!(next_server_msg(&mut ws).await, ServerMessage::Hello(_)));
+		handle.stop_and_wait().await;
 	}
 
 	#[tokio::test]

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Notification WebSocket admission now bounds incomplete handshakes to 16 concurrent tasks and expires them after two seconds without limiting authenticated clients.
+- Notification WebSocket admission now drains queued sockets through a reserved descriptor when the process reaches its file-descriptor limit, preventing cleanup starvation and restoring valid loopback upgrades after low-FD saturation.
 
 ## [0.16.3] - 2026-09-04
 

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Notification WebSocket admission now bounds incomplete handshakes to 16 concurrent tasks and expires them after two seconds without limiting authenticated clients.
+
 ## [0.16.3] - 2026-09-04
 
 ## [0.16.2] - 2026-09-04


### PR DESCRIPTION
## Finding / reproduction

The refreshed `dev` base (`5934c33c6740e3ba58408f49b039c6ee0ad7b310`) still enters every accepted TCP socket into the same unbounded task set before its WebSocket upgrade and query-token authentication finish.

An exact-base loopback probe under `RLIMIT_NOFILE=64` opened 80 incomplete upgrade requests. The server process reached 64 descriptors; an additional valid authenticated upgrade returned no HTTP response, and the same probe still returned no response after the handshake deadline. This is the current-base reproduction, not the stale `ca614b56` validation.

The affected boundary is notification WebSocket admission availability. This does not require or change any authenticated SDK message behavior.

## Root cause

`accept_loop` spawned `handle_conn` immediately for each accepted stream. `handle_conn` performed the actual Tungstenite upgrade and token callback with neither a pre-authentication task bound nor a handshake deadline, so incomplete requests acquired unbounded connection-task and socket lifetime before authentication. The loop also retried every `accept()` error immediately, so `EMFILE` could spin the accept branch and leave queued clients ahead of later valid upgrades.

A forced shutdown could additionally abort an established connection while its writer was blocked, bypassing the tail cleanup that removed connection state and emitted the provider-lease close notification. Endpoint discovery formatted raw IPv6 hosts as `ws://::1:port`, which is not a valid URI authority.

## Change

- `crates/gjc-sdk/src/server.rs`
  - keep incomplete upgrades in a separate `JoinSet` capped at 16 tasks;
  - apply a two-second timeout around the actual `accept_hdr_async_with_config` upgrade and token callback;
  - move only a successfully upgraded, callback-authenticated WebSocket into the established connection set;
  - keep established authenticated connections outside the pre-auth cap and deadline;
  - drain one queued socket through a reserved descriptor on Unix `EMFILE`/`ENFILE` (and Windows `WSAEMFILE`), back off transient accept errors, and join completed handshake tasks before rejecting a full slot;
  - use a drop guard so forced task aborts still remove connection state, finish origin-bound acknowledgements, and emit the close notification;
  - retain the existing aggregate shutdown grace while joining/aborting both task sets;
  - cover overload/drop/recovery, deadline close, a slow valid upgrade, bad-token slot release, authenticated lifetime/capacity, IPv4/IPv6 loopback bind, and shutdown cleanup with real-socket or cancellation regressions.
- `crates/gjc-sdk/src/discovery.rs`
  - preserve the raw host field while emitting bracketed IPv6 endpoint URLs.
- `packages/natives/CHANGELOG.md`
  - record the user-visible admission hardening under `Unreleased`.

The `16` task and `2s` deadline policy previously received maintainer approval in #3483 (`a98863712a73e1c0dfa219776844fbaa0a71d888`). Its later broad revert (`de7f06b415043e045e818295b16d6b43aff95683`) documents unrelated shell/artifact regressions; this PR restores only the WebSocket pre-auth boundary and the ordinary lifecycle defects found while refreshing it.

## Scope

- Changed files: 3.
- Production changes: bounded pre-auth acceptance and recovery, abort-safe connection cleanup, and valid IPv6 discovery URL serialization.
- Test changes: real-socket admission/deadline/authentication/shutdown coverage plus IPv6 URL and cancellation cleanup regressions.
- Total diff against refreshed `dev`: +430 / -33.
- This PR addresses the availability and lifecycle findings on #5272. It does not create or duplicate terminally closed issue #5268.

## Contract

Preserved:

- `ServerConfig`, N-API constructors, query-token authentication, wire protocol, public fields, and endpoint discovery schema;
- valid IPv4 and IPv6 loopback upgrades completing within two seconds;
- unlimited lifetime and no 16-client cap after authentication;
- existing aggregate one-second shutdown grace and direct `ServerHandle` URLs.

Intentionally changed:

- at most 16 incomplete upgrades may hold server tasks concurrently;
- excess pre-auth sockets fail closed, including queued sockets drained during file-descriptor exhaustion;
- an incomplete upgrade is closed after two seconds;
- forced aborts now perform the same connection-state and close-notification cleanup as cooperative exits;
- IPv6 discovery URLs are serialized with URI authority brackets (`ws://[::1]:port`).

`OWNER_CONFIRMATION_REQUIRED`: no. The changes are narrow correctness fixes within the already approved pre-auth boundary; the risk classification remains high because this is an authentication and lifecycle surface.

## Verification

- Base SHA: `5934c33c6740e3ba58408f49b039c6ee0ad7b310`
- Head SHA: `6a1790349c9bd4556e6f168df2d76a6fb4b10a3b`
- Reviewed patch SHA-256: `40d1e1f7ac84e213da2081d37ab3ad4883c4d3002347086002e176fe0a067ab2`
- Canonical PR-contract diff SHA-256 (`--binary --full-index --no-ext-diff`): `40830fac8f5891e82c62d8be97d62df447e44590eb8c0c6c8c5beeb4699205d5`
- Refreshed-base regression: exact `dev` base at `RLIMIT_NOFILE=64` held 64 descriptors with 80 partial upgrades; the overload and post-deadline recovery probes returned no `101` response.
- Branch runtime proof: a clean child-process matrix with inherited descriptors closed before applying the limit held 28 descriptors at `RLIMIT_NOFILE=64` and 24 at `RLIMIT_NOFILE=24`, rejected the overload probe, recovered to `HTTP/1.1 101 Switching Protocols` after the handshake tasks expired, and stopped cleanly in both cases.
- Affected SDK suite: `cargo test -p gjc-sdk` passed 168/168, including 70 server tests and IPv6 discovery coverage.
- SDK library lint: `cargo clippy -p gjc-sdk --lib -- -D warnings` passed.
- All-target SDK lint: branch and refreshed exact-base runs report the same 12 pre-existing test-only `useless_conversion` diagnostics; the branch adds 0 diagnostics.
- Rust formatting and workspace Rust checks: `cargo fmt --all -- --check` and `bun run check:rs` passed on Linux.
- Native addon: host `bun --cwd=packages/natives run build` passed; focused integration `bun test packages/natives/test/native.test.ts` passed 38/38. The full native test command had 155 passes and 2 unrelated environment failures before dependency restoration; its failures were missing `@napi-rs/cli` in the test's isolated PATH and missing `@types/node` for a declaration-consumer test.
- Darwin cross-build: the exact `CI=1 TARGET_PLATFORM=darwin TARGET_ARCH=arm64 bun run ci:build:native` command was attempted on this Linux host and failed because the local build emitted `pi_natives.linux-x64-gnu.node` instead of a Darwin addon; the host build passed and the failure is runner/toolchain capability, not a changed source diagnostic.
- TypeScript repository checks: dependency installation restored the missing local tools; `bun run check:ts` passed its tool, publish-type, Node 20, public-sync, and schema gates, then stopped at the pre-existing Slack daemon manifest digest mismatch. The changed paths do not include that daemon or manifest.
- `bun run check` therefore remains red only on that unchanged Slack manifest gate; its initial attempt before dependency restoration also exposed the missing local `biome` binary.
- Generated native declarations and source tree remained byte-stable after the host build; `git diff --check` passed.

## Overlap and integration

- The branch was refreshed by merging current `dev`; `origin/dev` is an ancestor of the final head, and the original PR head remains an ancestor of the refresh.
- The final implementation remains on PR #5272's external head branch; contributor commits and authorship are preserved.
- No generated native declaration changes were introduced.
- No issue or separate PR was opened for terminally closed #5268.

## Known limits / non-goals

- Authenticated-client capacity remains intentionally unlimited; the pre-auth cap protects the admission boundary rather than imposing a post-auth quota.
- The 16-task cap and two-second deadline remain private constants; configurability is out of scope.
- The spare descriptor is a best-effort recovery mechanism; ordinary transient accept errors are cancellation-aware and back off rather than busy-looping.
- Darwin/Windows hosted execution is not reproduced on this Linux workstation; Windows `WSAEMFILE` is handled explicitly as raw error 10024 (with Win32 code 4 also recognized).
- This PR does not repair the unrelated Slack manifest-generation gate or broaden native CI platform support.

## Risk classification

- [ ] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [x] `high-risk` — authentication, resource-admission, and destructive lifecycle behavior; requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:40830fac8f5891e82c62d8be97d62df447e44590eb8c0c6c8c5beeb4699205d5 reviewer:human reviewer-id:Yeachan-Heo evidence:authenticated-exact-head-approval-6a1790349c9bd4556e6f168df2d76a6fb4b10a3b
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken
