### PR TITLE
fix(models): refresh dynamic startup selectors

### DIFF
--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1621,6 +1621,7 @@ export class AuthStorage {
 	 */
 	setRuntimeApiKey(provider: string, apiKey: string): void {
 		const storageProvider = resolveOAuthStorageProvider(provider);
+		if (this.#runtimeOverrides.get(storageProvider) === apiKey) return;
 		this.#runtimeOverrides.set(storageProvider, apiKey);
 		this.#bumpGeneration("set-runtime-api-key", storageProvider);
 	}
@@ -1937,6 +1938,8 @@ export class AuthStorage {
 			throw new Error(`Preferred credential selector cannot be combined with a credential selector for ${provider}`);
 		}
 		this.#assertPreferredCredentialSelectorUsable(storageProvider, selector);
+		const existing = this.#runtimePreferredCredentialSelectors.get(storageProvider);
+		if (existing?.kind === selector.kind && existing.value === selector.value) return;
 		this.#runtimePreferredCredentialSelectors.set(storageProvider, selector);
 		this.#bumpGeneration("set-runtime-preferred-credential-selector", provider);
 	}

--- a/packages/ai/src/utils/discovery/antigravity.ts
+++ b/packages/ai/src/utils/discovery/antigravity.ts
@@ -180,6 +180,7 @@ export async function fetchAntigravityDiscoveryModels(
 	options: FetchAntigravityDiscoveryModelsOptions,
 ): Promise<Model<"google-gemini-cli">[] | null> {
 	const fetcher = options.fetcher ?? fetch;
+	const signal = options.signal ?? AbortSignal.timeout(5_000);
 	const targetProvider = options.targetProvider ?? "google-antigravity";
 	const endpoints = options.endpoint
 		? [trimTrailingSlashes(options.endpoint)]
@@ -196,7 +197,7 @@ export async function fetchAntigravityDiscoveryModels(
 					"User-Agent": options.userAgent ?? getAntigravityUserAgent(),
 				},
 				body: JSON.stringify({}),
-				signal: options.signal,
+				signal,
 			});
 		} catch {
 			continue;

--- a/packages/ai/src/utils/discovery/gemini.ts
+++ b/packages/ai/src/utils/discovery/gemini.ts
@@ -72,6 +72,7 @@ export async function fetchGeminiModels(
 	const baseUrl = normalizeBaseUrl(options.baseUrl);
 	const pageSize = normalizePositiveInt(options.pageSize, DEFAULT_PAGE_SIZE);
 	const maxPages = normalizePositiveInt(options.maxPages, DEFAULT_MAX_PAGES);
+	const signal = options.signal ?? AbortSignal.timeout(5_000);
 
 	const bundledById = new Map(
 		getBundledModels("google").map(model => [model.id, model as Model<"google-generative-ai">]),
@@ -86,7 +87,7 @@ export async function fetchGeminiModels(
 		try {
 			response = await fetchImpl(requestUrl, {
 				method: "GET",
-				signal: options.signal,
+				signal,
 			});
 		} catch {
 			return null;

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 ### Fixed
 
+- Plain and explicit-model launches now refresh a missing provider's cached dynamic catalog before resolving a qualified startup selector, so configured models such as `glm-zcode/glm-5.3` no longer open in `no-model` state while preserving cache-only startup for already available models.
+
 - The status-line usage segment now paints only the active model's provider, so switching to Grok no longer keeps a stale Claude 5h/7d pair. Canonical Grok Build reports render only their authoritative weekly window, while monthly credits are omitted instead of being mislabeled as `7d`.
 
 - Moving the `/model` preset cursor now reuses the authentication snapshot produced by catalog and credential refreshes instead of resolving every profile against the full model catalog on each Up/Down keypress; auth-dependent preset actions remain blocked until the initial static refresh and the availability snapshot are complete.

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -3578,8 +3578,9 @@ export class ModelRegistry {
 		// through discovery.type.
 		if (this.#configuredProviderIds.has("vllm")) configuredDiscoveryProviders.add("vllm");
 		if (this.#configuredProviderIds.has("sglang")) configuredDiscoveryProviders.add("sglang");
-		const managerOptions = (await this.#collectBuiltInModelManagerOptions(configuredDiscoveryProviders)).filter(
-			entry => (providerFilter ? providerFilter.has(entry.options.providerId) : true),
+		const managerOptions = await this.#collectBuiltInModelManagerOptions(
+			configuredDiscoveryProviders,
+			providerFilter,
 		);
 		if (managerOptions.length === 0) {
 			return [];
@@ -3592,6 +3593,7 @@ export class ModelRegistry {
 
 	async #collectBuiltInModelManagerOptions(
 		excludedProviderIds: ReadonlySet<string> = new Set(),
+		providerFilter?: ReadonlySet<string>,
 	): Promise<ModelManagerDiscoveryOptions[]> {
 		const specialProviderDescriptors: Array<{
 			providerId: string;
@@ -3635,10 +3637,16 @@ export class ModelRegistry {
 		];
 		const disabledProviders = getDisabledProviderIdsFromSettings(this.#settings);
 		const standardProviderDescriptors = PROVIDER_DESCRIPTORS.filter(
-			descriptor => !disabledProviders.has(descriptor.providerId) && !excludedProviderIds.has(descriptor.providerId),
+			descriptor =>
+				!disabledProviders.has(descriptor.providerId) &&
+				!excludedProviderIds.has(descriptor.providerId) &&
+				(providerFilter === undefined || providerFilter.has(descriptor.providerId)),
 		);
 		const enabledSpecialProviderDescriptors = specialProviderDescriptors.filter(
-			descriptor => !disabledProviders.has(descriptor.providerId) && !excludedProviderIds.has(descriptor.providerId),
+			descriptor =>
+				!disabledProviders.has(descriptor.providerId) &&
+				!excludedProviderIds.has(descriptor.providerId) &&
+				(providerFilter === undefined || providerFilter.has(descriptor.providerId)),
 		);
 		for (const descriptor of standardProviderDescriptors) {
 			if (!descriptor.allowUnauthenticated) continue;

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -62,6 +62,28 @@ export function parseModelString(
 		: { provider, id: modelStr.slice(slashIdx + 1) };
 }
 
+export async function refreshMissingQualifiedModelProvider(
+	selector: string | undefined,
+	modelRegistry: Pick<ModelRegistry, "getAvailable" | "refreshProvider">,
+): Promise<boolean> {
+	if (!selector) return false;
+	const parsedSelector = parseModelString(selector);
+	if (!parsedSelector) return false;
+	if (
+		modelRegistry
+			.getAvailable()
+			.some(
+				model =>
+					model.provider.toLowerCase() === parsedSelector.provider.toLowerCase() &&
+					model.id.toLowerCase() === parsedSelector.id.toLowerCase(),
+			)
+	)
+		return false;
+
+	await modelRegistry.refreshProvider(parsedSelector.provider, "online-if-uncached");
+	return true;
+}
+
 /**
  * Format a model as "provider/modelId" string.
  */

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -62,6 +62,28 @@ export function parseModelString(
 		: { provider, id: modelStr.slice(slashIdx + 1) };
 }
 
+export function resolveStartupModelRefreshSelectors(
+	options: {
+		model?: string;
+		provider?: string;
+		credential?: string;
+		continue?: boolean;
+		resume?: string | boolean;
+		hasStartupProfile: boolean;
+	},
+	settings: ModelRoleSettings,
+): ModelSelectorValue | undefined {
+	if (options.credential) return undefined;
+	if (options.model) {
+		return options.provider && !options.model.toLowerCase().startsWith(`${options.provider.toLowerCase()}/`)
+			? `${options.provider}/${options.model}`
+			: options.model;
+	}
+	if (options.hasStartupProfile) return undefined;
+	if (options.continue || options.resume) return undefined;
+	return resolveConfiguredModelPatterns(settings.getModelRole("default"), settings);
+}
+
 export async function refreshMissingQualifiedModelProviders(
 	selectors: ModelSelectorValue | undefined,
 	modelRegistry: Pick<ModelRegistry, "getAvailable" | "getDiscoverableProviders" | "refreshProvider">,
@@ -74,14 +96,11 @@ export async function refreshMissingQualifiedModelProviders(
 			.getDiscoverableProviders()
 			.find(candidate => candidate.toLowerCase() === parsedSelector.provider.toLowerCase());
 		if (!provider || refreshedProviders.has(provider)) continue;
+		const availableModels = modelRegistry.getAvailable();
+		const rawModelId = selector.slice(selector.indexOf("/") + 1);
 		if (
-			modelRegistry
-				.getAvailable()
-				.some(
-					model =>
-						model.provider.toLowerCase() === provider.toLowerCase() &&
-						model.id.toLowerCase() === parsedSelector.id.toLowerCase(),
-				)
+			resolveProviderModelReference(provider, rawModelId, availableModels) ||
+			resolveProviderModelReference(provider, parsedSelector.id, availableModels)
 		)
 			continue;
 

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -62,26 +62,33 @@ export function parseModelString(
 		: { provider, id: modelStr.slice(slashIdx + 1) };
 }
 
-export async function refreshMissingQualifiedModelProvider(
-	selector: string | undefined,
-	modelRegistry: Pick<ModelRegistry, "getAvailable" | "refreshProvider">,
+export async function refreshMissingQualifiedModelProviders(
+	selectors: ModelSelectorValue | undefined,
+	modelRegistry: Pick<ModelRegistry, "getAvailable" | "getDiscoverableProviders" | "refreshProvider">,
 ): Promise<boolean> {
-	if (!selector) return false;
-	const parsedSelector = parseModelString(selector);
-	if (!parsedSelector) return false;
-	if (
-		modelRegistry
-			.getAvailable()
-			.some(
-				model =>
-					model.provider.toLowerCase() === parsedSelector.provider.toLowerCase() &&
-					model.id.toLowerCase() === parsedSelector.id.toLowerCase(),
-			)
-	)
-		return false;
+	const refreshedProviders = new Set<string>();
+	for (const selector of normalizeModelSelectorValue(selectors)) {
+		const parsedSelector = parseModelString(selector);
+		if (!parsedSelector) continue;
+		const provider = modelRegistry
+			.getDiscoverableProviders()
+			.find(candidate => candidate.toLowerCase() === parsedSelector.provider.toLowerCase());
+		if (!provider || refreshedProviders.has(provider)) continue;
+		if (
+			modelRegistry
+				.getAvailable()
+				.some(
+					model =>
+						model.provider.toLowerCase() === provider.toLowerCase() &&
+						model.id.toLowerCase() === parsedSelector.id.toLowerCase(),
+				)
+		)
+			continue;
 
-	await modelRegistry.refreshProvider(parsedSelector.provider, "online-if-uncached");
-	return true;
+		await modelRegistry.refreshProvider(provider, "online-if-uncached");
+		refreshedProviders.add(provider);
+	}
+	return refreshedProviders.size > 0;
 }
 
 /**

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1651,13 +1651,14 @@ export async function runRootCommand(
 			)
 		: undefined;
 
-	const startupModelSelector = parsedArgs.model
-		? parsedArgs.provider && !parsedArgs.model.toLowerCase().startsWith(`${parsedArgs.provider.toLowerCase()}/`)
-			? `${parsedArgs.provider}/${parsedArgs.model}`
-			: parsedArgs.model
-		: !parsedArgs.continue && !parsedArgs.resume
-			? selectorHead(settingsInstance.getModelRole("default"))
-			: undefined;
+	const startupModelSelector =
+		parsedArgs.model && !parsedArgs.credential
+			? parsedArgs.provider && !parsedArgs.model.toLowerCase().startsWith(`${parsedArgs.provider.toLowerCase()}/`)
+				? `${parsedArgs.provider}/${parsedArgs.model}`
+				: parsedArgs.model
+			: !parsedArgs.model && !parsedArgs.continue && !parsedArgs.resume
+				? selectorHead(settingsInstance.getModelRole("default"))
+				: undefined;
 	await logger.time(
 		"refreshStartupModelProvider",
 		refreshMissingQualifiedModelProvider,

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -32,7 +32,7 @@ import { findConfigFile } from "./config";
 import { activateModelProfile, ModelProfileCredentialError } from "./config/model-profile-activation";
 import { ModelRegistry, ModelsConfigFile } from "./config/model-registry";
 import {
-	refreshMissingQualifiedModelProvider,
+	refreshMissingQualifiedModelProviders,
 	resolveCliModel,
 	resolveModelRoleValue,
 	resolveModelScope,
@@ -1651,18 +1651,18 @@ export async function runRootCommand(
 			)
 		: undefined;
 
-	const startupModelSelector =
+	const startupModelSelectors =
 		parsedArgs.model && !parsedArgs.credential
 			? parsedArgs.provider && !parsedArgs.model.toLowerCase().startsWith(`${parsedArgs.provider.toLowerCase()}/`)
 				? `${parsedArgs.provider}/${parsedArgs.model}`
 				: parsedArgs.model
 			: !parsedArgs.model && !parsedArgs.continue && !parsedArgs.resume
-				? selectorHead(settingsInstance.getModelRole("default"))
+				? settingsInstance.getModelRole("default")
 				: undefined;
 	await logger.time(
-		"refreshStartupModelProvider",
-		refreshMissingQualifiedModelProvider,
-		startupModelSelector,
+		"refreshStartupModelProviders",
+		refreshMissingQualifiedModelProviders,
+		startupModelSelectors,
 		modelRegistry,
 	);
 

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -31,7 +31,13 @@ import { selectSession } from "./cli/session-picker";
 import { findConfigFile } from "./config";
 import { activateModelProfile, ModelProfileCredentialError } from "./config/model-profile-activation";
 import { ModelRegistry, ModelsConfigFile } from "./config/model-registry";
-import { resolveCliModel, resolveModelRoleValue, resolveModelScope, type ScopedModel } from "./config/model-resolver";
+import {
+	refreshMissingQualifiedModelProvider,
+	resolveCliModel,
+	resolveModelRoleValue,
+	resolveModelScope,
+	type ScopedModel,
+} from "./config/model-resolver";
 import { selectorHead } from "./config/model-selector-value";
 import { getDefault, type SettingPath, Settings, settings } from "./config/settings";
 import { resolveMachineLocalUpdateChannel, type UpdateChannel } from "./config/update-channel";
@@ -1644,6 +1650,20 @@ export async function runRootCommand(
 				},
 			)
 		: undefined;
+
+	const startupModelSelector = parsedArgs.model
+		? parsedArgs.provider && !parsedArgs.model.toLowerCase().startsWith(`${parsedArgs.provider.toLowerCase()}/`)
+			? `${parsedArgs.provider}/${parsedArgs.model}`
+			: parsedArgs.model
+		: !parsedArgs.continue && !parsedArgs.resume
+			? selectorHead(settingsInstance.getModelRole("default"))
+			: undefined;
+	await logger.time(
+		"refreshStartupModelProvider",
+		refreshMissingQualifiedModelProvider,
+		startupModelSelector,
+		modelRegistry,
+	);
 
 	let scopedModels: ScopedModel[] = [];
 	const modelPatterns = parsedArgs.models ?? settingsInstance.get("enabledModels");

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -32,10 +32,12 @@ import { findConfigFile } from "./config";
 import { activateModelProfile, ModelProfileCredentialError } from "./config/model-profile-activation";
 import { ModelRegistry, ModelsConfigFile } from "./config/model-registry";
 import {
+	parseModelString,
 	refreshMissingQualifiedModelProviders,
 	resolveCliModel,
 	resolveModelRoleValue,
 	resolveModelScope,
+	resolveStartupModelRefreshSelectors,
 	type ScopedModel,
 } from "./config/model-resolver";
 import { selectorHead } from "./config/model-selector-value";
@@ -55,7 +57,7 @@ import type { PrintModeOptions } from "./modes/print-mode";
 import { initTheme, stopThemeWatcher } from "./modes/theme/theme";
 import type { SubmittedUserInput } from "./modes/types";
 import { applyCliRuntimeApiKeyOverride } from "./runtime-api-key";
-import { parseCliCredentialSelector } from "./runtime-credential-selector";
+import { type CliCredentialSelector, parseCliCredentialSelector } from "./runtime-credential-selector";
 import type { MCPManager } from "./runtime-mcp";
 import {
 	type CreateAgentSessionOptions,
@@ -1651,14 +1653,59 @@ export async function runRootCommand(
 			)
 		: undefined;
 
-	const startupModelSelectors =
-		parsedArgs.model && !parsedArgs.credential
-			? parsedArgs.provider && !parsedArgs.model.toLowerCase().startsWith(`${parsedArgs.provider.toLowerCase()}/`)
-				? `${parsedArgs.provider}/${parsedArgs.model}`
-				: parsedArgs.model
-			: !parsedArgs.model && !parsedArgs.continue && !parsedArgs.resume
-				? settingsInstance.getModelRole("default")
-				: undefined;
+	if (parsedArgs.apiKey && parsedArgs.credential) {
+		process.stderr.write(`${chalk.red("--api-key and --credential cannot be used together")}\n`);
+		process.exit(1);
+	}
+	if (parsedArgs.credential && parsedArgs.preferCredential) {
+		process.stderr.write(`${chalk.red("--credential and --prefer-credential cannot be used together")}\n`);
+		process.exit(1);
+	}
+	if (parsedArgs.apiKey && parsedArgs.preferCredential) {
+		process.stderr.write(`${chalk.red("--api-key and --prefer-credential cannot be used together")}\n`);
+		process.exit(1);
+	}
+
+	let credentialSelector: CliCredentialSelector | undefined;
+	let preferredCredentialSelector: CliCredentialSelector | undefined;
+	try {
+		credentialSelector = parsedArgs.credential ? parseCliCredentialSelector(parsedArgs.credential) : undefined;
+		preferredCredentialSelector = parsedArgs.preferCredential
+			? parseCliCredentialSelector(parsedArgs.preferCredential)
+			: undefined;
+		if (preferredCredentialSelector) {
+			const provider =
+				preferredCredentialSelector.provider ??
+				authStorage.resolveRuntimePreferredCredentialSelectorProvider(preferredCredentialSelector.selector);
+			authStorage.setRuntimePreferredCredentialSelector(provider, preferredCredentialSelector.selector);
+		}
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		process.stderr.write(`${chalk.red(message)}\n`);
+		process.exit(1);
+	}
+
+	const hasRootStartupProfile = Boolean(settingsInstance.get("modelProfile.default") || parsedArgs.mpreset);
+	const startupModelSelectors = resolveStartupModelRefreshSelectors(
+		{
+			model: parsedArgs.model,
+			provider: parsedArgs.provider,
+			credential: parsedArgs.credential,
+			continue: parsedArgs.continue,
+			resume: parsedArgs.resume,
+			hasStartupProfile: hasRootStartupProfile,
+		},
+		settingsInstance,
+	);
+	const explicitStartupModelSelector = parsedArgs.model
+		? typeof startupModelSelectors === "string"
+			? startupModelSelectors
+			: parsedArgs.model
+		: undefined;
+	if (parsedArgs.apiKey && explicitStartupModelSelector) {
+		const parsedModel = parseModelString(explicitStartupModelSelector);
+		if (parsedModel) authStorage.setRuntimeApiKey(parsedModel.provider, parsedArgs.apiKey);
+	}
 	await logger.time(
 		"refreshStartupModelProviders",
 		refreshMissingQualifiedModelProviders,
@@ -1800,7 +1847,6 @@ export async function runRootCommand(
 	if (isInteractive && sessionOptions.mcpConfigPath) {
 		sessionOptions.deferMcpConfigStartup = true;
 	}
-	const hasRootStartupProfile = Boolean(settingsInstance.get("modelProfile.default") || parsedArgs.mpreset);
 	// ACP is not carved out: `gjc acp` is broker-backed and never builds a local
 	// session here, and the broker-launched lifecycle child defers memory startup
 	// unconditionally (createLifecycleAgentSession) so readiness never waits on
@@ -1811,37 +1857,8 @@ export async function runRootCommand(
 	const acpStartupOptions = mode === "acp" ? resolveAcpStartupOptions(parsedArgs, sessionOptions) : undefined;
 
 	// Handle CLI credential selection and --api-key as runtime overrides (not persisted).
-	if (parsedArgs.apiKey && parsedArgs.credential) {
-		process.stderr.write(`${chalk.red("--api-key and --credential cannot be used together")}\n`);
-		process.exit(1);
-	}
-	if (parsedArgs.credential && parsedArgs.preferCredential) {
-		process.stderr.write(`${chalk.red("--credential and --prefer-credential cannot be used together")}\n`);
-		process.exit(1);
-	}
-	if (parsedArgs.apiKey && parsedArgs.preferCredential) {
-		process.stderr.write(`${chalk.red("--api-key and --prefer-credential cannot be used together")}\n`);
-		process.exit(1);
-	}
-
-	if (parsedArgs.credential) {
-		try {
-			sessionOptions.credentialSelector = parseCliCredentialSelector(parsedArgs.credential);
-		} catch (error) {
-			const message = error instanceof Error ? error.message : String(error);
-			process.stderr.write(`${chalk.red(message)}\n`);
-			process.exit(1);
-		}
-	}
-	if (parsedArgs.preferCredential) {
-		try {
-			sessionOptions.preferredCredentialSelector = parseCliCredentialSelector(parsedArgs.preferCredential);
-		} catch (error) {
-			const message = error instanceof Error ? error.message : String(error);
-			process.stderr.write(`${chalk.red(message)}\n`);
-			process.exit(1);
-		}
-	}
+	if (credentialSelector) sessionOptions.credentialSelector = credentialSelector;
+	if (preferredCredentialSelector) sessionOptions.preferredCredentialSelector = preferredCredentialSelector;
 	if (parsedArgs.apiKey) {
 		if (!sessionOptions.model && !sessionOptions.modelPattern) {
 			process.stderr.write(

--- a/packages/coding-agent/test/startup-dynamic-model-refresh.test.ts
+++ b/packages/coding-agent/test/startup-dynamic-model-refresh.test.ts
@@ -1,14 +1,15 @@
 import { describe, expect, test } from "bun:test";
 import type { Model } from "@gajae-code/ai";
-import { refreshMissingQualifiedModelProvider } from "../src/config/model-resolver";
+import { refreshMissingQualifiedModelProviders } from "../src/config/model-resolver";
 
 const model = (provider: string, id: string): Model =>
 	({ provider, id, name: id, api: "anthropic-messages", contextWindow: 1_000_000, maxTokens: 131_072 }) as Model;
 
-function setup(options: { models?: Model[] } = {}) {
+function setup(options: { models?: Model[]; providers?: string[] } = {}) {
 	const refreshCalls: Array<[string, string]> = [];
 	const modelRegistry = {
 		getAvailable: () => options.models ?? [],
+		getDiscoverableProviders: () => options.providers ?? ["dynamic-provider", "glm-zcode"],
 		refreshProvider: async (provider: string, strategy: string) => {
 			refreshCalls.push([provider, strategy]);
 		},
@@ -20,7 +21,7 @@ describe("startup dynamic model refresh", () => {
 	test("refreshes the explicit provider when --model names a missing dynamic model", async () => {
 		const fixture = setup();
 
-		const refreshed = await refreshMissingQualifiedModelProvider(
+		const refreshed = await refreshMissingQualifiedModelProviders(
 			"dynamic-provider/new-model",
 			fixture.modelRegistry as never,
 		);
@@ -32,7 +33,7 @@ describe("startup dynamic model refresh", () => {
 	test("refreshes the configured default provider before a plain gjc launch", async () => {
 		const fixture = setup();
 
-		const refreshed = await refreshMissingQualifiedModelProvider(
+		const refreshed = await refreshMissingQualifiedModelProviders(
 			"glm-zcode/glm-5.3:xhigh",
 			fixture.modelRegistry as never,
 		);
@@ -46,7 +47,7 @@ describe("startup dynamic model refresh", () => {
 			models: [model("glm-zcode", "glm-5.3")],
 		});
 
-		const refreshed = await refreshMissingQualifiedModelProvider(
+		const refreshed = await refreshMissingQualifiedModelProviders(
 			"glm-zcode/glm-5.3:xhigh",
 			fixture.modelRegistry as never,
 		);
@@ -58,11 +59,38 @@ describe("startup dynamic model refresh", () => {
 	test("does not refresh an absent or unqualified selector", async () => {
 		const fixture = setup();
 
-		const absent = await refreshMissingQualifiedModelProvider(undefined, fixture.modelRegistry as never);
-		const unqualified = await refreshMissingQualifiedModelProvider("glm-5.3", fixture.modelRegistry as never);
+		const absent = await refreshMissingQualifiedModelProviders(undefined, fixture.modelRegistry as never);
+		const unqualified = await refreshMissingQualifiedModelProviders("glm-5.3", fixture.modelRegistry as never);
 
 		expect(absent).toBe(false);
 		expect(unqualified).toBe(false);
 		expect(fixture.refreshCalls).toEqual([]);
+	});
+
+	test("refreshes each missing provider in a configured fallback chain exactly once", async () => {
+		const fixture = setup({ providers: ["primary-provider", "fallback-provider"] });
+
+		const refreshed = await refreshMissingQualifiedModelProviders(
+			["primary-provider/new-model:high", "fallback-provider/fallback-model", "primary-provider/another-model"],
+			fixture.modelRegistry as never,
+		);
+
+		expect(refreshed).toBe(true);
+		expect(fixture.refreshCalls).toEqual([
+			["primary-provider", "online-if-uncached"],
+			["fallback-provider", "online-if-uncached"],
+		]);
+	});
+
+	test("canonicalizes provider casing and ignores unknown qualified providers", async () => {
+		const fixture = setup({ providers: ["glm-zcode"] });
+
+		const refreshed = await refreshMissingQualifiedModelProviders(
+			["GLM-ZCODE/glm-5.3:xhigh", "unknown-provider/model"],
+			fixture.modelRegistry as never,
+		);
+
+		expect(refreshed).toBe(true);
+		expect(fixture.refreshCalls).toEqual([["glm-zcode", "online-if-uncached"]]);
 	});
 });

--- a/packages/coding-agent/test/startup-dynamic-model-refresh.test.ts
+++ b/packages/coding-agent/test/startup-dynamic-model-refresh.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import type { Model } from "@gajae-code/ai";
+import { refreshMissingQualifiedModelProvider } from "../src/config/model-resolver";
+
+const model = (provider: string, id: string): Model =>
+	({ provider, id, name: id, api: "anthropic-messages", contextWindow: 1_000_000, maxTokens: 131_072 }) as Model;
+
+function setup(options: { models?: Model[] } = {}) {
+	const refreshCalls: Array<[string, string]> = [];
+	const modelRegistry = {
+		getAvailable: () => options.models ?? [],
+		refreshProvider: async (provider: string, strategy: string) => {
+			refreshCalls.push([provider, strategy]);
+		},
+	};
+	return { modelRegistry, refreshCalls };
+}
+
+describe("startup dynamic model refresh", () => {
+	test("refreshes the explicit provider when --model names a missing dynamic model", async () => {
+		const fixture = setup();
+
+		const refreshed = await refreshMissingQualifiedModelProvider(
+			"dynamic-provider/new-model",
+			fixture.modelRegistry as never,
+		);
+
+		expect(refreshed).toBe(true);
+		expect(fixture.refreshCalls).toEqual([["dynamic-provider", "online-if-uncached"]]);
+	});
+
+	test("refreshes the configured default provider before a plain gjc launch", async () => {
+		const fixture = setup();
+
+		const refreshed = await refreshMissingQualifiedModelProvider(
+			"glm-zcode/glm-5.3:xhigh",
+			fixture.modelRegistry as never,
+		);
+
+		expect(refreshed).toBe(true);
+		expect(fixture.refreshCalls).toEqual([["glm-zcode", "online-if-uncached"]]);
+	});
+
+	test("does not refresh when the startup model is already available", async () => {
+		const fixture = setup({
+			models: [model("glm-zcode", "glm-5.3")],
+		});
+
+		const refreshed = await refreshMissingQualifiedModelProvider(
+			"glm-zcode/glm-5.3:xhigh",
+			fixture.modelRegistry as never,
+		);
+
+		expect(refreshed).toBe(false);
+		expect(fixture.refreshCalls).toEqual([]);
+	});
+
+	test("does not refresh an absent or unqualified selector", async () => {
+		const fixture = setup();
+
+		const absent = await refreshMissingQualifiedModelProvider(undefined, fixture.modelRegistry as never);
+		const unqualified = await refreshMissingQualifiedModelProvider("glm-5.3", fixture.modelRegistry as never);
+
+		expect(absent).toBe(false);
+		expect(unqualified).toBe(false);
+		expect(fixture.refreshCalls).toEqual([]);
+	});
+});

--- a/packages/coding-agent/test/startup-dynamic-model-refresh.test.ts
+++ b/packages/coding-agent/test/startup-dynamic-model-refresh.test.ts
@@ -1,6 +1,14 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, test, vi } from "bun:test";
+import * as path from "node:path";
 import type { Model } from "@gajae-code/ai";
-import { refreshMissingQualifiedModelProviders } from "../src/config/model-resolver";
+import { TempDir } from "@gajae-code/utils";
+import { ModelRegistry } from "../src/config/model-registry";
+import {
+	refreshMissingQualifiedModelProviders,
+	resolveStartupModelRefreshSelectors,
+} from "../src/config/model-resolver";
+import { Settings } from "../src/config/settings";
+import { AuthStorage } from "../src/session/auth-storage";
 
 const model = (provider: string, id: string): Model =>
 	({ provider, id, name: id, api: "anthropic-messages", contextWindow: 1_000_000, maxTokens: 131_072 }) as Model;
@@ -56,6 +64,20 @@ describe("startup dynamic model refresh", () => {
 		expect(fixture.refreshCalls).toEqual([]);
 	});
 
+	test("does not refresh an available concrete selector whose suffix resembles thinking", async () => {
+		const fixture = setup({
+			models: [model("dynamic-provider", "new-model:high")],
+		});
+
+		const refreshed = await refreshMissingQualifiedModelProviders(
+			"dynamic-provider/new-model:high",
+			fixture.modelRegistry as never,
+		);
+
+		expect(refreshed).toBe(false);
+		expect(fixture.refreshCalls).toEqual([]);
+	});
+
 	test("does not refresh an absent or unqualified selector", async () => {
 		const fixture = setup();
 
@@ -92,5 +114,49 @@ describe("startup dynamic model refresh", () => {
 
 		expect(refreshed).toBe(true);
 		expect(fixture.refreshCalls).toEqual([["glm-zcode", "online-if-uncached"]]);
+	});
+
+	test("preserves explicit provider qualifiers and suppresses credential, profile, and resume refreshes", () => {
+		const settings = Settings.isolated({ modelRoles: { default: "dynamic-provider/default-model" } });
+
+		expect(
+			resolveStartupModelRefreshSelectors(
+				{ model: "new-model", provider: "dynamic-provider", hasStartupProfile: false },
+				settings,
+			),
+		).toBe("dynamic-provider/new-model");
+		expect(
+			resolveStartupModelRefreshSelectors(
+				{ model: "dynamic-provider/new-model", provider: "dynamic-provider", hasStartupProfile: true },
+				settings,
+			),
+		).toBe("dynamic-provider/new-model");
+		expect(
+			resolveStartupModelRefreshSelectors(
+				{ credential: "dynamic-provider/id:1", hasStartupProfile: false },
+				settings,
+			),
+		).toBeUndefined();
+		expect(resolveStartupModelRefreshSelectors({ hasStartupProfile: true }, settings)).toBeUndefined();
+		expect(resolveStartupModelRefreshSelectors({ resume: true, hasStartupProfile: false }, settings)).toBeUndefined();
+	});
+
+	test("provider-scoped refresh does not resolve unrelated provider credentials", async () => {
+		using tempDir = TempDir.createSync("@gjc-startup-provider-scope-");
+		const authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+		authStorage.setRuntimeApiKey("google", "test-key");
+		const credentialProviders: string[] = [];
+		const peekSpy = vi.spyOn(authStorage, "peekApiKey").mockImplementation(async provider => {
+			credentialProviders.push(provider);
+			return provider === "google" ? "test-key" : undefined;
+		});
+		const registry = new ModelRegistry(authStorage, path.join(tempDir.path(), "models.yml"));
+		try {
+			await registry.refreshProvider("google", "offline");
+			expect(credentialProviders).toEqual(["google"]);
+		} finally {
+			peekSpy.mockRestore();
+			authStorage.close();
+		}
 	});
 });


### PR DESCRIPTION
## Problem
Plain `gjc` and explicit `--model` launches could resolve a provider-qualified startup selector before that provider's dynamic catalog was loaded. Users whose configured default exists only in discovery, such as `glm-zcode/glm-5.3:xhigh`, opened in `no-model` state even though `gjc models` listed the model and profile activation could use it.

Fixes #5274.

## Why
This is a shared startup-ordering defect rather than a GLM/ZCode authentication issue. Refreshing every provider on every launch would add unnecessary network work, so the retry is scoped to the provider named by a missing qualified startup selector and uses the existing `online-if-uncached` strategy. Already available models retain the cache-only fast path; resume/continue launches without an explicit override do not gain a foreground refresh.

## What changed
- refresh only the missing qualified startup provider before model scope/session option resolution
- preserve `--provider p --model p/id` and `--provider p --model id` forms
- canonicalize provider casing, ignore unknown provider qualifiers, and refresh each provider in a configured fallback chain at most once
- add generic regression coverage for explicit, configured-default, cached, and absent/unqualified selectors
- document the user-visible fix in the coding-agent changelog

## Testing
- focused startup/cache/auth suites — 168 pass
- `bun test packages/coding-agent/test/model-registry.test.ts` — 312 pass
- adjacent profile/discovery suites — 106 pass
- `bun --cwd=packages/coding-agent run check` — pass
- `bun --cwd=packages/coding-agent run build` — pass
- independent base/head probe: base `f0c7f4b0c5d` exited 1 with no model; exact head returned `REPRO_FIXED`
- plain source launch using configured `glm-zcode/glm-5.3:xhigh` returned `PLAIN_GJC_OK`
- explicit `--provider glm-zcode --model glm-zcode/glm-5.3` returned `EXPLICIT_GLM53_OK`
- adversarial nonexistent `glm-zcode/definitely-not-a-model` remained fail-closed with exit 1 and `Model not found`
- `bun --cwd=packages/coding-agent run check` and `bun --cwd=packages/ai run check` — pass

## Risk classification

- [ ] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [x] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:70a05a28c289611ddade653f4b72db35e886de59f94827d5185f4cafe8f48eec reviewer:human reviewer-id:Yeachan-Heo evidence:https://github.com/Yeachan-Heo/gajae-code/pull/5275#pullrequestreview-5112987267
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken






