### PR TITLE
feat(settings): add status line custom editor

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+
+- Status-line settings now include a draft-local spatial custom editor with exact-slot keyboard reordering, hidden-segment palette management, command text configuration, persisted Confirm/Exit semantics, live multi-row preview compatibility, narrow/Unicode rendering, and deterministic visual evidence.
+
 ### Fixed
 
 - Plain and explicit-model launches now refresh a missing provider's cached dynamic catalog before resolving a qualified startup selector, so configured models such as `glm-zcode/glm-5.3` no longer open in `no-model` state while preserving cache-only startup for already available models.

--- a/packages/coding-agent/scripts/capture-status-line-custom-editor-showcase.ts
+++ b/packages/coding-agent/scripts/capture-status-line-custom-editor-showcase.ts
@@ -10,6 +10,14 @@ import { ansiToHtml } from "./capture-sticky-viewport-showcase";
 const CANONICAL_COMMAND =
 	"bun packages/coding-agent/scripts/capture-status-line-custom-editor-showcase.ts --out .gjc/qa/status-line-custom-editor-<run>";
 const CAPTURE_TOOL_VERSION = "status-line-custom-editor-showcase-v1";
+const SOURCE_PATHS = [
+	"packages/coding-agent/src/modes/components/settings-selector.ts",
+	"packages/coding-agent/src/modes/components/tool-status-header.ts",
+	"packages/coding-agent/src/modes/controllers/selector-controller.ts",
+	"packages/tui/src/components/settings-list.ts",
+	"packages/coding-agent/test/fixtures/tui/status-line-custom-editor-showcase.ts",
+	"packages/coding-agent/scripts/verify-status-line-custom-editor-showcase.ts",
+] as const;
 
 interface ArtifactFile {
 	path: string;
@@ -22,6 +30,7 @@ interface ManifestEntry {
 	stateId: string;
 	viewport: { columns: number; rows: number };
 	renderMode: string;
+	simulatedStatusbarRows: number;
 	files: ArtifactFile[];
 }
 
@@ -42,12 +51,31 @@ function sha256(value: string): string {
 	return new Bun.CryptoHasher("sha256").update(value).digest("hex");
 }
 
+function commandOutput(command: string[]): string | undefined {
+	const result = Bun.spawnSync({ cmd: command, stdout: "pipe", stderr: "pipe" });
+	if (result.exitCode !== 0) return undefined;
+	const output = result.stdout.toString().trim();
+	return output || undefined;
+}
+
+async function sourceHash(): Promise<string> {
+	const entries = await Promise.all(
+		SOURCE_PATHS.map(async sourcePath => `${sourcePath}:${sha256(await Bun.file(sourcePath).text())}`),
+	);
+	return `sha256:${sha256(entries.join("\n"))}`;
+}
+
 function entryKey(entry: StatusLineCustomEditorShowcaseEntry): string {
 	return `${entry.stateId}/${entry.columns}x${entry.rows}/${entry.renderMode}`;
 }
 
-function clipRows(text: string, rows: number): string {
-	return text.split("\n").slice(0, rows).join("\n");
+function simulatedStatusbarRows(text: string): number {
+	const lines = Bun.stripANSI(text).split("\n");
+	const heading = lines.findIndex(line => line.includes("Simulated statusbar"));
+	if (heading < 0) return 0;
+	let end = heading + 1;
+	while (end < lines.length && lines[end]?.trim() && !lines[end]?.includes("Warning:")) end++;
+	return Math.max(0, end - heading - 1);
 }
 
 async function writeArtifact(root: string, relativePath: string, content: string): Promise<ArtifactFile> {
@@ -59,6 +87,10 @@ async function writeArtifact(root: string, relativePath: string, content: string
 
 async function main(): Promise<void> {
 	const root = outputPath(process.argv.slice(2));
+	const sourceHead = commandOutput(["git", "rev-parse", "HEAD"]);
+	if (!sourceHead) throw new Error("Could not resolve source HEAD");
+	const captureActor = commandOutput(["gh", "api", "user", "--jq", ".login"]) ?? "unauthenticated";
+	const digest = await sourceHash();
 	const independentReviewPath = path.join(root, "independent-review.json");
 	const existingIndependentReview = (await Bun.file(independentReviewPath).exists())
 		? await Bun.file(independentReviewPath).text()
@@ -72,7 +104,12 @@ async function main(): Promise<void> {
 	for (const entry of STATUS_LINE_CUSTOM_EDITOR_SHOWCASE_ENTRIES) {
 		const key = entryKey(entry);
 		const dir = key.replace(/[^a-zA-Z0-9._/-]/g, "_");
-		const terminalAnsi = clipRows(await renderStatusLineCustomEditorShowcase(entry), entry.rows);
+		const terminalAnsi = await renderStatusLineCustomEditorShowcase(entry);
+		const renderedRows = terminalAnsi.split("\n").length;
+		if (renderedRows > entry.rows) {
+			throw new Error(`${key}: rendered ${renderedRows} rows for a ${entry.rows}-row viewport`);
+		}
+		const statusbarRows = simulatedStatusbarRows(terminalAnsi);
 		const terminalPlain = Bun.stripANSI(terminalAnsi);
 		const html = ansiToHtml(terminalAnsi);
 		const metadata = json({
@@ -82,7 +119,8 @@ async function main(): Promise<void> {
 			viewport: { columns: entry.columns, rows: entry.rows },
 			renderMode: entry.renderMode,
 			fixedClock: "2026-01-01T00:00:00.000Z",
-			wrappingPolicy: entry.columns < 64 ? "two-row-warning" : "single-row-when-fits",
+			simulatedStatusbarRows: statusbarRows,
+			wrappingPolicy: statusbarRows > 2 ? "two-row" : "single-row",
 		});
 		const files = [
 			await writeArtifact(root, `${dir}/terminal.txt`, terminalPlain),
@@ -95,10 +133,15 @@ async function main(): Promise<void> {
 			stateId: entry.stateId,
 			viewport: { columns: entry.columns, rows: entry.rows },
 			renderMode: entry.renderMode,
+			simulatedStatusbarRows: statusbarRows,
 			files,
 		});
 	}
-	await writeArtifact(root, "manifest.json", json({ tool: CAPTURE_TOOL_VERSION, entries }));
+	await writeArtifact(
+		root,
+		"manifest.json",
+		json({ tool: CAPTURE_TOOL_VERSION, sourceHead, sourceHash: digest, captureActor, entries }),
+	);
 	process.stdout.write(`Captured ${entries.length} status-line custom editor showcase entries at ${root}\n`);
 }
 

--- a/packages/coding-agent/scripts/capture-status-line-custom-editor-showcase.ts
+++ b/packages/coding-agent/scripts/capture-status-line-custom-editor-showcase.ts
@@ -1,0 +1,108 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import {
+	renderStatusLineCustomEditorShowcase,
+	STATUS_LINE_CUSTOM_EDITOR_SHOWCASE_ENTRIES,
+	type StatusLineCustomEditorShowcaseEntry,
+} from "../test/fixtures/tui/status-line-custom-editor-showcase";
+import { ansiToHtml } from "./capture-sticky-viewport-showcase";
+
+const CANONICAL_COMMAND =
+	"bun packages/coding-agent/scripts/capture-status-line-custom-editor-showcase.ts --out .gjc/qa/status-line-custom-editor-<run>";
+const CAPTURE_TOOL_VERSION = "status-line-custom-editor-showcase-v1";
+
+interface ArtifactFile {
+	path: string;
+	sha256: string;
+	byte_length: number;
+}
+
+interface ManifestEntry {
+	key: string;
+	stateId: string;
+	viewport: { columns: number; rows: number };
+	renderMode: string;
+	files: ArtifactFile[];
+}
+
+function usage(): never {
+	throw new Error(`Usage: ${CANONICAL_COMMAND}`);
+}
+
+function outputPath(args: string[]): string {
+	if (args.length !== 2 || args[0] !== "--out" || !args[1]) usage();
+	return args[1];
+}
+
+function json(value: unknown): string {
+	return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+function sha256(value: string): string {
+	return new Bun.CryptoHasher("sha256").update(value).digest("hex");
+}
+
+function entryKey(entry: StatusLineCustomEditorShowcaseEntry): string {
+	return `${entry.stateId}/${entry.columns}x${entry.rows}/${entry.renderMode}`;
+}
+
+function clipRows(text: string, rows: number): string {
+	return text.split("\n").slice(0, rows).join("\n");
+}
+
+async function writeArtifact(root: string, relativePath: string, content: string): Promise<ArtifactFile> {
+	const fullPath = path.join(root, relativePath);
+	await fs.mkdir(path.dirname(fullPath), { recursive: true });
+	await Bun.write(fullPath, content);
+	return { path: relativePath, sha256: sha256(content), byte_length: Buffer.byteLength(content) };
+}
+
+async function main(): Promise<void> {
+	const root = outputPath(process.argv.slice(2));
+	const independentReviewPath = path.join(root, "independent-review.json");
+	const existingIndependentReview = (await Bun.file(independentReviewPath).exists())
+		? await Bun.file(independentReviewPath).text()
+		: undefined;
+	await fs.rm(root, { recursive: true, force: true });
+	await fs.mkdir(root, { recursive: true });
+	if (existingIndependentReview !== undefined) {
+		await Bun.write(independentReviewPath, existingIndependentReview);
+	}
+	const entries: ManifestEntry[] = [];
+	for (const entry of STATUS_LINE_CUSTOM_EDITOR_SHOWCASE_ENTRIES) {
+		const key = entryKey(entry);
+		const dir = key.replace(/[^a-zA-Z0-9._/-]/g, "_");
+		const terminalAnsi = clipRows(await renderStatusLineCustomEditorShowcase(entry), entry.rows);
+		const terminalPlain = Bun.stripANSI(terminalAnsi);
+		const html = ansiToHtml(terminalAnsi);
+		const metadata = json({
+			tool: CAPTURE_TOOL_VERSION,
+			command: CANONICAL_COMMAND,
+			stateId: entry.stateId,
+			viewport: { columns: entry.columns, rows: entry.rows },
+			renderMode: entry.renderMode,
+			fixedClock: "2026-01-01T00:00:00.000Z",
+			wrappingPolicy: entry.columns < 64 ? "two-row-warning" : "single-row-when-fits",
+		});
+		const files = [
+			await writeArtifact(root, `${dir}/terminal.txt`, terminalPlain),
+			await writeArtifact(root, `${dir}/terminal-ansi.txt`, terminalAnsi),
+			await writeArtifact(root, `${dir}/terminal.html`, html),
+			await writeArtifact(root, `${dir}/metadata.json`, metadata),
+		];
+		entries.push({
+			key,
+			stateId: entry.stateId,
+			viewport: { columns: entry.columns, rows: entry.rows },
+			renderMode: entry.renderMode,
+			files,
+		});
+	}
+	await writeArtifact(root, "manifest.json", json({ tool: CAPTURE_TOOL_VERSION, entries }));
+	process.stdout.write(`Captured ${entries.length} status-line custom editor showcase entries at ${root}\n`);
+}
+
+void main().catch(error => {
+	process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+	process.exit(1);
+});

--- a/packages/coding-agent/scripts/verify-status-line-custom-editor-showcase.ts
+++ b/packages/coding-agent/scripts/verify-status-line-custom-editor-showcase.ts
@@ -1,0 +1,253 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { STATUS_LINE_CUSTOM_EDITOR_SHOWCASE_ENTRIES } from "../test/fixtures/tui/status-line-custom-editor-showcase";
+import { ansiToHtml } from "./capture-sticky-viewport-showcase";
+
+const CAPTURE_TOOL_VERSION = "status-line-custom-editor-showcase-v1";
+const CANONICAL_COMMAND =
+	"bun packages/coding-agent/scripts/capture-status-line-custom-editor-showcase.ts --out .gjc/qa/status-line-custom-editor-<run>";
+const FIXED_CLOCK = "2026-01-01T00:00:00.000Z";
+
+function expectedWrappingPolicy(columns: number): string {
+	return columns < 64 ? "two-row-warning" : "single-row-when-fits";
+}
+
+interface ManifestFile {
+	tool: string;
+	entries: Array<{
+		key: string;
+		stateId: string;
+		viewport: { columns: number; rows: number };
+		renderMode: string;
+		files: Array<{ path: string; sha256: string; byte_length: number }>;
+	}>;
+	independentReview?: {
+		reviewer: string;
+		verdict: "approved" | "rejected";
+		evidence: string;
+		manifestSha256?: string;
+		sourceHash?: string;
+	};
+}
+
+function sha256(value: string): string {
+	return new Bun.CryptoHasher("sha256").update(value).digest("hex");
+}
+
+function expectedKey(entry: (typeof STATUS_LINE_CUSTOM_EDITOR_SHOWCASE_ENTRIES)[number]): string {
+	return `${entry.stateId}/${entry.columns}x${entry.rows}/${entry.renderMode}`;
+}
+
+function parseArgs(args: string[]): { root: string; requireIndependentReview: boolean } {
+	let root = "";
+	let requireIndependentReview = false;
+	for (let i = 0; i < args.length; i++) {
+		const arg = args[i];
+		if (arg === "--root") root = args[++i] ?? "";
+		else if (arg === "--require-independent-review") requireIndependentReview = true;
+		else throw new Error(`Unknown argument: ${arg}`);
+	}
+	if (!root) {
+		throw new Error(
+			"Usage: bun packages/coding-agent/scripts/verify-status-line-custom-editor-showcase.ts --root <dir> [--require-independent-review]",
+		);
+	}
+	return { root, requireIndependentReview };
+}
+
+async function readText(root: string, relativePath: string): Promise<string> {
+	const fullPath = path.resolve(root, relativePath);
+	const resolvedRoot = path.resolve(root);
+	if (!fullPath.startsWith(`${resolvedRoot}${path.sep}`)) throw new Error(`Artifact escapes root: ${relativePath}`);
+	return await Bun.file(fullPath).text();
+}
+
+async function tryReadReview(root: string): Promise<ManifestFile["independentReview"] | undefined> {
+	const reviewPath = path.join(root, "independent-review.json");
+	if (!(await Bun.file(reviewPath).exists())) return undefined;
+	return JSON.parse(await Bun.file(reviewPath).text()) as ManifestFile["independentReview"];
+}
+
+async function collectRelativeFiles(root: string, dir = ""): Promise<string[]> {
+	const fullDir = path.join(root, dir);
+	const entries = await fs.readdir(fullDir, { withFileTypes: true });
+	const files: string[] = [];
+	for (const entry of entries) {
+		const relative = dir ? `${dir}/${entry.name}` : entry.name;
+		if (entry.isDirectory()) {
+			files.push(...(await collectRelativeFiles(root, relative)));
+		} else if (entry.isFile()) {
+			files.push(relative);
+		}
+	}
+	return files;
+}
+
+function requireWitness(entry: ManifestFile["entries"][number], plain: string): void {
+	if (entry.stateId === "exit-restored" || entry.stateId === "confirm-persisted") {
+		if (!plain.includes("Status Line")) throw new Error(`${entry.key}: missing returned settings witness`);
+		return;
+	}
+	const baseWitnesses = [
+		"Status Line Custom Editor",
+		"Simulated statusbar",
+		"Hidden segment palette",
+		"Visible choices",
+	];
+	for (const witness of baseWitnesses) {
+		if (!plain.includes(witness)) throw new Error(`${entry.key}: missing witness ${witness}`);
+	}
+	if (entry.stateId.includes("choice-focused") && !plain.includes("Choices:")) {
+		throw new Error(`${entry.key}: missing choice panel witness`);
+	}
+	if (
+		entry.stateId === "picked-origin-slot" &&
+		(!plain.includes("Selected:") || plain.includes("Floating ghost") || plain.includes("Origin "))
+	) {
+		throw new Error(`${entry.key}: missing selected witness or stale ghost/origin text present`);
+	}
+	if (entry.stateId.includes("overflow") && !plain.includes("Warning: statusbar wrapped to 2 rows")) {
+		throw new Error(`${entry.key}: missing overflow warning`);
+	}
+	if (entry.stateId === "narrow-cjk" && !/[\u3131-\uD7A3\u3040-\u30FF\u3400-\u9FFF]/.test(plain)) {
+		throw new Error(`${entry.key}: missing CJK width witness`);
+	}
+	if (plain.includes("Move left:") || plain.includes("Move right:") || plain.includes("Segment: gajae")) {
+		throw new Error(`${entry.key}: legacy row witness present`);
+	}
+}
+
+async function main(): Promise<void> {
+	const { root, requireIndependentReview } = parseArgs(process.argv.slice(2));
+	const manifestText = await Bun.file(path.join(root, "manifest.json")).text();
+	const manifest = JSON.parse(manifestText) as ManifestFile;
+	const manifestSha256 = sha256(manifestText);
+	if (manifest.tool !== CAPTURE_TOOL_VERSION) throw new Error(`Unexpected tool version: ${manifest.tool}`);
+	const expectedKeys = new Set(STATUS_LINE_CUSTOM_EDITOR_SHOWCASE_ENTRIES.map(expectedKey));
+	const actualKeys = new Set(manifest.entries.map(entry => entry.key));
+	if (manifest.entries.length !== actualKeys.size) throw new Error("Duplicate showcase entries found");
+	if (manifest.entries.length !== expectedKeys.size) throw new Error("Unexpected showcase entry count");
+	for (const key of expectedKeys) if (!actualKeys.has(key)) throw new Error(`Missing showcase key: ${key}`);
+	if (requireIndependentReview) {
+		const review = manifest.independentReview ?? (await tryReadReview(root));
+		if (
+			review?.verdict !== "approved" ||
+			!review.evidence ||
+			review.manifestSha256 !== manifestSha256 ||
+			!review.sourceHash?.startsWith("sha256:")
+		) {
+			throw new Error("Missing approved independent review in manifest");
+		}
+	}
+	const artifactPaths = new Set<string>();
+	const expectedRootFiles = new Set(["manifest.json"]);
+	if (await Bun.file(path.join(root, "independent-review.json")).exists())
+		expectedRootFiles.add("independent-review.json");
+	for (const entry of manifest.entries) {
+		if (entry.key !== `${entry.stateId}/${entry.viewport.columns}x${entry.viewport.rows}/${entry.renderMode}`) {
+			throw new Error(`${entry.key}: key does not match manifest fields`);
+		}
+		const expectedDirectory = entry.key.replace(/[^a-zA-Z0-9._/-]/g, "_");
+		const names = new Set(entry.files.map(file => path.basename(file.path)));
+		if (names.size !== 4 || entry.files.length !== 4)
+			throw new Error(`${entry.key}: artifact membership is not exact`);
+		for (const required of ["terminal.txt", "terminal-ansi.txt", "terminal.html", "metadata.json"]) {
+			if (!names.has(required)) throw new Error(`${entry.key}: missing ${required}`);
+		}
+		for (const file of entry.files) {
+			if (!file.path.startsWith(`${expectedDirectory}/`)) {
+				throw new Error(`${entry.key}: artifact path is not bound to canonical entry directory`);
+			}
+			if (artifactPaths.has(file.path)) throw new Error(`${entry.key}: duplicate artifact path ${file.path}`);
+			artifactPaths.add(file.path);
+			const content = await readText(root, file.path);
+			if (sha256(content) !== file.sha256) throw new Error(`${entry.key}: sha mismatch for ${file.path}`);
+			if (Buffer.byteLength(content) !== file.byte_length) {
+				throw new Error(`${entry.key}: byte length mismatch for ${file.path}`);
+			}
+		}
+		const plainPath = entry.files.find(file => path.basename(file.path) === "terminal.txt")?.path;
+		const ansiPath = entry.files.find(file => path.basename(file.path) === "terminal-ansi.txt")?.path;
+		const htmlPath = entry.files.find(file => path.basename(file.path) === "terminal.html")?.path;
+		const metadataPath = entry.files.find(file => path.basename(file.path) === "metadata.json")?.path;
+		if (!plainPath || !ansiPath || !htmlPath || !metadataPath) throw new Error(`${entry.key}: incomplete file list`);
+		const plain = await readText(root, plainPath);
+		const ansi = await readText(root, ansiPath);
+		const html = await readText(root, htmlPath);
+		if (Bun.stripANSI(ansi) !== plain) throw new Error(`${entry.key}: stripped ANSI differs from plain text`);
+		if (html !== ansiToHtml(ansi)) throw new Error(`${entry.key}: HTML artifact is not canonical ANSI conversion`);
+		if (plain.split("\n").length > entry.viewport.rows) {
+			throw new Error(`${entry.key}: terminal row count exceeds declared viewport`);
+		}
+		for (const line of plain.split("\n")) {
+			if (Bun.stringWidth(line) > entry.viewport.columns) {
+				throw new Error(`${entry.key}: terminal line exceeds declared viewport width`);
+			}
+		}
+		if (entry.renderMode === "ascii-no-color") {
+			if (/\x1b\[[0-9;]*m/.test(ansi)) throw new Error(`${entry.key}: ascii-no-color artifact contains ANSI`);
+			if (/[^\x09\x0a\x0d\x20-\x7e]/.test(plain)) {
+				throw new Error(`${entry.key}: ascii-no-color artifact contains non-ASCII glyphs`);
+			}
+		}
+		const metadata = JSON.parse(await readText(root, metadataPath)) as {
+			tool?: string;
+			command?: string;
+			stateId?: string;
+			viewport?: { columns?: number; rows?: number };
+			renderMode?: string;
+			fixedClock?: string;
+			wrappingPolicy?: string;
+		};
+		if (
+			metadata.tool !== CAPTURE_TOOL_VERSION ||
+			metadata.command !== CANONICAL_COMMAND ||
+			metadata.stateId !== entry.stateId ||
+			metadata.viewport?.columns !== entry.viewport.columns ||
+			metadata.viewport?.rows !== entry.viewport.rows ||
+			metadata.renderMode !== entry.renderMode ||
+			metadata.fixedClock !== FIXED_CLOCK ||
+			metadata.wrappingPolicy !== expectedWrappingPolicy(entry.viewport.columns)
+		) {
+			throw new Error(`${entry.key}: metadata does not match manifest`);
+		}
+		requireWitness(entry, plain);
+		if (entry.stateId === "palette-exact-insert" && (plain.includes("Selected:") || plain.includes("{gajae}"))) {
+			throw new Error(`${entry.key}: exact insertion state still has floating/hidden segment evidence`);
+		}
+		if (entry.stateId === "palette-exact-insert" && !plain.includes("left model / path /")) {
+			throw new Error(`${entry.key}: exact insertion state missing ordered layout witness`);
+		}
+		if (
+			entry.stateId === "exit-restored" &&
+			!plain.includes("left=model,path,git right=session_name,jobs separator=slash")
+		) {
+			throw new Error(`${entry.key}: exit-restored state missing exact restored preview witness`);
+		}
+		if (
+			entry.stateId === "confirm-persisted" &&
+			!plain.includes("left=path,git right=session_name,jobs separator=slash")
+		) {
+			throw new Error(`${entry.key}: confirm-persisted state missing exact persisted preview witness`);
+		}
+		if (entry.stateId === "separator-choice-applied" && !plain.includes("[Pipe]")) {
+			throw new Error(`${entry.key}: separator applied state missing Pipe witness`);
+		}
+		if (entry.stateId === "option-choice-applied" && !plain.includes("[40]")) {
+			throw new Error(`${entry.key}: option applied state missing numeric option witness`);
+		}
+		if (entry.stateId.includes("narrow") && !plain.includes("Focused target:")) {
+			throw new Error(`${entry.key}: narrow state missing focused target witness`);
+		}
+	}
+	for (const filePath of await collectRelativeFiles(root)) {
+		if (expectedRootFiles.has(filePath)) continue;
+		if (!artifactPaths.has(filePath)) throw new Error(`Unmanifested artifact file: ${filePath}`);
+	}
+	process.stdout.write(`Verified ${manifest.entries.length} status-line custom editor showcase entries at ${root}\n`);
+}
+
+void main().catch(error => {
+	process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+	process.exit(1);
+});

--- a/packages/coding-agent/scripts/verify-status-line-custom-editor-showcase.ts
+++ b/packages/coding-agent/scripts/verify-status-line-custom-editor-showcase.ts
@@ -1,6 +1,5 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { STATUS_LINE_CUSTOM_EDITOR_SHOWCASE_ENTRIES } from "../test/fixtures/tui/status-line-custom-editor-showcase";
 import { ansiToHtml } from "./capture-sticky-viewport-showcase";
 
 const CAPTURE_TOOL_VERSION = "status-line-custom-editor-showcase-v1";
@@ -8,25 +7,61 @@ const CANONICAL_COMMAND =
 	"bun packages/coding-agent/scripts/capture-status-line-custom-editor-showcase.ts --out .gjc/qa/status-line-custom-editor-<run>";
 const FIXED_CLOCK = "2026-01-01T00:00:00.000Z";
 
-function expectedWrappingPolicy(columns: number): string {
-	return columns < 64 ? "two-row-warning" : "single-row-when-fits";
+const UNICODE_STATES = [
+	"root-statusbar",
+	"picked-origin-slot",
+	"palette-exact-insert",
+	"separator-control",
+	"separator-choice-focused",
+	"separator-choice-applied",
+	"option-boolean-choice-focused",
+	"option-enum-choice-focused",
+	"option-numeric-choice-focused",
+	"option-choice-applied",
+	"exit-restored",
+	"confirm-persisted",
+	"overflow-two-row-warning",
+] as const;
+const ASCII_STATES = [
+	"root-statusbar",
+	"picked-origin-slot",
+	"separator-choice-focused",
+	"option-boolean-choice-focused",
+	"option-enum-choice-focused",
+	"option-numeric-choice-focused",
+] as const;
+const EXPECTED_KEYS = new Set([
+	...UNICODE_STATES.map(state => `${state}/80x32/unicode-color`),
+	"overflow-two-row-warning/48x40/unicode-color",
+	"narrow-cjk/48x40/unicode-color",
+	...ASCII_STATES.map(state => `${state}/80x32/ascii-no-color`),
+]);
+
+function expectedWrappingPolicy(statusbarRows: number): string {
+	return statusbarRows > 2 ? "two-row" : "single-row";
 }
 
 interface ManifestFile {
 	tool: string;
+	sourceHead: string;
+	sourceHash: string;
+	captureActor: string;
 	entries: Array<{
 		key: string;
 		stateId: string;
 		viewport: { columns: number; rows: number };
 		renderMode: string;
+		simulatedStatusbarRows: number;
 		files: Array<{ path: string; sha256: string; byte_length: number }>;
 	}>;
 	independentReview?: {
 		reviewer: string;
+		reviewerAssociation: "OWNER" | "MEMBER" | "COLLABORATOR";
 		verdict: "approved" | "rejected";
 		evidence: string;
 		manifestSha256?: string;
 		sourceHash?: string;
+		headSha?: string;
 	};
 }
 
@@ -34,8 +69,13 @@ function sha256(value: string): string {
 	return new Bun.CryptoHasher("sha256").update(value).digest("hex");
 }
 
-function expectedKey(entry: (typeof STATUS_LINE_CUSTOM_EDITOR_SHOWCASE_ENTRIES)[number]): string {
-	return `${entry.stateId}/${entry.columns}x${entry.rows}/${entry.renderMode}`;
+function measuredStatusbarRows(plain: string): number {
+	const lines = plain.split("\n");
+	const heading = lines.findIndex(line => line.includes("Simulated statusbar"));
+	if (heading < 0) return 0;
+	let end = heading + 1;
+	while (end < lines.length && lines[end]?.trim() && !lines[end]?.includes("Warning:")) end++;
+	return Math.max(0, end - heading - 1);
 }
 
 function parseArgs(args: string[]): { root: string; requireIndependentReview: boolean } {
@@ -123,18 +163,24 @@ async function main(): Promise<void> {
 	const manifest = JSON.parse(manifestText) as ManifestFile;
 	const manifestSha256 = sha256(manifestText);
 	if (manifest.tool !== CAPTURE_TOOL_VERSION) throw new Error(`Unexpected tool version: ${manifest.tool}`);
-	const expectedKeys = new Set(STATUS_LINE_CUSTOM_EDITOR_SHOWCASE_ENTRIES.map(expectedKey));
+	if (!/^[0-9a-f]{40}$/.test(manifest.sourceHead)) throw new Error("Manifest source HEAD is not a full commit SHA");
+	if (!/^sha256:[0-9a-f]{64}$/.test(manifest.sourceHash)) throw new Error("Manifest source hash is invalid");
 	const actualKeys = new Set(manifest.entries.map(entry => entry.key));
 	if (manifest.entries.length !== actualKeys.size) throw new Error("Duplicate showcase entries found");
-	if (manifest.entries.length !== expectedKeys.size) throw new Error("Unexpected showcase entry count");
-	for (const key of expectedKeys) if (!actualKeys.has(key)) throw new Error(`Missing showcase key: ${key}`);
+	if (manifest.entries.length !== EXPECTED_KEYS.size) throw new Error("Unexpected showcase entry count");
+	for (const key of EXPECTED_KEYS) if (!actualKeys.has(key)) throw new Error(`Missing showcase key: ${key}`);
+	for (const key of actualKeys) if (!EXPECTED_KEYS.has(key)) throw new Error(`Unexpected showcase key: ${key}`);
 	if (requireIndependentReview) {
 		const review = manifest.independentReview ?? (await tryReadReview(root));
 		if (
 			review?.verdict !== "approved" ||
-			!review.evidence ||
+			!review.reviewer?.trim() ||
+			review.reviewer === manifest.captureActor ||
+			!(["OWNER", "MEMBER", "COLLABORATOR"] as const).includes(review.reviewerAssociation) ||
+			!/^https:\/\/github\.com\//.test(review.evidence) ||
 			review.manifestSha256 !== manifestSha256 ||
-			!review.sourceHash?.startsWith("sha256:")
+			review.sourceHash !== manifest.sourceHash ||
+			review.headSha !== manifest.sourceHead
 		) {
 			throw new Error("Missing approved independent review in manifest");
 		}
@@ -197,8 +243,10 @@ async function main(): Promise<void> {
 			viewport?: { columns?: number; rows?: number };
 			renderMode?: string;
 			fixedClock?: string;
+			simulatedStatusbarRows?: number;
 			wrappingPolicy?: string;
 		};
+		const actualStatusbarRows = measuredStatusbarRows(plain);
 		if (
 			metadata.tool !== CAPTURE_TOOL_VERSION ||
 			metadata.command !== CANONICAL_COMMAND ||
@@ -207,7 +255,9 @@ async function main(): Promise<void> {
 			metadata.viewport?.rows !== entry.viewport.rows ||
 			metadata.renderMode !== entry.renderMode ||
 			metadata.fixedClock !== FIXED_CLOCK ||
-			metadata.wrappingPolicy !== expectedWrappingPolicy(entry.viewport.columns)
+			entry.simulatedStatusbarRows !== actualStatusbarRows ||
+			metadata.simulatedStatusbarRows !== actualStatusbarRows ||
+			metadata.wrappingPolicy !== expectedWrappingPolicy(actualStatusbarRows)
 		) {
 			throw new Error(`${entry.key}: metadata does not match manifest`);
 		}
@@ -238,6 +288,12 @@ async function main(): Promise<void> {
 		}
 		if (entry.stateId.includes("narrow") && !plain.includes("Focused target:")) {
 			throw new Error(`${entry.key}: narrow state missing focused target witness`);
+		}
+		if (entry.stateId === "overflow-two-row-warning" && actualStatusbarRows !== 4) {
+			throw new Error(`${entry.key}: expected two actual and two slot statusbar rows`);
+		}
+		if (entry.stateId === "narrow-cjk" && !plain.includes("상태줄 경계 · 意味の境界 · 语义边界")) {
+			throw new Error(`${entry.key}: missing exact mixed-width semantic witness`);
 		}
 	}
 	for (const filePath of await collectRelativeFiles(root)) {

--- a/packages/coding-agent/src/modes/DESIGN.md
+++ b/packages/coding-agent/src/modes/DESIGN.md
@@ -347,6 +347,60 @@ CJK/Latin todo, IRC, status, and BTW text break at semantic phrase boundaries,
 not inside a phase/action/status label, short identifier, or grapheme cluster.
 Those defects, width overflow, overlap, hidden focus/cursor, and lost anchors
 are blocking visual-QA failures.
+
+### Status Line Custom Editor simulation
+
+The Appearance tab's Status Line Custom Editor is a spatial editor, not a
+generic setting row list. It renders a simulated statusbar with left/right
+segment areas, a hidden-segment palette, visible Separator and segment-option
+controls, and Confirm/Exit actions. It must not render legacy `Segment`,
+`Move left`, or `Move right` rows.
+
+The editor owns transient state locally: focused statusbar slot, focused palette
+item, focused root control, open visible-choice panel, picked segment, floating
+ghost, empty origin slot, and overflow warning. Durable settings remain only the
+existing `statusLine.leftSegments`, `statusLine.rightSegments`,
+`statusLine.separator`, and `statusLine.segmentOptions` keys; Confirm persists
+through the existing settings guard, while Exit or root-state Escape restores
+the previous preview and closes.
+
+Focus variants are `statusbar`, `palette`, `separator-control`,
+`option-control(path)`, `choice(target, focusedValue, returnFocus)`, `confirm`,
+and `exit`. Left/Right is owned by the editor while active and never switches
+settings tabs. Enter selects/deselects, picks/drops, applies a focused choice,
+or activates Confirm/Exit according to focus. Up/Down traverses palette,
+visible root controls, actions, and choice candidates. Escape inside `choice`
+returns to the opener without mutation; Escape everywhere else cancels and
+restores. Delete only hides a focused visible statusbar segment.
+
+Separator and every segment option are visible-choice controls, never cycle-only
+rows. Descriptor data owns labels, allowed values, visible current-value
+formatting, and typed draft application. Separator choices are Powerline, Thin
+chevron, Slash, Pipe, Block, None, and ASCII. Boolean options show `true` and
+`false`; enum options show their union values; `path.maxLength` shows `16`,
+`24`, `32`, `40`, `50`, `60`, and `80`.
+
+At constrained width the simulated statusbar renders as two rows and emits an
+explicit overflow/wrap warning. ANSI-aware cell measurement remains mandatory;
+ASCII/no-color output must retain textual focus, ghost/origin, selected choice,
+and warning affordances.
+
+Deterministic evidence belongs to
+`test/fixtures/tui/status-line-custom-editor-showcase.ts`, captured by
+`scripts/capture-status-line-custom-editor-showcase.ts --out
+.gjc/qa/status-line-custom-editor-<run>` and verified by
+`scripts/verify-status-line-custom-editor-showcase.ts --root
+.gjc/qa/status-line-custom-editor-<run> --require-independent-review`. The
+canonical states are `root-statusbar`, `picked-origin-slot`,
+`palette-exact-insert`, `separator-control`, `separator-choice-focused`,
+`separator-choice-applied`, `option-boolean-choice-focused`,
+`option-enum-choice-focused`, `option-numeric-choice-focused`,
+`option-choice-applied`, `exit-restored`, `confirm-persisted`,
+`overflow-two-row-warning`, and `narrow-cjk`. Each state records
+`terminal.txt`, `terminal-ansi.txt`, `terminal.html`, and `metadata.json`, plus
+the root manifest. Missing state witnesses, ANSI/plain mismatch, invalid
+metadata, and absent independent review are blocking visual-QA failures.
+
 ### Sticky viewport deterministic visual QA
 
 `test/fixtures/tui/sticky-viewport-showcase.ts` is a fixed-clock, no-network,

--- a/packages/coding-agent/src/modes/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/components/settings-selector.ts
@@ -3,6 +3,8 @@ import type { Effort } from "@gajae-code/ai/core";
 import {
 	type Component,
 	Container,
+	Ellipsis,
+	getKeybindings,
 	Input,
 	matchesKey,
 	resolvePetMode,
@@ -14,6 +16,8 @@ import {
 	type Tab,
 	TabBar,
 	Text,
+	truncateToWidth,
+	visibleWidth,
 } from "@gajae-code/tui";
 import { type SettingPath, settings } from "../../config/settings";
 import type {
@@ -41,7 +45,7 @@ import { normalizeProviderOrder } from "./provider-order-context";
 import { getSettingsForTab, type SettingDef } from "./settings-defs";
 import { getPreset } from "./status-line/presets";
 import { ALL_SEGMENT_IDS } from "./status-line/segments";
-import type { StatusLineSegmentOptions } from "./tool-status-header";
+import type { StatusLinePreviewParts, StatusLineSegmentOptions } from "./tool-status-header";
 
 /**
  * A submenu component for selecting from a list of options.
@@ -263,20 +267,75 @@ function statusSegmentLabel(id: StatusLineSegmentId): string {
 	return id.replace(/_/g, " ");
 }
 
-function segmentPlacement(
-	id: StatusLineSegmentId,
-	leftSegments: StatusLineSegmentId[],
-	rightSegments: StatusLineSegmentId[],
-): "hidden" | "left" | "right" {
-	if (leftSegments.includes(id)) return "left";
-	if (rightSegments.includes(id)) return "right";
-	return "hidden";
+type StatusLineSide = "left" | "right";
+type StatusLineOptionPath =
+	| "model.showThinkingLevel"
+	| "path.abbreviate"
+	| "path.maxLength"
+	| "path.stripWorkPrefix"
+	| "git.showBranch"
+	| "git.showStaged"
+	| "git.showUnstaged"
+	| "git.showUntracked"
+	| "time.format"
+	| "time.showSeconds"
+	| "usage.mode";
+type StatusLineChoiceTarget = "separator" | StatusLineOptionPath;
+type StatusLineRootFocus =
+	| { kind: "statusbar"; side: StatusLineSide; index: number }
+	| { kind: "palette"; index: number }
+	| { kind: "separator-control" }
+	| { kind: "option-control"; path: StatusLineOptionPath }
+	| { kind: "confirm" }
+	| { kind: "exit" };
+type StatusLineFocus =
+	| StatusLineRootFocus
+	| { kind: "choice"; target: StatusLineChoiceTarget; focusedIndex: number; returnFocus: StatusLineRootFocus };
+
+interface PickedStatusLineSegment {
+	id: StatusLineSegmentId;
+	origin: { kind: "statusbar"; side: StatusLineSide; index: number } | { kind: "palette" };
+}
+
+interface StatusLineChoiceDescriptor {
+	target: StatusLineChoiceTarget;
+	label: string;
+	values: SelectItem[];
+	currentValue: () => string;
+	apply: (value: string) => void;
+	highlightSegment?: StatusLineSegmentId;
+}
+
+const SEPARATOR_OPTIONS: SelectItem[] = [
+	{ value: "powerline", label: "Powerline" },
+	{ value: "powerline-thin", label: "Thin chevron" },
+	{ value: "slash", label: "Slash" },
+	{ value: "pipe", label: "Pipe" },
+	{ value: "block", label: "Block" },
+	{ value: "none", label: "None" },
+	{ value: "ascii", label: "ASCII" },
+];
+
+function isDeleteKey(data: string): boolean {
+	const kb = getKeybindings();
+	return (
+		kb.matches(data, "tui.editor.deleteCharForward") ||
+		matchesKey(data, "delete") ||
+		matchesKey(data, "shift+delete") ||
+		data === "\x1b[3~"
+	);
+}
+
+function cloneRootFocus(focus: StatusLineRootFocus): StatusLineRootFocus {
+	return { ...focus };
 }
 
 class StatusLineCustomEditor extends Container {
-	#list!: SettingsList;
 	#draft: StatusLineDraft;
 	#previewHighlightSegment: StatusLineSegmentId | undefined;
+	#focus: StatusLineFocus = { kind: "statusbar", side: "left", index: 0 };
+	#picked: PickedStatusLineSegment | undefined;
+	#pickedStatusbarFocus: Extract<StatusLineRootFocus, { kind: "statusbar" }> | undefined;
 
 	constructor(
 		private readonly callbacks: SettingsCallbacks,
@@ -299,275 +358,808 @@ class StatusLineCustomEditor extends Container {
 				settings.get("statusLine.segmentOptions") as StatusLineSegmentOptions,
 			),
 		};
-		this.#preview();
-		this.#build();
-	}
-
-	#build(): void {
-		this.clear();
-		this.addChild(new Text(theme.bold(theme.fg("accent", "Status Line Custom Editor")), 0, 0));
-		this.addChild(new Spacer(1));
-		this.#list = new SettingsList(
-			this.#items(),
-			14,
-			getSettingsListTheme(),
-			(id, value) => this.#handleChange(id, value),
-			() => this.#cancel(),
-			item => this.#setSelectedItem(item),
-			2,
-		);
-		this.addChild(this.#list);
-	}
-
-	#refresh(): void {
-		this.#list.setItems(this.#items());
-	}
-	#setSelectedItem(item: SettingItem | undefined): void {
-		this.#previewHighlightSegment = this.#highlightSegmentForItem(item);
+		this.#normalizeFocus();
 		this.#preview();
 	}
 
-	#highlightSegmentForItem(item: SettingItem | undefined): StatusLineSegmentId | undefined {
-		if (!item) return undefined;
-		if (item.id.startsWith("segment.")) {
-			return item.id.slice("segment.".length) as StatusLineSegmentId;
-		}
-		if (item.id.startsWith("moveup.")) {
-			return item.id.slice("moveup.".length) as StatusLineSegmentId;
-		}
-		if (item.id.startsWith("movedown.")) {
-			return item.id.slice("movedown.".length) as StatusLineSegmentId;
-		}
-		if (item.id.startsWith("option.")) {
-			const [segment] = item.id.slice("option.".length).split(".");
-			return segment as StatusLineSegmentId;
-		}
-		return undefined;
+	get navigationLocked(): boolean {
+		return true;
 	}
 
-	#items(): SettingItem[] {
-		const items: SettingItem[] = [
+	#choiceDescriptors(): StatusLineChoiceDescriptor[] {
+		return [
 			{
-				id: "action.save",
-				label: "Save custom status line",
-				description: "Persist the previewed custom status line to user config.",
-				currentValue: "approve",
-				values: ["approve"],
-			},
-			{
-				id: "action.cancel",
-				label: "Cancel and restore",
-				description: "Close without persisting draft settings and restore the previous preview.",
-				currentValue: "restore",
-				values: ["restore"],
-			},
-			{
-				id: "separator",
+				target: "separator",
 				label: "Separator",
-				description: "Separator style between status line segments.",
-				currentValue: this.#draft.separator,
-				submenu: (currentValue, done) =>
-					new SelectSubmenu(
-						"Status Line Separator",
-						"Style of separators between segments.",
-						[
-							{ value: "powerline", label: "Powerline" },
-							{ value: "powerline-thin", label: "Thin chevron" },
-							{ value: "slash", label: "Slash" },
-							{ value: "pipe", label: "Pipe" },
-							{ value: "block", label: "Block" },
-							{ value: "none", label: "None" },
-							{ value: "ascii", label: "ASCII" },
-						],
-						currentValue,
-						done,
-						() => done(),
-					),
+				values: SEPARATOR_OPTIONS,
+				currentValue: () => this.#draft.separator,
+				apply: value => {
+					this.#draft.separator = value as StatusLineSeparatorStyle;
+				},
+			},
+			{
+				target: "model.showThinkingLevel",
+				label: "Model: show thinking level",
+				values: BOOL_VALUES.map(value => ({ value, label: value })),
+				currentValue: () => String(this.#draft.segmentOptions.model?.showThinkingLevel !== false),
+				apply: value => this.#setOption("model.showThinkingLevel", value),
+				highlightSegment: "model",
+			},
+			{
+				target: "path.abbreviate",
+				label: "Path: abbreviate",
+				values: BOOL_VALUES.map(value => ({ value, label: value })),
+				currentValue: () => String(this.#draft.segmentOptions.path?.abbreviate !== false),
+				apply: value => this.#setOption("path.abbreviate", value),
+				highlightSegment: "path",
+			},
+			{
+				target: "path.maxLength",
+				label: "Path: max length",
+				values: PATH_LENGTH_OPTIONS,
+				currentValue: () => String(this.#draft.segmentOptions.path?.maxLength ?? 32),
+				apply: value => this.#setOption("path.maxLength", value),
+				highlightSegment: "path",
+			},
+			{
+				target: "path.stripWorkPrefix",
+				label: "Path: strip work prefix",
+				values: BOOL_VALUES.map(value => ({ value, label: value })),
+				currentValue: () => String(this.#draft.segmentOptions.path?.stripWorkPrefix === true),
+				apply: value => this.#setOption("path.stripWorkPrefix", value),
+				highlightSegment: "path",
+			},
+			{
+				target: "git.showBranch",
+				label: "Git: show branch",
+				values: BOOL_VALUES.map(value => ({ value, label: value })),
+				currentValue: () => String(this.#draft.segmentOptions.git?.showBranch !== false),
+				apply: value => this.#setOption("git.showBranch", value),
+				highlightSegment: "git",
+			},
+			{
+				target: "git.showStaged",
+				label: "Git: show staged",
+				values: BOOL_VALUES.map(value => ({ value, label: value })),
+				currentValue: () => String(this.#draft.segmentOptions.git?.showStaged !== false),
+				apply: value => this.#setOption("git.showStaged", value),
+				highlightSegment: "git",
+			},
+			{
+				target: "git.showUnstaged",
+				label: "Git: show unstaged",
+				values: BOOL_VALUES.map(value => ({ value, label: value })),
+				currentValue: () => String(this.#draft.segmentOptions.git?.showUnstaged !== false),
+				apply: value => this.#setOption("git.showUnstaged", value),
+				highlightSegment: "git",
+			},
+			{
+				target: "git.showUntracked",
+				label: "Git: show untracked",
+				values: BOOL_VALUES.map(value => ({ value, label: value })),
+				currentValue: () => String(this.#draft.segmentOptions.git?.showUntracked !== false),
+				apply: value => this.#setOption("git.showUntracked", value),
+				highlightSegment: "git",
+			},
+			{
+				target: "time.format",
+				label: "Time: format",
+				values: TIME_FORMAT_OPTIONS,
+				currentValue: () => this.#draft.segmentOptions.time?.format ?? "24h",
+				apply: value => this.#setOption("time.format", value),
+			},
+			{
+				target: "time.showSeconds",
+				label: "Time: show seconds",
+				values: BOOL_VALUES.map(value => ({ value, label: value })),
+				currentValue: () => String(this.#draft.segmentOptions.time?.showSeconds === true),
+				apply: value => this.#setOption("time.showSeconds", value),
+			},
+			{
+				target: "usage.mode",
+				label: "Usage: mode",
+				values: USAGE_MODE_OPTIONS,
+				currentValue: () => this.#draft.segmentOptions.usage?.mode ?? "used",
+				apply: value => this.#setOption("usage.mode", value),
+				highlightSegment: "usage",
 			},
 		];
+	}
 
-		for (const id of PUBLIC_STATUS_SEGMENTS) {
-			items.push({
-				id: `segment.${id}`,
-				label: `Segment: ${statusSegmentLabel(id)}`,
-				description: "Cycle placement: hidden → left → right. Use move actions below to reorder visible segments.",
-				currentValue: segmentPlacement(id, this.#draft.leftSegments, this.#draft.rightSegments),
-				values: ["hidden", "left", "right"],
-			});
-			if (segmentPlacement(id, this.#draft.leftSegments, this.#draft.rightSegments) !== "hidden") {
-				items.push(
-					{
-						id: `moveup.${id}`,
-						label: `Move left: ${statusSegmentLabel(id)}`,
-						currentValue: "←",
-						values: ["←"],
-					},
-					{
-						id: `movedown.${id}`,
-						label: `Move right: ${statusSegmentLabel(id)}`,
-						currentValue: "→",
-						values: ["→"],
-					},
-				);
-			}
-			if (id === "usage") {
-				items.push({
-					id: "option.usage.mode",
-					label: "Usage: mode",
-					currentValue: this.#draft.segmentOptions.usage?.mode ?? "used",
-					submenu: (currentValue, done) =>
-						new SelectSubmenu(
-							"Usage mode",
-							"Show used quota or remaining quota in the usage segment.",
-							USAGE_MODE_OPTIONS,
-							currentValue,
-							done,
-							() => done(),
-						),
-				});
-			}
-			if (id === "command") {
-				items.push({
-					id: "option.command.command",
-					label: "Command: command",
-					description: "Shell command whose sanitized stdout is shown in the status line.",
-					currentValue: this.#draft.segmentOptions.command?.command ?? "",
-					submenu: (currentValue, done) =>
-						new TextInputSubmenu(
-							"Status line command",
-							"Runs in the configured shell with a short timeout and cached refreshes.",
-							currentValue,
-							value => done(value),
-							() => done(),
-						),
-				});
-			}
+	#descriptor(target: StatusLineChoiceTarget): StatusLineChoiceDescriptor | undefined {
+		return this.#choiceDescriptors().find(descriptor => descriptor.target === target);
+	}
+
+	#hiddenSegments(): StatusLineSegmentId[] {
+		const visible = new Set([...this.#draft.leftSegments, ...this.#draft.rightSegments]);
+		return PUBLIC_STATUS_SEGMENTS.filter(id => !visible.has(id));
+	}
+
+	#paletteSegments(includePicked = this.#focus.kind === "palette"): StatusLineSegmentId[] {
+		const visible = new Set([...this.#draft.leftSegments, ...this.#draft.rightSegments]);
+		const selected = includePicked ? this.#picked?.id : undefined;
+		return PUBLIC_STATUS_SEGMENTS.filter(id => !visible.has(id) || id === selected);
+	}
+
+	#focusSegment(): StatusLineSegmentId | undefined {
+		if (this.#focus.kind !== "statusbar") return undefined;
+		return this.#draft[`${this.#focus.side}Segments`][this.#focus.index];
+	}
+
+	#segmentCount(side: StatusLineSide, omitPicked = false): number {
+		const segments = this.#draft[`${side}Segments`];
+		if (
+			!omitPicked ||
+			!this.#picked ||
+			this.#picked.origin.kind !== "statusbar" ||
+			this.#picked.origin.side !== side
+		) {
+			return segments.length;
 		}
+		return Math.max(0, segments.length - 1);
+	}
 
-		items.push(
-			{
-				id: "option.model.showThinkingLevel",
-				label: "Model: show thinking level",
-				currentValue: String(this.#draft.segmentOptions.model?.showThinkingLevel !== false),
-				values: BOOL_VALUES,
-			},
-			{
-				id: "option.path.abbreviate",
-				label: "Path: abbreviate",
-				currentValue: String(this.#draft.segmentOptions.path?.abbreviate !== false),
-				values: BOOL_VALUES,
-			},
-			{
-				id: "option.path.maxLength",
-				label: "Path: max length",
-				currentValue: String(this.#draft.segmentOptions.path?.maxLength ?? 32),
-				submenu: (currentValue, done) =>
-					new SelectSubmenu(
-						"Path max length",
-						"Maximum displayed path length.",
-						PATH_LENGTH_OPTIONS,
-						currentValue,
-						done,
-						() => done(),
-					),
-			},
-			{
-				id: "option.path.stripWorkPrefix",
-				label: "Path: strip work prefix",
-				currentValue: String(this.#draft.segmentOptions.path?.stripWorkPrefix === true),
-				values: BOOL_VALUES,
-			},
-			{
-				id: "option.git.showBranch",
-				label: "Git: show branch",
-				currentValue: String(this.#draft.segmentOptions.git?.showBranch !== false),
-				values: BOOL_VALUES,
-			},
-			{
-				id: "option.git.showStaged",
-				label: "Git: show staged",
-				currentValue: String(this.#draft.segmentOptions.git?.showStaged !== false),
-				values: BOOL_VALUES,
-			},
-			{
-				id: "option.git.showUnstaged",
-				label: "Git: show unstaged",
-				currentValue: String(this.#draft.segmentOptions.git?.showUnstaged !== false),
-				values: BOOL_VALUES,
-			},
-			{
-				id: "option.git.showUntracked",
-				label: "Git: show untracked",
-				currentValue: String(this.#draft.segmentOptions.git?.showUntracked !== false),
-				values: BOOL_VALUES,
-			},
-			{
-				id: "option.time.format",
-				label: "Time: format",
-				currentValue: this.#draft.segmentOptions.time?.format ?? "24h",
-				submenu: (currentValue, done) =>
-					new SelectSubmenu(
-						"Time format",
-						"Clock format for the time segment.",
-						TIME_FORMAT_OPTIONS,
-						currentValue,
-						done,
-						() => done(),
-					),
-			},
-			{
-				id: "option.time.showSeconds",
-				label: "Time: show seconds",
-				currentValue: String(this.#draft.segmentOptions.time?.showSeconds === true),
-				values: BOOL_VALUES,
-			},
+	#normalizeFocus(): void {
+		const descriptors = this.#choiceDescriptors();
+		if (this.#focus.kind === "choice") {
+			const descriptor = this.#descriptor(this.#focus.target);
+			if (!descriptor) {
+				this.#focus = { kind: "separator-control" };
+			} else {
+				this.#focus.focusedIndex = Math.max(0, Math.min(this.#focus.focusedIndex, descriptor.values.length - 1));
+			}
+			return;
+		}
+		if (this.#focus.kind === "statusbar") {
+			const max = this.#picked
+				? this.#segmentCount(this.#focus.side, true)
+				: this.#draft[`${this.#focus.side}Segments`].length - 1;
+			if (max < 0) {
+				const otherSide: StatusLineSide = this.#focus.side === "left" ? "right" : "left";
+				if (this.#draft[`${otherSide}Segments`].length > 0) {
+					this.#focus = { kind: "statusbar", side: otherSide, index: 0 };
+				} else if (this.#paletteSegments().length > 0) {
+					this.#focus = { kind: "palette", index: 0 };
+				} else {
+					this.#focus = { kind: "separator-control" };
+				}
+			} else {
+				this.#focus.index = Math.max(0, Math.min(this.#focus.index, max));
+			}
+		} else if (this.#focus.kind === "palette") {
+			const palette = this.#paletteSegments();
+			if (palette.length === 0) {
+				this.#focus = { kind: "separator-control" };
+			} else {
+				this.#focus.index = Math.max(0, Math.min(this.#focus.index, palette.length - 1));
+			}
+		} else if (
+			this.#focus.kind === "option-control" &&
+			!descriptors.some(descriptor => descriptor.target === (this.#focus as { path: StatusLineOptionPath }).path)
+		) {
+			this.#focus = { kind: "separator-control" };
+		}
+	}
+
+	#rootOrder(): StatusLineRootFocus[] {
+		const roots: StatusLineRootFocus[] = [];
+		roots.push(this.#nearestStatusbarFocus());
+		if (this.#paletteSegments().length > 0) roots.push({ kind: "palette", index: 0 });
+		roots.push({ kind: "separator-control" });
+		roots.push({ kind: "confirm" }, { kind: "exit" });
+		return roots;
+	}
+
+	#nearestStatusbarFocus(): StatusLineRootFocus {
+		if (this.#focus.kind === "statusbar") {
+			return { kind: "statusbar", side: this.#focus.side, index: this.#focus.index };
+		}
+		if (this.#draft.leftSegments.length > 0 || this.#picked) {
+			return {
+				kind: "statusbar",
+				side: "left",
+				index: this.#picked ? this.#segmentCount("left", true) : 0,
+			};
+		}
+		if (this.#draft.rightSegments.length > 0) {
+			return { kind: "statusbar", side: "right", index: 0 };
+		}
+		return { kind: "statusbar", side: "left", index: 0 };
+	}
+
+	#rootFocusKey(focus: StatusLineRootFocus): string {
+		switch (focus.kind) {
+			case "statusbar":
+				return `${focus.kind}:${focus.side}:${focus.index}`;
+			case "palette":
+				return `${focus.kind}:${focus.index}`;
+			case "option-control":
+				return `${focus.kind}:${focus.path}`;
+			default:
+				return focus.kind;
+		}
+	}
+
+	#moveVertical(delta: -1 | 1): void {
+		if (this.#focus.kind === "choice") {
+			const descriptor = this.#descriptor(this.#focus.target);
+			if (!descriptor || descriptor.values.length === 0) return;
+			this.#focus.focusedIndex =
+				(this.#focus.focusedIndex + delta + descriptor.values.length) % descriptor.values.length;
+			return;
+		}
+		if (this.#picked) {
+			if (this.#focus.kind === "palette") {
+				if (delta === -1) this.#focus = this.#pickedStatusbarFocus ?? this.#nearestStatusbarFocus();
+			} else if (delta === 1) {
+				if (this.#focus.kind === "statusbar") this.#pickedStatusbarFocus = { ...this.#focus };
+				this.#focus = { kind: "palette", index: this.#focusPaletteIndex() };
+			}
+			this.#normalizeFocus();
+			return;
+		}
+		const order = this.#rootOrder();
+		const currentKey = this.#rootFocusKey(this.#focus);
+		const currentIndex = Math.max(
+			0,
+			order.findIndex(item => this.#rootFocusKey(item) === currentKey),
 		);
-
-		return items;
+		this.#focus = cloneRootFocus(order[(currentIndex + delta + order.length) % order.length] ?? order[0]);
+		this.#normalizeFocus();
 	}
 
-	#handleChange(id: string, value: string): void {
-		if (id === "action.save") {
-			this.#save();
-			return;
-		}
-		if (id === "action.cancel") {
-			this.#cancel();
-			return;
-		}
-		if (id === "separator") {
-			this.#draft.separator = value as StatusLineSeparatorStyle;
-		} else if (id.startsWith("segment.")) {
-			this.#setSegmentPlacement(
-				id.slice("segment.".length) as StatusLineSegmentId,
-				value as "hidden" | "left" | "right",
-			);
-		} else if (id.startsWith("moveup.")) {
-			this.#moveSegment(id.slice("moveup.".length) as StatusLineSegmentId, -1);
-		} else if (id.startsWith("movedown.")) {
-			this.#moveSegment(id.slice("movedown.".length) as StatusLineSegmentId, 1);
-		} else if (id.startsWith("option.")) {
-			this.#setOption(id.slice("option.".length), value);
-		}
+	#focusPaletteIndex(): number {
+		if (this.#focus.kind === "palette") return this.#focus.index;
+		if (this.#picked) return Math.max(0, this.#paletteSegments(true).indexOf(this.#picked.id));
+		return Math.max(0, Math.min(this.#paletteSegments(false).length - 1, 0));
+	}
+
+	#linearVisibleFocus(): Array<{ side: StatusLineSide; index: number }> {
+		return [
+			...this.#draft.leftSegments.map((_, index) => ({ side: "left" as const, index })),
+			...this.#draft.rightSegments.map((_, index) => ({ side: "right" as const, index })),
+		];
+	}
+
+	#moveVisibleFocus(delta: -1 | 1): void {
+		if (this.#focus.kind !== "statusbar") return;
+		const focus = this.#focus;
+		const items = this.#linearVisibleFocus();
+		if (items.length === 0) return;
+		const currentIndex = Math.max(
+			0,
+			items.findIndex(item => item.side === focus.side && item.index === focus.index),
+		);
+		this.#focus = { kind: "statusbar", ...items[(currentIndex + delta + items.length) % items.length] };
+	}
+
+	#slotOrder(): Array<{ side: StatusLineSide; index: number }> {
+		const leftCount = this.#segmentCount("left", true);
+		const rightCount = this.#segmentCount("right", true);
+		return [
+			...Array.from({ length: leftCount + 1 }, (_, index) => ({ side: "left" as const, index })),
+			...Array.from({ length: rightCount + 1 }, (_, index) => ({ side: "right" as const, index })),
+		];
+	}
+
+	#movePickedSlot(delta: -1 | 1): void {
+		if (!this.#picked || this.#focus.kind !== "statusbar") return;
+		const focus = this.#focus;
+		const slots = this.#slotOrder();
+		const currentIndex = Math.max(
+			0,
+			slots.findIndex(item => item.side === focus.side && item.index === focus.index),
+		);
+		this.#focus = { kind: "statusbar", ...slots[Math.max(0, Math.min(slots.length - 1, currentIndex + delta))] };
+		this.#pickedStatusbarFocus = { ...this.#focus };
+		this.#updatePreviewHighlight();
+	}
+
+	#movePaletteFocus(delta: -1 | 1): void {
+		if (this.#focus.kind !== "palette") return;
+		const palette = this.#paletteSegments();
+		if (palette.length === 0) return;
+		this.#focus.index = (this.#focus.index + delta + palette.length) % palette.length;
+	}
+
+	#moveChoiceControl(delta: -1 | 1): void {
+		if (this.#focus.kind !== "separator-control" && this.#focus.kind !== "option-control") return;
+		const descriptors = this.#choiceDescriptors();
+		const currentTarget = this.#focus.kind === "separator-control" ? "separator" : this.#focus.path;
+		const currentIndex = Math.max(
+			0,
+			descriptors.findIndex(descriptor => descriptor.target === currentTarget),
+		);
+		const next = descriptors[(currentIndex + delta + descriptors.length) % descriptors.length];
+		if (!next) return;
+		this.#focus =
+			next.target === "separator"
+				? { kind: "separator-control" }
+				: { kind: "option-control", path: next.target as StatusLineOptionPath };
+	}
+
+	#moveChoiceTarget(delta: -1 | 1): void {
+		if (this.#focus.kind !== "choice") return;
+		const focus = this.#focus;
+		const descriptors = this.#choiceDescriptors();
+		const currentIndex = Math.max(
+			0,
+			descriptors.findIndex(descriptor => descriptor.target === focus.target),
+		);
+		const next = descriptors[(currentIndex + delta + descriptors.length) % descriptors.length];
+		if (!next) return;
+		const currentValue = next.currentValue();
+		this.#focus = {
+			kind: "choice",
+			target: next.target,
+			focusedIndex: Math.max(
+				0,
+				next.values.findIndex(value => value.value === currentValue),
+			),
+			returnFocus:
+				next.target === "separator"
+					? { kind: "separator-control" }
+					: { kind: "option-control", path: next.target as StatusLineOptionPath },
+		};
+	}
+
+	#pickFocusedStatusbar(): void {
+		if (this.#focus.kind !== "statusbar") return;
+		const id = this.#focusSegment();
+		if (!id) return;
+		this.#picked = { id, origin: { kind: "statusbar", side: this.#focus.side, index: this.#focus.index } };
+		this.#pickedStatusbarFocus = { kind: "statusbar", side: this.#focus.side, index: this.#focus.index };
+		this.#updatePreviewHighlight();
 		this.#preview();
-		this.#refresh();
 	}
 
-	#setSegmentPlacement(id: StatusLineSegmentId, placement: "hidden" | "left" | "right"): void {
+	#pickFocusedPalette(): void {
+		if (this.#focus.kind !== "palette") return;
+		const id = this.#paletteSegments()[this.#focus.index];
+		if (!id) return;
+		this.#picked = { id, origin: { kind: "palette" } };
+		this.#focus = { kind: "statusbar", side: "left", index: this.#segmentCount("left", true) };
+		this.#pickedStatusbarFocus = { ...this.#focus };
+		this.#updatePreviewHighlight();
+		this.#preview();
+	}
+
+	#dropPicked(): void {
+		if (!this.#picked || this.#focus.kind !== "statusbar") return;
+		const id = this.#picked.id;
+		const nextLeft = this.#draft.leftSegments.filter(segment => segment !== id);
+		const nextRight = this.#draft.rightSegments.filter(segment => segment !== id);
+		const target = this.#focus.side === "left" ? nextLeft : nextRight;
+		target.splice(Math.max(0, Math.min(target.length, this.#focus.index)), 0, id);
+		this.#draft.leftSegments = nextLeft;
+		this.#draft.rightSegments = nextRight;
+		this.#focus = { kind: "statusbar", side: this.#focus.side, index: target.indexOf(id) };
+		this.#picked = undefined;
+		this.#pickedStatusbarFocus = undefined;
+		this.#updatePreviewHighlight();
+		this.#preview();
+	}
+
+	#dropPickedToPalette(): void {
+		if (!this.#picked || this.#focus.kind !== "palette") return;
+		const id = this.#picked.id;
 		this.#draft.leftSegments = this.#draft.leftSegments.filter(segment => segment !== id);
 		this.#draft.rightSegments = this.#draft.rightSegments.filter(segment => segment !== id);
-		if (placement === "left") this.#draft.leftSegments.push(id);
-		if (placement === "right") this.#draft.rightSegments.push(id);
+		this.#picked = undefined;
+		this.#pickedStatusbarFocus = undefined;
+		const hidden = this.#hiddenSegments();
+		this.#focus = { kind: "palette", index: Math.max(0, hidden.indexOf(id)) };
+		this.#updatePreviewHighlight();
+		this.#preview();
 	}
 
-	#moveSegment(id: StatusLineSegmentId, delta: -1 | 1): void {
-		const group = this.#draft.leftSegments.includes(id) ? this.#draft.leftSegments : this.#draft.rightSegments;
-		const index = group.indexOf(id);
-		if (index < 0) return;
-		const nextIndex = Math.max(0, Math.min(group.length - 1, index + delta));
-		if (nextIndex === index) return;
-		const [segment] = group.splice(index, 1);
-		if (segment) group.splice(nextIndex, 0, segment);
+	#hideFocusedSegment(): void {
+		if (this.#picked || this.#focus.kind !== "statusbar") return;
+		const group = this.#draft[`${this.#focus.side}Segments`];
+		if (!group[this.#focus.index]) return;
+		group.splice(this.#focus.index, 1);
+		const hidden = this.#hiddenSegments();
+		this.#focus = hidden.length ? { kind: "palette", index: hidden.length - 1 } : { kind: "separator-control" };
+		this.#updatePreviewHighlight();
+		this.#preview();
+	}
+
+	#openChoice(target: StatusLineChoiceTarget, returnFocus: StatusLineRootFocus): void {
+		const descriptor = this.#descriptor(target);
+		if (!descriptor) return;
+		const currentValue = descriptor.currentValue();
+		this.#focus = {
+			kind: "choice",
+			target,
+			focusedIndex: Math.max(
+				0,
+				descriptor.values.findIndex(value => value.value === currentValue),
+			),
+			returnFocus,
+		};
+	}
+
+	#applyChoice(): void {
+		if (this.#focus.kind !== "choice") return;
+		const descriptor = this.#descriptor(this.#focus.target);
+		if (!descriptor) return;
+		const value = descriptor.values[this.#focus.focusedIndex]?.value;
+		if (value === undefined) return;
+		descriptor.apply(value);
+		this.#focus = cloneRootFocus(this.#focus.returnFocus);
+		this.#updatePreviewHighlight();
+		this.#preview();
+	}
+
+	#updatePreviewHighlight(): void {
+		if (this.#picked) {
+			this.#previewHighlightSegment = this.#picked.id;
+			return;
+		}
+		if (this.#focus.kind === "statusbar") {
+			this.#previewHighlightSegment = this.#focusSegment();
+			return;
+		}
+		if (this.#focus.kind === "palette") {
+			this.#previewHighlightSegment = this.#paletteSegments()[this.#focus.index];
+			return;
+		}
+		if (this.#focus.kind === "option-control") {
+			this.#previewHighlightSegment = this.#descriptor(this.#focus.path)?.highlightSegment;
+			return;
+		}
+		if (this.#focus.kind === "choice") {
+			this.#previewHighlightSegment = this.#descriptor(this.#focus.target)?.highlightSegment;
+			return;
+		}
+		this.#previewHighlightSegment = undefined;
+	}
+
+	#focusLabel(): string {
+		switch (this.#focus.kind) {
+			case "statusbar":
+				return `statusbar:${this.#focus.side}:${this.#focus.index}`;
+			case "palette":
+				return `palette:${this.#focus.index}`;
+			case "option-control":
+				return `option:${this.#focus.path}`;
+			case "choice":
+				return `choice:${this.#focus.target}`;
+			default:
+				return this.#focus.kind;
+		}
+	}
+
+	#separatorGlyph(): string {
+		if (theme.getSymbolPreset() === "ascii") {
+			return this.#draft.separator === "none" ? " " : this.#draft.separator === "pipe" ? " | " : " / ";
+		}
+		switch (this.#draft.separator) {
+			case "pipe":
+				return " | ";
+			case "block":
+				return " █ ";
+			case "none":
+				return " ";
+			case "ascii":
+				return " > ";
+			case "powerline":
+				return "  ";
+			case "powerline-thin":
+				return " ❯ ";
+			case "slash":
+				return " / ";
+		}
+	}
+
+	#fit(line: string, width: number): string {
+		const ascii = theme.getSymbolPreset() === "ascii";
+		const fitted = truncateToWidth(
+			line,
+			ascii ? Math.max(0, width - 2) : width,
+			ascii ? Ellipsis.Ascii : Ellipsis.Unicode,
+		);
+		if (!ascii) return fitted;
+		return fitted.replace(/·/g, "-").replace(/│/g, "|").replace(/…/g, "...");
+	}
+
+	#padEndVisible(line: string, width: number): string {
+		return line + " ".repeat(Math.max(0, width - visibleWidth(line)));
+	}
+
+	#padStartVisible(line: string, width: number): string {
+		return " ".repeat(Math.max(0, width - visibleWidth(line))) + line;
+	}
+
+	#centerVisible(line: string, width: number): string {
+		const left = Math.floor(Math.max(0, width - visibleWidth(line)) / 2);
+		return " ".repeat(left) + line;
+	}
+
+	#simulationWidth(width: number): number {
+		return Math.max(1, width - 2);
+	}
+
+	#simulationIndent(width: number): string {
+		return " ".repeat(Math.max(0, Math.floor((width - this.#simulationWidth(width)) / 2)));
+	}
+
+	#highlightBox(text: string, style: "focus" | "selected"): string {
+		const selectedText = `> ${text} <`;
+		const bgColor = style === "selected" ? "warning" : "text";
+		const brightBg = theme.getFgAnsi(bgColor).replace("\x1b[38;", "\x1b[48;");
+		const darkFg = theme.getBgAnsi("selectedBg").replace("\x1b[48;", "\x1b[38;");
+		return `${brightBg}${darkFg}${selectedText}\x1b[0m`;
+	}
+
+	#focusBox(text: string): string {
+		return this.#highlightBox(text, "focus");
+	}
+
+	#selectedBox(text: string): string {
+		return this.#highlightBox(text, "selected");
+	}
+
+	#dashedBox(text: string): string {
+		return theme.fg("dim", theme.getSymbolPreset() === "ascii" ? `[ ${text} ]` : `┆ ${text} ┆`);
+	}
+
+	#renderSegment(id: StatusLineSegmentId, selected: boolean, visibleInStatusbar: boolean): string {
+		const label = statusSegmentLabel(id);
+		if (selected) return this.#focusBox(label);
+		if (visibleInStatusbar) return label;
+		return this.#dashedBox(label);
+	}
+
+	#renderSide(side: StatusLineSide, visibleIds: ReadonlySet<StatusLineSegmentId> | undefined): string {
+		const segments = this.#draft[`${side}Segments`];
+		const rendered: string[] = [];
+		for (let index = 0; index < segments.length; index++) {
+			const id = segments[index];
+			if (!id) continue;
+			const isOrigin =
+				this.#picked?.origin.kind === "statusbar" &&
+				this.#picked.origin.side === side &&
+				this.#picked.origin.index === index;
+			if (isOrigin) continue;
+			const selected =
+				!this.#picked &&
+				this.#focus.kind === "statusbar" &&
+				this.#focus.side === side &&
+				this.#focus.index === index;
+			rendered.push(this.#renderSegment(id, selected, visibleIds?.has(id) ?? false));
+		}
+		if (this.#picked && this.#focus.kind === "statusbar" && this.#focus.side === side) {
+			rendered.splice(
+				Math.max(0, Math.min(rendered.length, this.#focus.index)),
+				0,
+				this.#selectedBox(statusSegmentLabel(this.#picked.id)),
+			);
+		}
+		return rendered.length
+			? rendered.join(theme.fg("statusLineSep", this.#separatorGlyph()))
+			: theme.fg("muted", "(empty)");
+	}
+
+	#draftPreviewSettings(includePickedPlacement = false): StatusLinePreviewSettings {
+		let leftSegments = [...this.#draft.leftSegments];
+		let rightSegments = [...this.#draft.rightSegments];
+		let previewHighlightSegment = this.#previewHighlightSegment;
+		if (includePickedPlacement && this.#picked) {
+			const id = this.#picked.id;
+			leftSegments = leftSegments.filter(segment => segment !== id);
+			rightSegments = rightSegments.filter(segment => segment !== id);
+			if (this.#focus.kind === "statusbar") {
+				const target = this.#focus.side === "left" ? leftSegments : rightSegments;
+				target.splice(Math.max(0, Math.min(target.length, this.#focus.index)), 0, id);
+				previewHighlightSegment = id;
+			}
+		}
+		return {
+			preset: "custom",
+			leftSegments,
+			rightSegments,
+			separator: this.#draft.separator,
+			segmentOptions: cloneSegmentOptions(this.#draft.segmentOptions),
+			sessionAccent: settings.get("statusLine.sessionAccent"),
+			maxRows: settings.get("statusLine.maxRows"),
+			previewHighlightSegment,
+			previewHighlightStyle: this.#picked ? "selected" : "focus",
+		};
+	}
+
+	#actualStatusbarParts(width: number): StatusLinePreviewParts | undefined {
+		return this.callbacks.getStatusLinePreviewPartsForSettings?.(
+			this.#draftPreviewSettings(true),
+			this.#simulationWidth(width),
+		);
+	}
+
+	#renderActualStatusbar(width: number, parts: StatusLinePreviewParts | undefined): string[] {
+		if (parts) return this.#renderActualStatusbarParts(width, parts);
+		const rendered = this.callbacks.getStatusLinePreviewForSettings?.(this.#draftPreviewSettings(true), width);
+		if (!rendered) return [];
+		return rendered
+			.split("\n")
+			.map(line => line.trimEnd())
+			.filter(line => line.length > 0)
+			.map(line => this.#centerVisible(this.#fit(line, this.#simulationWidth(width)), width));
+	}
+
+	#renderActualStatusbarParts(width: number, parts: StatusLinePreviewParts): string[] {
+		const barWidth = this.#simulationWidth(width);
+		const indent = this.#simulationIndent(width);
+		const separator = theme.fg("statusLineSep", ` ${parts.separator.left} `);
+		const left = parts.left.join(separator);
+		const right = parts.right.join(separator);
+		const combinedGap = Math.max(1, barWidth - visibleWidth(left) - visibleWidth(right));
+		if (visibleWidth(left) + visibleWidth(right) + 1 <= barWidth) {
+			return [this.#fit(`${indent}${left}${" ".repeat(combinedGap)}${right}`, width)];
+		}
+		return [
+			this.#fit(
+				`${indent}${this.#padEndVisible(truncateToWidth(left, barWidth, Ellipsis.Unicode), barWidth)}`,
+				width,
+			),
+			this.#fit(
+				`${indent}${this.#padStartVisible(truncateToWidth(right, barWidth, Ellipsis.Unicode), barWidth)}`,
+				width,
+			),
+		];
+	}
+
+	#renderSlotRows(width: number, parts: StatusLinePreviewParts | undefined): string[] {
+		const barWidth = this.#simulationWidth(width);
+		const indent = this.#simulationIndent(width);
+		const leftVisible = parts ? new Set(parts.leftIds) : undefined;
+		const rightVisible = parts
+			? new Set(parts.rightIds.filter((id): id is StatusLineSegmentId => id !== null))
+			: undefined;
+		const left = `${theme.bold("left")} ${this.#renderSide("left", leftVisible)}`;
+		const rightExtras =
+			parts?.right
+				.filter((part, index) => parts.rightIds[index] === null && /^v\d/.test(Bun.stripANSI(part)))
+				.map(part => theme.fg("dim", Bun.stripANSI(part))) ?? [];
+		const rightCore = this.#renderSide("right", rightVisible);
+		const right =
+			rightExtras.length > 0
+				? `${theme.bold("right")} ${rightCore}${theme.fg("statusLineSep", this.#separatorGlyph())}${rightExtras.join(
+						theme.fg("statusLineSep", this.#separatorGlyph()),
+					)}`
+				: `${theme.bold("right")} ${rightCore}`;
+		const combinedGap = Math.max(1, barWidth - visibleWidth(left) - visibleWidth(right));
+		if (visibleWidth(left) + visibleWidth(right) + 1 <= barWidth) {
+			return [this.#fit(`${indent}${left}${" ".repeat(combinedGap)}${right}`, width)];
+		}
+		return [
+			this.#fit(
+				`${indent}${this.#padEndVisible(truncateToWidth(left, barWidth, Ellipsis.Unicode), barWidth)}`,
+				width,
+			),
+			this.#fit(
+				`${indent}${this.#padStartVisible(truncateToWidth(right, barWidth, Ellipsis.Unicode), barWidth)}`,
+				width,
+			),
+		];
+	}
+
+	#renderChoicePanel(width: number): string[] {
+		if (this.#focus.kind !== "choice") return [];
+		const focus = this.#focus;
+		const descriptor = this.#descriptor(focus.target);
+		if (!descriptor) return [];
+		const values = descriptor.values.map((value, index) => {
+			const selected = index === focus.focusedIndex;
+			const active = value.value === descriptor.currentValue();
+			const activeMarker = theme.getSymbolPreset() === "ascii" ? "v " : "✓ ";
+			const label = `${active ? activeMarker : ""}${value.label}`;
+			if (selected) return this.#focusBox(label);
+			if (active) return this.#selectedBox(label);
+			return label;
+		});
+		return [
+			truncateToWidth(theme.bold(`Choices: ${descriptor.label}: ${values.join("  ")}`), width),
+			truncateToWidth(theme.fg("dim", "  Left/Right value · Up/Down option · Enter apply · Esc return"), width),
+		];
+	}
+
+	override render(width: number): string[] {
+		this.#normalizeFocus();
+		const lines: string[] = [];
+		lines.push(truncateToWidth(theme.bold(theme.fg("accent", "Status Line Custom Editor")), width));
+		const focusLine = `Focus: ${this.#focusLabel()}`;
+		lines.push(truncateToWidth(theme.fg("muted", focusLine), width));
+		if (this.#picked) {
+			lines.push(truncateToWidth(theme.fg("accent", `Selected: ${statusSegmentLabel(this.#picked.id)}`), width));
+		}
+		lines.push("");
+		lines.push(this.#centerVisible(theme.bold("Simulated statusbar"), width));
+		const actualStatusbarParts = this.#actualStatusbarParts(width);
+		const actualStatusbar = this.#renderActualStatusbar(width, actualStatusbarParts);
+		if (actualStatusbar.length > 0) {
+			lines.push(...actualStatusbar);
+		}
+		const slotRows = this.#renderSlotRows(width, actualStatusbarParts);
+		lines.push(...slotRows);
+		if (actualStatusbar.length > 1 || slotRows.length > 1 || width < 64) {
+			lines.push(this.#fit(theme.fg("warning", "  Warning: statusbar wrapped to 2 rows"), width));
+			if (this.#focus.kind === "statusbar") {
+				const focused = this.#picked ? this.#picked.id : this.#focusSegment();
+				if (focused) lines.push(this.#fit(`  Focused target: ${statusSegmentLabel(focused)}`, width));
+			}
+		}
+		lines.push("");
+		const paletteSegments = this.#paletteSegments();
+		const paletteTokens = paletteSegments.map((id, index) => {
+			const selected = this.#picked?.id === id;
+			const focused = this.#focus.kind === "palette" && this.#focus.index === index;
+			const label = `{${statusSegmentLabel(id)}}`;
+			if (selected) return this.#selectedBox(label);
+			return focused ? this.#focusBox(label) : theme.fg("muted", label);
+		});
+		lines.push(truncateToWidth(theme.bold("Hidden segment palette"), width));
+		lines.push(truncateToWidth(`  ${paletteTokens.length ? paletteTokens.join(" ") : "(empty)"}`, width));
+		if (width < 64 && this.#focus.kind === "palette") {
+			const focusedPalette = paletteSegments[this.#focus.index];
+			if (focusedPalette)
+				lines.push(truncateToWidth(`  Focused palette target: ${statusSegmentLabel(focusedPalette)}`, width));
+		}
+		lines.push("");
+		lines.push(truncateToWidth(theme.bold("Visible choices"), width));
+		const descriptors = this.#choiceDescriptors();
+		const focusedDescriptor = descriptors.find(
+			descriptor =>
+				(this.#focus.kind === "separator-control" && descriptor.target === "separator") ||
+				(this.#focus.kind === "option-control" && descriptor.target === this.#focus.path) ||
+				(this.#focus.kind === "choice" && descriptor.target === this.#focus.target),
+		);
+		const summaryRows = [descriptors.slice(0, 6), descriptors.slice(6)];
+		for (const row of summaryRows) {
+			lines.push(
+				truncateToWidth(
+					`  ${row
+						.map(descriptor => {
+							const focused = focusedDescriptor?.target === descriptor.target;
+							return focused ? this.#focusBox(descriptor.label) : descriptor.label;
+						})
+						.join(" · ")}`,
+					width,
+				),
+			);
+		}
+		if (focusedDescriptor) {
+			const current = focusedDescriptor.currentValue();
+			const choices = focusedDescriptor.values
+				.map(value => (value.value === current ? `[${value.label}]` : value.label))
+				.join(" | ");
+			lines.push(
+				truncateToWidth(`${theme.fg("accent", theme.nav.cursor)} ${focusedDescriptor.label}: ${choices}`, width),
+			);
+		} else {
+			const separator = descriptors[0];
+			if (separator) {
+				const current = separator.currentValue();
+				const choices = separator.values
+					.map(value => (value.value === current ? `[${value.label}]` : value.label))
+					.join(" | ");
+				lines.push(truncateToWidth(`  ${separator.label}: ${choices}`, width));
+			}
+		}
+		lines.push("");
+		const confirm = this.#focus.kind === "confirm" ? theme.bold(theme.fg("accent", "[Confirm]")) : "[Confirm]";
+		const exit = this.#focus.kind === "exit" ? theme.bold(theme.fg("accent", "[Exit]")) : "[Exit]";
+		lines.push(truncateToWidth(`  ${confirm} ${exit}`, width));
+		lines.push(...this.#renderChoicePanel(width));
+		lines.push(
+			truncateToWidth(
+				theme.fg(
+					"dim",
+					"  Enter select/drop/apply · Left/Right segment/palette/value · Up/Down slots/palette/options/actions · Delete hide · Esc exit",
+				),
+				width,
+			),
+		);
+		return lines.map(line => this.#fit(line, width));
 	}
 
 	#setOption(path: string, value: string): void {
@@ -622,16 +1214,11 @@ class StatusLineCustomEditor extends Container {
 	}
 
 	#preview(): void {
-		this.callbacks.onStatusLinePreview?.({
-			preset: "custom",
-			leftSegments: [...this.#draft.leftSegments],
-			rightSegments: [...this.#draft.rightSegments],
-			separator: this.#draft.separator,
-			segmentOptions: cloneSegmentOptions(this.#draft.segmentOptions),
-			sessionAccent: settings.get("statusLine.sessionAccent"),
-			maxRows: settings.get("statusLine.maxRows"),
-			previewHighlightSegment: this.#previewHighlightSegment,
-		});
+		this.callbacks.onRenderRequested?.();
+	}
+
+	#emitDraftToParentPreview(): void {
+		this.callbacks.onStatusLinePreview?.(this.#draftPreviewSettings());
 	}
 
 	#restorePreview(): void {
@@ -665,7 +1252,7 @@ class StatusLineCustomEditor extends Container {
 		this.callbacks.onChange("statusLine.separator", this.#draft.separator);
 		this.callbacks.onChange("statusLine.segmentOptions", cloneSegmentOptions(this.#draft.segmentOptions));
 		this.#previewHighlightSegment = undefined;
-		this.#preview();
+		this.#emitDraftToParentPreview();
 		this.done("saved");
 	}
 
@@ -675,7 +1262,112 @@ class StatusLineCustomEditor extends Container {
 	}
 
 	handleInput(data: string): void {
-		this.#list.handleInput(data);
+		if (this.#focus.kind === "choice") {
+			if (matchesKey(data, "left")) {
+				this.#moveVertical(-1);
+				this.#updatePreviewHighlight();
+				this.#preview();
+				return;
+			}
+			if (matchesKey(data, "right")) {
+				this.#moveVertical(1);
+				this.#updatePreviewHighlight();
+				this.#preview();
+				return;
+			}
+			if (matchesKey(data, "up")) {
+				this.#moveChoiceTarget(-1);
+				this.#updatePreviewHighlight();
+				this.#preview();
+				return;
+			}
+			if (matchesKey(data, "down")) {
+				this.#moveChoiceTarget(1);
+				this.#updatePreviewHighlight();
+				this.#preview();
+				return;
+			}
+			if (matchesKey(data, "enter") || matchesKey(data, "return") || data === "\n") {
+				this.#applyChoice();
+				return;
+			}
+			if (matchesKey(data, "escape")) {
+				this.#focus = cloneRootFocus(this.#focus.returnFocus);
+				this.#updatePreviewHighlight();
+				this.#preview();
+				return;
+			}
+			return;
+		}
+
+		if (matchesKey(data, "escape")) {
+			this.#cancel();
+			return;
+		}
+		if (matchesKey(data, "up")) {
+			this.#moveVertical(-1);
+			this.#updatePreviewHighlight();
+			this.#preview();
+			return;
+		}
+		if (matchesKey(data, "down")) {
+			this.#moveVertical(1);
+			this.#updatePreviewHighlight();
+			this.#preview();
+			return;
+		}
+		if (matchesKey(data, "left")) {
+			if (this.#focus.kind === "palette") this.#movePaletteFocus(-1);
+			else if (this.#focus.kind === "separator-control" || this.#focus.kind === "option-control")
+				this.#moveChoiceControl(-1);
+			else if (this.#focus.kind === "confirm" || this.#focus.kind === "exit") {
+				this.#focus = this.#focus.kind === "confirm" ? { kind: "exit" } : { kind: "confirm" };
+			} else if (this.#picked) this.#movePickedSlot(-1);
+			else this.#moveVisibleFocus(-1);
+			this.#updatePreviewHighlight();
+			this.#preview();
+			return;
+		}
+		if (matchesKey(data, "right")) {
+			if (this.#focus.kind === "palette") this.#movePaletteFocus(1);
+			else if (this.#focus.kind === "separator-control" || this.#focus.kind === "option-control")
+				this.#moveChoiceControl(1);
+			else if (this.#focus.kind === "confirm" || this.#focus.kind === "exit") {
+				this.#focus = this.#focus.kind === "confirm" ? { kind: "exit" } : { kind: "confirm" };
+			} else if (this.#picked) this.#movePickedSlot(1);
+			else this.#moveVisibleFocus(1);
+			this.#updatePreviewHighlight();
+			this.#preview();
+			return;
+		}
+		if (isDeleteKey(data)) {
+			this.#hideFocusedSegment();
+			return;
+		}
+		if (matchesKey(data, "enter") || matchesKey(data, "return") || data === "\n") {
+			switch (this.#focus.kind) {
+				case "statusbar":
+					if (this.#picked) this.#dropPicked();
+					else this.#pickFocusedStatusbar();
+					return;
+				case "palette":
+					if (this.#picked) this.#dropPickedToPalette();
+					else this.#pickFocusedPalette();
+					return;
+				case "separator-control":
+					this.#openChoice("separator", { kind: "separator-control" });
+					return;
+				case "option-control":
+					this.#openChoice(this.#focus.path, { kind: "option-control", path: this.#focus.path });
+					return;
+				case "confirm":
+					this.#save();
+					return;
+				case "exit":
+					this.#cancel();
+					return;
+			}
+		}
 	}
 }
 
@@ -728,6 +1420,7 @@ export interface StatusLinePreviewSettings {
 	separator?: StatusLineSeparatorStyle;
 	segmentOptions?: StatusLineSegmentOptions;
 	previewHighlightSegment?: StatusLineSegmentId;
+	previewHighlightStyle?: "focus" | "selected";
 	sessionAccent?: boolean;
 	maxRows?: number;
 }
@@ -757,6 +1450,13 @@ export interface SettingsCallbacks {
 	onStatusLinePreview?: (settings: StatusLinePreviewSettings) => void;
 	/** Get current rendered status line for inline preview */
 	getStatusLinePreview?: (width?: number) => string;
+	/** Render a status-line preview for supplied draft settings without mutating the live status line. */
+	getStatusLinePreviewForSettings?: (settings: StatusLinePreviewSettings, width?: number) => string;
+	/** Render status-line segment groups for supplied draft settings without mutating the live status line. */
+	getStatusLinePreviewPartsForSettings?: (
+		settings: StatusLinePreviewSettings,
+		width?: number,
+	) => StatusLinePreviewParts;
 	/** Called when plugins change */
 	onPluginsChanged?: () => void;
 	/** Called when asynchronously rebuilt settings content needs a repaint. */
@@ -1253,14 +1953,7 @@ export class SettingsSelectorComponent extends Container {
 
 		// Add status line preview for appearance tab
 		if (tabId === "appearance") {
-			this.#statusPreviewContainer = new Container();
-			this.#statusPreviewContainer.addChild(new Spacer(1));
-			this.#statusPreviewContainer.addChild(
-				new DynamicThemeText(() => theme.fg("muted", uiString(settings.get("ui.language"), "settings.preview"))),
-			);
-			this.#statusPreviewText = new Text(this.#getStatusPreviewString(), 0, 0);
-			this.#statusPreviewContainer.addChild(this.#statusPreviewText);
-			this.#statusPreviewContainer.addChild(new Spacer(1));
+			this.#statusPreviewContainer = this.#createStatusPreviewContainer();
 			this.addChild(this.#statusPreviewContainer);
 		}
 
@@ -1323,6 +2016,39 @@ export class SettingsSelectorComponent extends Container {
 		this.addChild(this.#currentList);
 	}
 
+	#createStatusPreviewContainer(): Container {
+		const container = new Container();
+		container.addChild(new Spacer(1));
+		container.addChild(
+			new DynamicThemeText(() => theme.fg("muted", uiString(settings.get("ui.language"), "settings.preview"))),
+		);
+		this.#statusPreviewText = new Text(this.#getStatusPreviewString(), 0, 0);
+		container.addChild(this.#statusPreviewText);
+		container.addChild(new Spacer(1));
+		return container;
+	}
+
+	#hideStatusPreview(): void {
+		if (!this.#statusPreviewContainer) return;
+		this.removeChild(this.#statusPreviewContainer);
+		this.#statusPreviewContainer = null;
+		this.#statusPreviewText = null;
+	}
+
+	#showStatusPreview(): void {
+		if (this.#statusPreviewContainer || this.#currentTabId !== "appearance") return;
+		const container = this.#createStatusPreviewContainer();
+		this.#statusPreviewContainer = container;
+		const children = [...this.children];
+		const listIndex = this.#currentList ? children.indexOf(this.#currentList) : -1;
+		if (listIndex >= 0) {
+			children.splice(listIndex, 0, container);
+			this.replaceChildren(children);
+		} else {
+			this.addChild(container);
+		}
+	}
+
 	/** Map a definition list to UI items, dropping any whose condition is false. */
 	#buildItemsForDefs(defs: SettingDef[]): SettingItem[] {
 		const items: SettingItem[] = [];
@@ -1365,9 +2091,15 @@ export class SettingsSelectorComponent extends Container {
 				id: STATUS_LINE_CUSTOM_EDITOR_ID,
 				label: "Status Line Custom Editor",
 				description:
-					"Edit custom status line segments, placement, separator, and typed segment options with live previews.",
+					"Edit custom status line segments, placement, separator, and typed segment options in a simulated statusbar.",
 				currentValue: "open",
-				submenu: (_currentValue, done) => new StatusLineCustomEditor(customEditorCallbacks, done),
+				submenu: (_currentValue, done) => {
+					this.#hideStatusPreview();
+					return new StatusLineCustomEditor(customEditorCallbacks, value => {
+						this.#showStatusPreview();
+						done(value);
+					});
+				},
 			};
 			const presetIndex = items.findIndex(item => item.id === "statusLine.preset");
 			if (presetIndex >= 0) {
@@ -1512,6 +2244,10 @@ export class SettingsSelectorComponent extends Container {
 		// Handle tab switching — but NOT when a text input is active, since
 		// arrow keys must reach the cursor and Tab must not switch tabs.
 		if (!this.#textInputActive && tabNavigation) {
+			if (this.#currentList?.navigationLocked) {
+				this.#currentList.handleInput(data);
+				return;
+			}
 			this.#tabBar.handleInput(data);
 			return;
 		}

--- a/packages/coding-agent/src/modes/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/components/settings-selector.ts
@@ -88,6 +88,14 @@ class TextInputSubmenu extends Container {
 	handleInput(data: string): void {
 		handleInputOrEscape(data, this.#input, this.onCancel);
 	}
+
+	submit(): void {
+		this.onSubmit(this.#input.getValue());
+	}
+
+	cancel(): void {
+		this.onCancel();
+	}
 }
 
 class SelectSubmenu extends Container {
@@ -214,6 +222,8 @@ function mergeSegmentOptions(
 	overrides: StatusLineSegmentOptions | undefined,
 ): StatusLineSegmentOptions {
 	return {
+		...base,
+		...overrides,
 		model: base?.model || overrides?.model ? { ...(base?.model ?? {}), ...(overrides?.model ?? {}) } : undefined,
 		path: base?.path || overrides?.path ? { ...(base?.path ?? {}), ...(overrides?.path ?? {}) } : undefined,
 		git: base?.git || overrides?.git ? { ...(base?.git ?? {}), ...(overrides?.git ?? {}) } : undefined,
@@ -231,13 +241,31 @@ function effectiveSegmentOptions(
 	return mergeSegmentOptions(getPreset(preset).segmentOptions, options);
 }
 
+function normalizeEditorSegments(value: unknown): StatusLineSegmentId[] {
+	if (!Array.isArray(value)) return [];
+	const seen = new Set<string>();
+	const normalized: StatusLineSegmentId[] = [];
+	for (const raw of value) {
+		const id = typeof raw === "string" ? raw : String(raw);
+		if (!id || seen.has(id)) continue;
+		seen.add(id);
+		normalized.push(id as StatusLineSegmentId);
+	}
+	return normalized;
+}
+
 function effectiveCustomSegments(
 	preset: StatusLinePreset,
-	leftSegments: StatusLineSegmentId[],
-	rightSegments: StatusLineSegmentId[],
+	leftSegments: unknown,
+	rightSegments: unknown,
 ): { leftSegments: StatusLineSegmentId[]; rightSegments: StatusLineSegmentId[] } {
 	if (preset === "custom") {
-		return { leftSegments: [...leftSegments], rightSegments: [...rightSegments] };
+		const left = normalizeEditorSegments(leftSegments);
+		const leftIds = new Set(left);
+		return {
+			leftSegments: left,
+			rightSegments: normalizeEditorSegments(rightSegments).filter(id => !leftIds.has(id)),
+		};
 	}
 	const presetDef = getPreset(preset);
 	return {
@@ -279,7 +307,8 @@ type StatusLineOptionPath =
 	| "git.showUntracked"
 	| "time.format"
 	| "time.showSeconds"
-	| "usage.mode";
+	| "usage.mode"
+	| "command.command";
 type StatusLineChoiceTarget = "separator" | StatusLineOptionPath;
 type StatusLineRootFocus =
 	| { kind: "statusbar"; side: StatusLineSide; index: number }
@@ -336,6 +365,7 @@ class StatusLineCustomEditor extends Container {
 	#focus: StatusLineFocus = { kind: "statusbar", side: "left", index: 0 };
 	#picked: PickedStatusLineSegment | undefined;
 	#pickedStatusbarFocus: Extract<StatusLineRootFocus, { kind: "statusbar" }> | undefined;
+	#textInput: TextInputSubmenu | undefined;
 
 	constructor(
 		private readonly callbacks: SettingsCallbacks,
@@ -470,6 +500,10 @@ class StatusLineCustomEditor extends Container {
 		return this.#choiceDescriptors().find(descriptor => descriptor.target === target);
 	}
 
+	#controlTargets(): StatusLineChoiceTarget[] {
+		return [...this.#choiceDescriptors().map(descriptor => descriptor.target), "command.command"];
+	}
+
 	#hiddenSegments(): StatusLineSegmentId[] {
 		const visible = new Set([...this.#draft.leftSegments, ...this.#draft.rightSegments]);
 		return PUBLIC_STATUS_SEGMENTS.filter(id => !visible.has(id));
@@ -500,7 +534,6 @@ class StatusLineCustomEditor extends Container {
 	}
 
 	#normalizeFocus(): void {
-		const descriptors = this.#choiceDescriptors();
 		if (this.#focus.kind === "choice") {
 			const descriptor = this.#descriptor(this.#focus.target);
 			if (!descriptor) {
@@ -535,7 +568,7 @@ class StatusLineCustomEditor extends Container {
 			}
 		} else if (
 			this.#focus.kind === "option-control" &&
-			!descriptors.some(descriptor => descriptor.target === (this.#focus as { path: StatusLineOptionPath }).path)
+			!this.#controlTargets().includes((this.#focus as { path: StatusLineOptionPath }).path)
 		) {
 			this.#focus = { kind: "separator-control" };
 		}
@@ -664,18 +697,15 @@ class StatusLineCustomEditor extends Container {
 
 	#moveChoiceControl(delta: -1 | 1): void {
 		if (this.#focus.kind !== "separator-control" && this.#focus.kind !== "option-control") return;
-		const descriptors = this.#choiceDescriptors();
+		const targets = this.#controlTargets();
 		const currentTarget = this.#focus.kind === "separator-control" ? "separator" : this.#focus.path;
-		const currentIndex = Math.max(
-			0,
-			descriptors.findIndex(descriptor => descriptor.target === currentTarget),
-		);
-		const next = descriptors[(currentIndex + delta + descriptors.length) % descriptors.length];
+		const currentIndex = Math.max(0, targets.indexOf(currentTarget));
+		const next = targets[(currentIndex + delta + targets.length) % targets.length];
 		if (!next) return;
 		this.#focus =
-			next.target === "separator"
+			next === "separator"
 				? { kind: "separator-control" }
-				: { kind: "option-control", path: next.target as StatusLineOptionPath };
+				: { kind: "option-control", path: next as StatusLineOptionPath };
 	}
 
 	#moveChoiceTarget(delta: -1 | 1): void {
@@ -756,10 +786,13 @@ class StatusLineCustomEditor extends Container {
 	#hideFocusedSegment(): void {
 		if (this.#picked || this.#focus.kind !== "statusbar") return;
 		const group = this.#draft[`${this.#focus.side}Segments`];
-		if (!group[this.#focus.index]) return;
+		const removed = group[this.#focus.index];
+		if (!removed) return;
 		group.splice(this.#focus.index, 1);
 		const hidden = this.#hiddenSegments();
-		this.#focus = hidden.length ? { kind: "palette", index: hidden.length - 1 } : { kind: "separator-control" };
+		this.#focus = hidden.length
+			? { kind: "palette", index: Math.max(0, hidden.indexOf(removed)) }
+			: { kind: "separator-control" };
 		this.#updatePreviewHighlight();
 		this.#preview();
 	}
@@ -777,6 +810,27 @@ class StatusLineCustomEditor extends Container {
 			),
 			returnFocus,
 		};
+	}
+
+	#openCommandInput(): void {
+		this.#textInput = new TextInputSubmenu(
+			"Status line command",
+			"Runs in the configured shell with a short timeout and cached refreshes.",
+			this.#draft.segmentOptions.command?.command ?? "",
+			value => {
+				this.#setOption("command.command", value);
+				this.#textInput = undefined;
+				this.#focus = { kind: "option-control", path: "command.command" };
+				this.#updatePreviewHighlight();
+				this.#preview();
+			},
+			() => {
+				this.#textInput = undefined;
+				this.#focus = { kind: "option-control", path: "command.command" };
+				this.#updatePreviewHighlight();
+				this.#preview();
+			},
+		);
 	}
 
 	#applyChoice(): void {
@@ -805,7 +859,8 @@ class StatusLineCustomEditor extends Container {
 			return;
 		}
 		if (this.#focus.kind === "option-control") {
-			this.#previewHighlightSegment = this.#descriptor(this.#focus.path)?.highlightSegment;
+			this.#previewHighlightSegment =
+				this.#focus.path === "command.command" ? "command" : this.#descriptor(this.#focus.path)?.highlightSegment;
 			return;
 		}
 		if (this.#focus.kind === "choice") {
@@ -927,7 +982,7 @@ class StatusLineCustomEditor extends Container {
 				this.#focus.kind === "statusbar" &&
 				this.#focus.side === side &&
 				this.#focus.index === index;
-			rendered.push(this.#renderSegment(id, selected, visibleIds?.has(id) ?? false));
+			rendered.push(this.#renderSegment(id, selected, visibleIds ? visibleIds.has(id) : true));
 		}
 		if (this.#picked && this.#focus.kind === "statusbar" && this.#focus.side === side) {
 			rendered.splice(
@@ -976,22 +1031,27 @@ class StatusLineCustomEditor extends Container {
 	}
 
 	#renderActualStatusbar(width: number, parts: StatusLinePreviewParts | undefined): string[] {
-		if (parts) return this.#renderActualStatusbarParts(width, parts);
-		const rendered = this.callbacks.getStatusLinePreviewForSettings?.(this.#draftPreviewSettings(true), width);
-		if (!rendered) return [];
-		return rendered
-			.split("\n")
-			.map(line => line.trimEnd())
-			.filter(line => line.length > 0)
-			.map(line => this.#centerVisible(this.#fit(line, this.#simulationWidth(width)), width));
+		const rendered = this.callbacks.getStatusLinePreviewForSettings?.(
+			this.#draftPreviewSettings(true),
+			this.#simulationWidth(width),
+		);
+		if (rendered) {
+			return rendered
+				.split("\n")
+				.map(line => line.trimEnd())
+				.filter(line => line.length > 0)
+				.map(line => this.#centerVisible(this.#fit(line, this.#simulationWidth(width)), width));
+		}
+		return parts ? this.#renderActualStatusbarParts(width, parts) : [];
 	}
 
 	#renderActualStatusbarParts(width: number, parts: StatusLinePreviewParts): string[] {
 		const barWidth = this.#simulationWidth(width);
 		const indent = this.#simulationIndent(width);
-		const separator = theme.fg("statusLineSep", ` ${parts.separator.left} `);
-		const left = parts.left.join(separator);
-		const right = parts.right.join(separator);
+		const leftSeparator = theme.fg("statusLineSep", ` ${parts.separator.left} `);
+		const rightSeparator = theme.fg("statusLineSep", ` ${parts.separator.right} `);
+		const left = parts.left.join(leftSeparator);
+		const right = parts.right.join(rightSeparator);
 		const combinedGap = Math.max(1, barWidth - visibleWidth(left) - visibleWidth(right));
 		if (visibleWidth(left) + visibleWidth(right) + 1 <= barWidth) {
 			return [this.#fit(`${indent}${left}${" ".repeat(combinedGap)}${right}`, width)];
@@ -1064,6 +1124,7 @@ class StatusLineCustomEditor extends Container {
 	}
 
 	override render(width: number): string[] {
+		if (this.#textInput) return this.#textInput.render(width);
 		this.#normalizeFocus();
 		const lines: string[] = [];
 		lines.push(truncateToWidth(theme.bold(theme.fg("accent", "Status Line Custom Editor")), width));
@@ -1081,7 +1142,7 @@ class StatusLineCustomEditor extends Container {
 		}
 		const slotRows = this.#renderSlotRows(width, actualStatusbarParts);
 		lines.push(...slotRows);
-		if (actualStatusbar.length > 1 || slotRows.length > 1 || width < 64) {
+		if (actualStatusbar.length > 1 || slotRows.length > 1) {
 			lines.push(this.#fit(theme.fg("warning", "  Warning: statusbar wrapped to 2 rows"), width));
 			if (this.#focus.kind === "statusbar") {
 				const focused = this.#picked ? this.#picked.id : this.#focusSegment();
@@ -1127,6 +1188,10 @@ class StatusLineCustomEditor extends Container {
 				),
 			);
 		}
+		const commandFocused = this.#focus.kind === "option-control" && this.#focus.path === "command.command";
+		lines.push(
+			truncateToWidth(`  ${commandFocused ? this.#focusBox("Command: command") : "Command: command"}`, width),
+		);
 		if (focusedDescriptor) {
 			const current = focusedDescriptor.currentValue();
 			const choices = focusedDescriptor.values
@@ -1135,6 +1200,9 @@ class StatusLineCustomEditor extends Container {
 			lines.push(
 				truncateToWidth(`${theme.fg("accent", theme.nav.cursor)} ${focusedDescriptor.label}: ${choices}`, width),
 			);
+		} else if (commandFocused) {
+			const command = this.#draft.segmentOptions.command?.command ?? "";
+			lines.push(truncateToWidth(`${theme.fg("accent", theme.nav.cursor)} Command: ${command || "(empty)"}`, width));
 		} else {
 			const separator = descriptors[0];
 			if (separator) {
@@ -1262,6 +1330,17 @@ class StatusLineCustomEditor extends Container {
 	}
 
 	handleInput(data: string): void {
+		const kb = getKeybindings();
+		const selectUp = kb.matches(data, "tui.select.up");
+		const selectDown = kb.matches(data, "tui.select.down");
+		const selectConfirm = kb.matches(data, "tui.select.confirm") || data === "\n";
+		const selectCancel = kb.matches(data, "tui.select.cancel");
+		if (this.#textInput) {
+			if (selectCancel) this.#textInput.cancel();
+			else if (selectConfirm) this.#textInput.submit();
+			else this.#textInput.handleInput(data);
+			return;
+		}
 		if (this.#focus.kind === "choice") {
 			if (matchesKey(data, "left")) {
 				this.#moveVertical(-1);
@@ -1275,23 +1354,23 @@ class StatusLineCustomEditor extends Container {
 				this.#preview();
 				return;
 			}
-			if (matchesKey(data, "up")) {
+			if (selectUp) {
 				this.#moveChoiceTarget(-1);
 				this.#updatePreviewHighlight();
 				this.#preview();
 				return;
 			}
-			if (matchesKey(data, "down")) {
+			if (selectDown) {
 				this.#moveChoiceTarget(1);
 				this.#updatePreviewHighlight();
 				this.#preview();
 				return;
 			}
-			if (matchesKey(data, "enter") || matchesKey(data, "return") || data === "\n") {
+			if (selectConfirm) {
 				this.#applyChoice();
 				return;
 			}
-			if (matchesKey(data, "escape")) {
+			if (selectCancel) {
 				this.#focus = cloneRootFocus(this.#focus.returnFocus);
 				this.#updatePreviewHighlight();
 				this.#preview();
@@ -1300,17 +1379,17 @@ class StatusLineCustomEditor extends Container {
 			return;
 		}
 
-		if (matchesKey(data, "escape")) {
+		if (selectCancel) {
 			this.#cancel();
 			return;
 		}
-		if (matchesKey(data, "up")) {
+		if (selectUp) {
 			this.#moveVertical(-1);
 			this.#updatePreviewHighlight();
 			this.#preview();
 			return;
 		}
-		if (matchesKey(data, "down")) {
+		if (selectDown) {
 			this.#moveVertical(1);
 			this.#updatePreviewHighlight();
 			this.#preview();
@@ -1344,7 +1423,7 @@ class StatusLineCustomEditor extends Container {
 			this.#hideFocusedSegment();
 			return;
 		}
-		if (matchesKey(data, "enter") || matchesKey(data, "return") || data === "\n") {
+		if (selectConfirm) {
 			switch (this.#focus.kind) {
 				case "statusbar":
 					if (this.#picked) this.#dropPicked();
@@ -1358,7 +1437,8 @@ class StatusLineCustomEditor extends Container {
 					this.#openChoice("separator", { kind: "separator-control" });
 					return;
 				case "option-control":
-					this.#openChoice(this.#focus.path, { kind: "option-control", path: this.#focus.path });
+					if (this.#focus.path === "command.command") this.#openCommandInput();
+					else this.#openChoice(this.#focus.path, { kind: "option-control", path: this.#focus.path });
 					return;
 				case "confirm":
 					this.#save();

--- a/packages/coding-agent/src/modes/components/tool-status-header.ts
+++ b/packages/coding-agent/src/modes/components/tool-status-header.ts
@@ -821,11 +821,12 @@ export class StatusLineComponent implements Component {
 			Pick<StatusLineSettings, "leftSegments" | "rightSegments" | "separator" | "segmentOptions">
 		> &
 			StatusLineSettings,
+		previewOnly = false,
 	): SegmentContext {
 		const state = this.session.state;
 
 		this.#syncCachedUsageForActiveProvider();
-		this.refreshUsageInBackground();
+		if (!previewOnly) this.refreshUsageInBackground();
 
 		// Get usage statistics
 		const aggregateUsageStats = this.session.sessionManager?.getUsageStatistics() ?? {
@@ -856,8 +857,9 @@ export class StatusLineComponent implements Component {
 		const commandSegmentActive =
 			effectiveSettings.leftSegments.includes("command") || effectiveSettings.rightSegments.includes("command");
 		const commandOptions = commandSegmentActive ? this.#trustedCommandOptions() : undefined;
-		const commandKey = commandOptions ? this.#refreshCommandInBackground(commandOptions) : undefined;
-		if (!commandKey) this.#disableCommandSegment();
+		const commandKey =
+			!previewOnly && commandOptions ? this.#refreshCommandInBackground(commandOptions) : this.#commandConfigKey;
+		if (!previewOnly && !commandKey) this.#disableCommandSegment();
 
 		return {
 			session: this.session,
@@ -876,14 +878,16 @@ export class StatusLineComponent implements Component {
 			git: {
 				branch: this.#getCurrentBranch(),
 				status: this.#getGitStatus(),
-				pr: prSegmentActive ? this.#lookupPr() : null,
+				pr: prSegmentActive ? (previewOnly ? (this.#cachedPr ?? null) : this.#lookupPr()) : null,
 			},
 			usage: this.#cachedUsage,
-			command: commandKey
+			command: commandSegmentActive
 				? {
 						output: this.#commandOutput,
 						failed: this.#commandFailed,
-						pending: this.#commandInFlightKey === commandKey,
+						pending: previewOnly
+							? this.#commandOutput === null && !this.#commandFailed
+							: this.#commandInFlightKey === commandKey,
 					}
 				: undefined,
 		};
@@ -1034,8 +1038,9 @@ export class StatusLineComponent implements Component {
 			Pick<StatusLineSettings, "leftSegments" | "rightSegments" | "separator" | "segmentOptions">
 		> &
 			StatusLineSettings,
+		previewOnly = false,
 	): CollectedStatusSegments {
-		const ctx = this.#buildSegmentContext(width, effectiveSettings);
+		const ctx = this.#buildSegmentContext(width, effectiveSettings, previewOnly);
 		const separatorDef = getSeparator(effectiveSettings.separator ?? "powerline-thin", theme);
 
 		// Use the subtle surface tone (the same elevated background as user-message
@@ -1333,9 +1338,9 @@ export class StatusLineComponent implements Component {
 	 * being dropped. Falls back to the polished justified single row whenever
 	 * everything fits on one line.
 	 */
-	#buildStatusRows(width: number, maxRows: number): string[] {
+	#buildStatusRows(width: number, maxRows: number, previewOnly = false): string[] {
 		const effectiveSettings = this.#resolveSettings();
-		const seg = this.#collectStatusSegments(width, effectiveSettings);
+		const seg = this.#collectStatusSegments(width, effectiveSettings, previewOnly);
 		const cacheKey = JSON.stringify({
 			width,
 			maxRows,
@@ -1370,14 +1375,14 @@ export class StatusLineComponent implements Component {
 				.join(","),
 			version: this.#version,
 		});
-		if (this.#renderedRowsCache?.key === cacheKey) {
+		if (!previewOnly && this.#renderedRowsCache?.key === cacheKey) {
 			this.#renderedRowsCacheHits++;
 			return [...this.#renderedRowsCache.rows];
 		}
-		this.#renderedRowsCacheMisses++;
+		if (!previewOnly) this.#renderedRowsCacheMisses++;
 
 		if (seg.left.length === 0 && seg.right.length === 0) {
-			this.#renderedRowsCache = { key: cacheKey, rows: [] };
+			if (!previewOnly) this.#renderedRowsCache = { key: cacheKey, rows: [] };
 			return [];
 		}
 
@@ -1455,7 +1460,7 @@ export class StatusLineComponent implements Component {
 			if (dropped > 0) {
 				const priorityRow = this.#priorityRowFor(seg, [], [], topFillWidth);
 				if (priorityRow !== null) {
-					this.#renderedRowsCache = { key: cacheKey, rows: [priorityRow] };
+					if (!previewOnly) this.#renderedRowsCache = { key: cacheKey, rows: [priorityRow] };
 					return [priorityRow];
 				}
 			}
@@ -1495,7 +1500,7 @@ export class StatusLineComponent implements Component {
 			if (packedRows.length === 0 && marker) rows = [marker];
 		}
 
-		this.#renderedRowsCache = { key: cacheKey, rows };
+		if (!previewOnly) this.#renderedRowsCache = { key: cacheKey, rows };
 		return [...rows];
 	}
 
@@ -1521,7 +1526,7 @@ export class StatusLineComponent implements Component {
 		const previousSettings = this.#settings;
 		this.#settings = { ...previousSettings, previewHighlightSegment: undefined, ...previewSettings };
 		try {
-			return this.#buildStatusRows(width, this.#resolveMaxRows()).join("\n");
+			return this.#buildStatusRows(width, this.#resolveMaxRows(), true).join("\n");
 		} finally {
 			this.#settings = previousSettings;
 		}
@@ -1621,7 +1626,7 @@ export class StatusLineComponent implements Component {
 		this.#resolvedSettingsCache = undefined;
 		this.#resolvedSettingsFingerprint = undefined;
 		try {
-			const seg = this.#collectStatusSegments(width, this.#resolveSettings());
+			const seg = this.#collectStatusSegments(width, this.#resolveSettings(), true);
 			const placed = this.#placePreviewSegments(seg, width);
 			return { ...placed, separator: seg.separatorDef };
 		} finally {

--- a/packages/coding-agent/src/modes/components/tool-status-header.ts
+++ b/packages/coding-agent/src/modes/components/tool-status-header.ts
@@ -57,6 +57,7 @@ export interface StatusLineSettings {
 	separator?: StatusLineSeparatorStyle;
 	segmentOptions?: StatusLineSegmentOptions;
 	previewHighlightSegment?: StatusLineSegmentId;
+	previewHighlightStyle?: "focus" | "selected";
 	showHookStatus?: boolean;
 	showSkillHud?: boolean;
 	showActionHints?: boolean;
@@ -76,6 +77,14 @@ export interface StatusLineComponentOptions {
 export interface StatusLineActionHint {
 	id: AppKeybinding;
 	content: string;
+}
+
+export interface StatusLinePreviewParts {
+	left: string[];
+	leftIds: StatusLineSegmentId[];
+	right: string[];
+	rightIds: (StatusLineSegmentId | null)[];
+	separator: SeparatorDef;
 }
 
 const ACTION_HINT_PRIORITY: readonly AppKeybinding[] = [
@@ -145,6 +154,7 @@ interface CollectedStatusSegments {
 	/** Parallel to `right`; null for action hints, job counts and the version tag. */
 	rightSegIds: (StatusLineSegmentId | null)[];
 	previewHighlightSegment: StatusLineSegmentId | undefined;
+	previewHighlightStyle: "focus" | "selected";
 	sessionAccent: boolean | undefined;
 	leftSepWidth: number;
 	rightSepWidth: number;
@@ -952,7 +962,14 @@ export class StatusLineComponent implements Component {
 		if (available <= 0 || count <= 0) return "";
 		const withCount = `…+${count}`;
 		const text = visibleWidth(withCount) <= available ? withCount : "…";
-		return theme.fg("dim", text);
+		return truncateToWidth(theme.fg("dim", text), available);
+	}
+
+	#renderPreviewHighlight(content: string, style: "focus" | "selected"): string {
+		const bgColor = style === "selected" ? "warning" : "text";
+		const bgAnsi = theme.getFgAnsi(bgColor).replace("\x1b[38;", "\x1b[48;");
+		const fgAnsi = theme.getBgAnsi("selectedBg").replace("\x1b[48;", "\x1b[38;");
+		return `${bgAnsi}${fgAnsi}> ${Bun.stripANSI(content)} <\x1b[0m`;
 	}
 
 	#renderStatusGroup(
@@ -1030,8 +1047,9 @@ export class StatusLineComponent implements Component {
 		const sepAnsi = theme.getFgAnsi("statusLineSep");
 
 		const previewHighlightSegment = effectiveSettings.previewHighlightSegment;
+		const previewHighlightStyle = effectiveSettings.previewHighlightStyle ?? "focus";
 		const highlightSegment = (segId: StatusLineSegmentId, content: string): string =>
-			previewHighlightSegment === segId ? `\x1b[7m${content}\x1b[27m` : content;
+			previewHighlightSegment === segId ? this.#renderPreviewHighlight(content, previewHighlightStyle) : content;
 
 		const left: string[] = [];
 		const leftSegIds: StatusLineSegmentId[] = [];
@@ -1093,6 +1111,7 @@ export class StatusLineComponent implements Component {
 			right,
 			rightSegIds,
 			previewHighlightSegment,
+			previewHighlightStyle,
 			sessionAccent: effectiveSettings.sessionAccent,
 			leftSepWidth: visibleWidth(separatorDef.left),
 			rightSepWidth: visibleWidth(separatorDef.right),
@@ -1189,7 +1208,7 @@ export class StatusLineComponent implements Component {
 
 	#buildStatusLine(width: number, precollected?: CollectedStatusSegments): string {
 		const seg = precollected ?? this.#collectStatusSegments(width, this.#resolveSettings());
-		const { ctx, separatorDef, bgAnsi, fgAnsi, sepAnsi, previewHighlightSegment } = seg;
+		const { ctx, separatorDef, bgAnsi, fgAnsi, sepAnsi, previewHighlightSegment, previewHighlightStyle } = seg;
 		const { leftSepWidth, rightSepWidth, leftCapWidth, rightCapWidth } = seg;
 		const topFillWidth = Math.max(0, width);
 
@@ -1222,7 +1241,10 @@ export class StatusLineComponent implements Component {
 					const overflow = totalWidth() - budget;
 					const shrunk = this.#shrinkPathToWidth(left[pathIdx], ctx, overflow);
 					if (shrunk !== null) {
-						left[pathIdx] = previewHighlightSegment === "path" ? `\x1b[7m${shrunk}\x1b[27m` : shrunk;
+						left[pathIdx] =
+							previewHighlightSegment === "path"
+								? this.#renderPreviewHighlight(shrunk, previewHighlightStyle)
+								: shrunk;
 						leftWidth = this.#groupWidth(left, leftCapWidth, leftSepWidth);
 					}
 				}
@@ -1493,6 +1515,120 @@ export class StatusLineComponent implements Component {
 	 */
 	getPreviewContent(width: number): string {
 		return this.#buildStatusRows(width, this.#resolveMaxRows()).join("\n");
+	}
+
+	getPreviewContentForSettings(width: number, previewSettings: StatusLineSettings): string {
+		const previousSettings = this.#settings;
+		this.#settings = { ...previousSettings, previewHighlightSegment: undefined, ...previewSettings };
+		try {
+			return this.#buildStatusRows(width, this.#resolveMaxRows()).join("\n");
+		} finally {
+			this.#settings = previousSettings;
+		}
+	}
+
+	#placePreviewSegments(
+		seg: CollectedStatusSegments,
+		width: number,
+	): {
+		left: string[];
+		leftIds: StatusLineSegmentId[];
+		right: string[];
+		rightIds: (StatusLineSegmentId | null)[];
+	} {
+		const {
+			ctx,
+			previewHighlightSegment,
+			previewHighlightStyle,
+			leftSepWidth,
+			rightSepWidth,
+			leftCapWidth,
+			rightCapWidth,
+		} = seg;
+		const rank = this.#priorityRanker(seg);
+		const layout = (budget: number) => {
+			const left = [...seg.left];
+			const leftIds = [...seg.leftSegIds];
+			const right = [...seg.right];
+			const rightIds = [...seg.rightSegIds];
+			let leftWidth = this.#groupWidth(left, leftCapWidth, leftSepWidth);
+			let rightWidth = this.#groupWidth(right, rightCapWidth, rightSepWidth);
+			const totalWidth = () => leftWidth + rightWidth + (left.length > 0 && right.length > 0 ? 1 : 0);
+			let dropped = 0;
+
+			const pathIdx = leftIds.indexOf("path");
+			if (pathIdx >= 0 && totalWidth() > budget) {
+				const shrunk = this.#shrinkPathToWidth(left[pathIdx], ctx, totalWidth() - budget);
+				if (shrunk !== null) {
+					left[pathIdx] =
+						previewHighlightSegment === "path"
+							? this.#renderPreviewHighlight(shrunk, previewHighlightStyle)
+							: shrunk;
+					leftWidth = this.#groupWidth(left, leftCapWidth, leftSepWidth);
+				}
+			}
+			while (totalWidth() > budget && (left.length > 0 || right.length > 0)) {
+				let victimSide: "left" | "right" | null = null;
+				let victimIndex = -1;
+				let victimRank = Number.POSITIVE_INFINITY;
+				for (let index = right.length - 1; index >= 0; index -= 1) {
+					const candidate = rank(rightIds[index]);
+					if (candidate < victimRank) {
+						victimRank = candidate;
+						victimSide = "right";
+						victimIndex = index;
+					}
+				}
+				for (let index = left.length - 1; index >= 0; index -= 1) {
+					const candidate = rank(leftIds[index]);
+					if (candidate < victimRank) {
+						victimRank = candidate;
+						victimSide = "left";
+						victimIndex = index;
+					}
+				}
+				if (victimSide === null) break;
+				if (victimSide === "right") {
+					right.splice(victimIndex, 1);
+					rightIds.splice(victimIndex, 1);
+					rightWidth = this.#groupWidth(right, rightCapWidth, rightSepWidth);
+				} else {
+					left.splice(victimIndex, 1);
+					leftIds.splice(victimIndex, 1);
+					leftWidth = this.#groupWidth(left, leftCapWidth, leftSepWidth);
+				}
+				dropped += 1;
+			}
+			return { left, leftIds, right, rightIds, dropped };
+		};
+
+		let placed = layout(Math.max(0, width));
+		let reserved = 0;
+		if (placed.dropped > 0 && width > 0) {
+			for (let pass = 0; pass < 4; pass += 1) {
+				const needed = Math.min(width, visibleWidth(`…+${placed.dropped}`));
+				if (needed <= reserved) break;
+				reserved = needed;
+				placed = layout(Math.max(0, width - reserved));
+			}
+		}
+		return placed;
+	}
+
+	getPreviewPartsForSettings(width: number, previewSettings: StatusLineSettings): StatusLinePreviewParts {
+		const previousSettings = this.#settings;
+		this.#settings = { ...previousSettings, ...previewSettings };
+		this.#resolvedSettingsCache = undefined;
+		this.#resolvedSettingsFingerprint = undefined;
+		try {
+			const seg = this.#collectStatusSegments(width, this.#resolveSettings());
+			const placed = this.#placePreviewSegments(seg, width);
+			return { ...placed, separator: seg.separatorDef };
+		} finally {
+			this.#settings = previousSettings;
+			this.#resolvedSettingsCache = undefined;
+			this.#resolvedSettingsFingerprint = undefined;
+		}
 	}
 
 	getCacheStatsForTest(): { rowHits: number; rowMisses: number } {

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1976,6 +1976,22 @@ export class SelectorController {
 								width ?? this.ctx.editor.getTopBorderAvailableWidth(this.ctx.ui.terminal.columns);
 							return this.ctx.statusLine.getPreviewContent(availableWidth);
 						},
+						getStatusLinePreviewForSettings: (previewSettings, width?: number) => {
+							const availableWidth =
+								width ?? this.ctx.editor.getTopBorderAvailableWidth(this.ctx.ui.terminal.columns);
+							return this.ctx.statusLine.getPreviewContentForSettings(availableWidth, {
+								...buildStatusLineSettings(settings),
+								...previewSettings,
+							});
+						},
+						getStatusLinePreviewPartsForSettings: (previewSettings, width?: number) => {
+							const availableWidth =
+								width ?? this.ctx.editor.getTopBorderAvailableWidth(this.ctx.ui.terminal.columns);
+							return this.ctx.statusLine.getPreviewPartsForSettings(availableWidth, {
+								...buildStatusLineSettings(settings),
+								...previewSettings,
+							});
+						},
 						onPluginsChanged: () => {
 							this.ctx.ui.requestRender();
 						},

--- a/packages/coding-agent/test/fixtures/tui/status-line-custom-editor-showcase.ts
+++ b/packages/coding-agent/test/fixtures/tui/status-line-custom-editor-showcase.ts
@@ -47,17 +47,17 @@ export const STATUS_LINE_CUSTOM_EDITOR_SHOWCASE_ENTRIES: StatusLineCustomEditorS
 	...BASE_STATES.filter(stateId => stateId !== "narrow-cjk").map(stateId => ({
 		stateId,
 		columns: 80,
-		rows: 24,
+		rows: 32,
 		renderMode: "unicode-color" as const,
 	})),
-	{ stateId: "overflow-two-row-warning", columns: 48, rows: 36, renderMode: "unicode-color" },
-	{ stateId: "narrow-cjk", columns: 48, rows: 36, renderMode: "unicode-color" },
-	{ stateId: "root-statusbar", columns: 80, rows: 24, renderMode: "ascii-no-color" },
-	{ stateId: "picked-origin-slot", columns: 80, rows: 24, renderMode: "ascii-no-color" },
-	{ stateId: "separator-choice-focused", columns: 80, rows: 24, renderMode: "ascii-no-color" },
-	{ stateId: "option-boolean-choice-focused", columns: 80, rows: 24, renderMode: "ascii-no-color" },
-	{ stateId: "option-enum-choice-focused", columns: 80, rows: 24, renderMode: "ascii-no-color" },
-	{ stateId: "option-numeric-choice-focused", columns: 80, rows: 24, renderMode: "ascii-no-color" },
+	{ stateId: "overflow-two-row-warning", columns: 48, rows: 40, renderMode: "unicode-color" },
+	{ stateId: "narrow-cjk", columns: 48, rows: 40, renderMode: "unicode-color" },
+	{ stateId: "root-statusbar", columns: 80, rows: 32, renderMode: "ascii-no-color" },
+	{ stateId: "picked-origin-slot", columns: 80, rows: 32, renderMode: "ascii-no-color" },
+	{ stateId: "separator-choice-focused", columns: 80, rows: 32, renderMode: "ascii-no-color" },
+	{ stateId: "option-boolean-choice-focused", columns: 80, rows: 32, renderMode: "ascii-no-color" },
+	{ stateId: "option-enum-choice-focused", columns: 80, rows: 32, renderMode: "ascii-no-color" },
+	{ stateId: "option-numeric-choice-focused", columns: 80, rows: 32, renderMode: "ascii-no-color" },
 ];
 
 export const STATUS_LINE_CUSTOM_EDITOR_SHOWCASE_EXPECTED_ENTRY_COUNT =
@@ -77,6 +77,9 @@ function driveUntil(component: SettingsSelectorComponent, width: number, witness
 		if (Bun.stripANSI(render(component, width)).includes(witness)) return;
 		component.handleInput("\x1b[B");
 	}
+	throw new Error(
+		`Could not reach showcase state ${JSON.stringify(witness)}:\n${Bun.stripANSI(render(component, width))}`,
+	);
 }
 
 function focusOption(component: SettingsSelectorComponent, width: number, target: string, rightMoves: number): void {
@@ -118,16 +121,23 @@ function buildComponent(dense = false, cjk = false): SettingsSelectorComponent {
 			},
 			getStatusLinePreview: () => currentPreview,
 			getStatusLinePreviewForSettings: preview => {
-				if (cjk) return "상태줄 경계 · 意味の境界 · 语义边界";
+				if (cjk) return "상태줄 경계 · 意味の境界 · 语义边界\n보조 행 · 補助行 · 辅助行";
+				if (dense) {
+					return `left=${(preview.leftSegments ?? []).join(",")}\nright=${(preview.rightSegments ?? []).join(",")}`;
+				}
 				return formatPreview(preview);
 			},
-			getStatusLinePreviewPartsForSettings: preview => ({
-				left: (preview.leftSegments ?? []).map(segment => segment.replace(/_/g, " ")),
-				leftIds: preview.leftSegments ?? [],
-				right: [...(preview.rightSegments ?? []).map(segment => segment.replace(/_/g, " ")), "v0.16.1"],
-				rightIds: [...(preview.rightSegments ?? []), null],
-				separator: { left: "|", right: "|" },
-			}),
+			...(cjk
+				? {}
+				: {
+						getStatusLinePreviewPartsForSettings: (preview: StatusLinePreviewSettings) => ({
+							left: (preview.leftSegments ?? []).map(segment => segment.replace(/_/g, " ")),
+							leftIds: preview.leftSegments ?? [],
+							right: [...(preview.rightSegments ?? []).map(segment => segment.replace(/_/g, " ")), "v0.16.1"],
+							rightIds: [...(preview.rightSegments ?? []), null],
+							separator: { left: "|", right: "|" },
+						}),
+					}),
 			onCancel: () => {},
 		},
 	);

--- a/packages/coding-agent/test/fixtures/tui/status-line-custom-editor-showcase.ts
+++ b/packages/coding-agent/test/fixtures/tui/status-line-custom-editor-showcase.ts
@@ -1,0 +1,208 @@
+import { resetSettingsForTest, Settings, settings } from "@gajae-code/coding-agent/config/settings";
+import type { StatusLinePreviewSettings } from "@gajae-code/coding-agent/modes/components/settings-selector";
+import { SettingsSelectorComponent } from "@gajae-code/coding-agent/modes/components/settings-selector";
+import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
+
+export type StatusLineCustomEditorShowcaseStateId =
+	| "root-statusbar"
+	| "picked-origin-slot"
+	| "palette-exact-insert"
+	| "separator-control"
+	| "separator-choice-focused"
+	| "separator-choice-applied"
+	| "option-boolean-choice-focused"
+	| "option-enum-choice-focused"
+	| "option-numeric-choice-focused"
+	| "option-choice-applied"
+	| "exit-restored"
+	| "confirm-persisted"
+	| "overflow-two-row-warning"
+	| "narrow-cjk";
+
+export interface StatusLineCustomEditorShowcaseEntry {
+	stateId: StatusLineCustomEditorShowcaseStateId;
+	columns: number;
+	rows: number;
+	renderMode: "unicode-color" | "ascii-no-color";
+}
+
+const BASE_STATES: StatusLineCustomEditorShowcaseStateId[] = [
+	"root-statusbar",
+	"picked-origin-slot",
+	"palette-exact-insert",
+	"separator-control",
+	"separator-choice-focused",
+	"separator-choice-applied",
+	"option-boolean-choice-focused",
+	"option-enum-choice-focused",
+	"option-numeric-choice-focused",
+	"option-choice-applied",
+	"exit-restored",
+	"confirm-persisted",
+	"overflow-two-row-warning",
+	"narrow-cjk",
+];
+
+export const STATUS_LINE_CUSTOM_EDITOR_SHOWCASE_ENTRIES: StatusLineCustomEditorShowcaseEntry[] = [
+	...BASE_STATES.filter(stateId => stateId !== "narrow-cjk").map(stateId => ({
+		stateId,
+		columns: 80,
+		rows: 24,
+		renderMode: "unicode-color" as const,
+	})),
+	{ stateId: "overflow-two-row-warning", columns: 48, rows: 36, renderMode: "unicode-color" },
+	{ stateId: "narrow-cjk", columns: 48, rows: 36, renderMode: "unicode-color" },
+	{ stateId: "root-statusbar", columns: 80, rows: 24, renderMode: "ascii-no-color" },
+	{ stateId: "picked-origin-slot", columns: 80, rows: 24, renderMode: "ascii-no-color" },
+	{ stateId: "separator-choice-focused", columns: 80, rows: 24, renderMode: "ascii-no-color" },
+	{ stateId: "option-boolean-choice-focused", columns: 80, rows: 24, renderMode: "ascii-no-color" },
+	{ stateId: "option-enum-choice-focused", columns: 80, rows: 24, renderMode: "ascii-no-color" },
+	{ stateId: "option-numeric-choice-focused", columns: 80, rows: 24, renderMode: "ascii-no-color" },
+];
+
+export const STATUS_LINE_CUSTOM_EDITOR_SHOWCASE_EXPECTED_ENTRY_COUNT =
+	STATUS_LINE_CUSTOM_EDITOR_SHOWCASE_ENTRIES.length;
+
+function openCustomEditor(component: SettingsSelectorComponent): void {
+	for (let i = 0; i < 6; i++) component.handleInput("\x1b[B");
+	component.handleInput("\n");
+}
+
+function render(component: SettingsSelectorComponent, width: number): string {
+	return component.render(width).join("\n");
+}
+
+function driveUntil(component: SettingsSelectorComponent, width: number, witness: string, limit = 120): void {
+	for (let i = 0; i < limit; i++) {
+		if (Bun.stripANSI(render(component, width)).includes(witness)) return;
+		component.handleInput("\x1b[B");
+	}
+}
+
+function focusOption(component: SettingsSelectorComponent, width: number, target: string, rightMoves: number): void {
+	driveUntil(component, width, "Focus: separator-control");
+	for (let i = 0; i < rightMoves; i++) component.handleInput("\x1b[C");
+	driveUntil(component, width, `Focus: option:${target}`, 1);
+}
+
+function buildComponent(dense = false, cjk = false): SettingsSelectorComponent {
+	if (cjk) settings.set("ui.language", "ko");
+	settings.set("statusLine.preset", "custom");
+	settings.set(
+		"statusLine.leftSegments",
+		dense ? ["gajae", "hostname", "model", "mode", "path", "git", "pr"] : ["model", "path", "git"],
+	);
+	settings.set(
+		"statusLine.rightSegments",
+		dense ? ["session_name", "jobs", "context_pct", "time_spent", "subagents"] : ["session_name", "jobs"],
+	);
+	settings.set("statusLine.separator", "slash");
+	settings.set("statusLine.segmentOptions", { path: { maxLength: 32 }, time: { format: "24h" } });
+	let currentPreview = cjk
+		? "상태줄 경계 · 意味の境界 · 语义边界"
+		: "left=model,path,git right=session_name,jobs separator=slash";
+	const formatPreview = (preview: StatusLinePreviewSettings): string =>
+		`left=${(preview.leftSegments ?? []).join(",")} right=${(preview.rightSegments ?? []).join(",")} separator=${preview.separator}`;
+	const component = new SettingsSelectorComponent(
+		{
+			availableThinkingLevels: [],
+			thinkingLevel: undefined,
+			availableThemes: ["red-claw", "blue-crab"],
+			availableModelProfiles: [],
+			cwd: process.cwd(),
+		},
+		{
+			onChange: () => {},
+			onStatusLinePreview: preview => {
+				if (!cjk) currentPreview = formatPreview(preview);
+			},
+			getStatusLinePreview: () => currentPreview,
+			getStatusLinePreviewForSettings: preview => {
+				if (cjk) return "상태줄 경계 · 意味の境界 · 语义边界";
+				return formatPreview(preview);
+			},
+			getStatusLinePreviewPartsForSettings: preview => ({
+				left: (preview.leftSegments ?? []).map(segment => segment.replace(/_/g, " ")),
+				leftIds: preview.leftSegments ?? [],
+				right: [...(preview.rightSegments ?? []).map(segment => segment.replace(/_/g, " ")), "v0.16.1"],
+				rightIds: [...(preview.rightSegments ?? []), null],
+				separator: { left: "|", right: "|" },
+			}),
+			onCancel: () => {},
+		},
+	);
+	openCustomEditor(component);
+	return component;
+}
+
+export async function renderStatusLineCustomEditorShowcase(
+	entry: StatusLineCustomEditorShowcaseEntry,
+): Promise<string> {
+	resetSettingsForTest();
+	await Settings.init({ inMemory: true });
+	await initTheme(false, entry.renderMode === "ascii-no-color" ? "ascii" : "unicode", false, "red-claw", "blue-crab");
+	const component = buildComponent(
+		entry.stateId === "overflow-two-row-warning" || entry.stateId === "narrow-cjk",
+		entry.stateId === "narrow-cjk",
+	);
+	const width = entry.columns;
+
+	switch (entry.stateId) {
+		case "picked-origin-slot":
+			component.handleInput("\n");
+			break;
+		case "palette-exact-insert":
+			component.handleInput("\x1b[B");
+			component.handleInput("\n");
+			component.handleInput("\x1b[D");
+			component.handleInput("\n");
+			break;
+		case "separator-control":
+			driveUntil(component, width, "Focus: separator-control");
+			break;
+		case "separator-choice-focused":
+			driveUntil(component, width, "Focus: separator-control");
+			component.handleInput("\n");
+			break;
+		case "separator-choice-applied":
+			driveUntil(component, width, "Focus: separator-control");
+			component.handleInput("\n");
+			component.handleInput("\x1b[C");
+			component.handleInput("\n");
+			break;
+		case "option-boolean-choice-focused":
+			focusOption(component, width, "model.showThinkingLevel", 1);
+			component.handleInput("\n");
+			break;
+		case "option-enum-choice-focused":
+			focusOption(component, width, "time.format", 9);
+			component.handleInput("\n");
+			break;
+		case "option-numeric-choice-focused":
+			focusOption(component, width, "path.maxLength", 3);
+			component.handleInput("\n");
+			break;
+		case "option-choice-applied":
+			focusOption(component, width, "path.maxLength", 3);
+			component.handleInput("\n");
+			component.handleInput("\x1b[C");
+			component.handleInput("\n");
+			break;
+		case "exit-restored":
+			component.handleInput("\x1b[3~");
+			driveUntil(component, width, "Focus: exit");
+			component.handleInput("\n");
+			break;
+		case "confirm-persisted":
+			component.handleInput("\x1b[3~");
+			driveUntil(component, width, "Focus: confirm");
+			component.handleInput("\n");
+			break;
+		case "overflow-two-row-warning":
+		case "narrow-cjk":
+			break;
+	}
+
+	const text = render(component, width);
+	return entry.renderMode === "ascii-no-color" ? Bun.stripANSI(text) : text;
+}

--- a/packages/coding-agent/test/modes/components/settings-selector-status-line-custom.test.ts
+++ b/packages/coding-agent/test/modes/components/settings-selector-status-line-custom.test.ts
@@ -1,7 +1,8 @@
-import { beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { KeybindingsManager } from "@gajae-code/coding-agent/config/keybindings";
 import type { SettingPath } from "@gajae-code/coding-agent/config/settings";
 import { resetSettingsForTest, Settings, settings } from "@gajae-code/coding-agent/config/settings";
 import {
@@ -10,7 +11,8 @@ import {
 } from "@gajae-code/coding-agent/modes/components/settings-selector";
 import { getPreset } from "@gajae-code/coding-agent/modes/components/status-line/presets";
 import type { StatusLineSegmentId } from "@gajae-code/coding-agent/modes/components/status-line/types";
-import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
+import { initTheme, theme } from "@gajae-code/coding-agent/modes/theme/theme";
+import { setKeybindings } from "@gajae-code/tui";
 
 interface ChangedSetting {
 	path: SettingPath;
@@ -18,6 +20,7 @@ interface ChangedSetting {
 }
 
 interface SelectorOptions {
+	disableStatusLineStringPreview?: boolean;
 	getStatusLinePreview?: (width?: number) => string;
 	getStatusLinePreviewForSettings?: (preview: StatusLinePreviewSettings, width?: number) => string;
 	getStatusLinePreviewPartsForSettings?: (
@@ -40,7 +43,12 @@ beforeAll(async () => {
 beforeEach(async () => {
 	resetSettingsForTest();
 	await Settings.init({ inMemory: true });
+	setKeybindings(KeybindingsManager.inMemory());
 	vi.restoreAllMocks();
+});
+
+afterEach(() => {
+	setKeybindings(KeybindingsManager.inMemory());
 });
 
 function createSelector(options: SelectorOptions = {}) {
@@ -65,9 +73,13 @@ function createSelector(options: SelectorOptions = {}) {
 				previewWidths.push(width);
 				return options.getStatusLinePreview?.(width) ?? `preview-${width ?? "current"}`;
 			},
-			getStatusLinePreviewForSettings: (preview, width) =>
-				options.getStatusLinePreviewForSettings?.(preview, width) ??
-				`ACTUAL left=${preview.leftSegments?.join(",") ?? ""} right=${preview.rightSegments?.join(",") ?? ""} sep=${preview.separator} width=${width ?? "current"}`,
+			...(options.disableStatusLineStringPreview
+				? {}
+				: {
+						getStatusLinePreviewForSettings: (preview: StatusLinePreviewSettings, width?: number) =>
+							options.getStatusLinePreviewForSettings?.(preview, width) ??
+							`ACTUAL left=${preview.leftSegments?.join(",") ?? ""} right=${preview.rightSegments?.join(",") ?? ""} sep=${preview.separator} width=${width ?? "current"}`,
+					}),
 			getStatusLinePreviewPartsForSettings: options.getStatusLinePreviewPartsForSettings,
 			onCancel: () => {},
 		},
@@ -139,6 +151,34 @@ describe("SettingsSelectorComponent status line custom editor", () => {
 		expect(render(component)).toContain("Simulated statusbar");
 	});
 
+	it("honors remapped select navigation, confirm, and cancel actions", () => {
+		settings.set("statusLine.preset", "custom");
+		settings.set("statusLine.leftSegments", ["model", "path"]);
+		settings.set("statusLine.rightSegments", []);
+		const { component, previews } = createSelector();
+
+		selectCustomEditor(component);
+		setKeybindings(
+			KeybindingsManager.inMemory({
+				"tui.select.up": "f6",
+				"tui.select.down": "f7",
+				"tui.select.confirm": "f8",
+				"tui.select.cancel": "f9",
+			}),
+		);
+		component.handleInput("\x1b[19~"); // F8 opens the editor.
+		component.handleInput("\x1b[19~"); // Pick model.
+		expect(render(component)).toContain("Selected: model");
+		component.handleInput("\x1b[18~"); // F7 moves to the palette.
+		expect(render(component)).toContain("Focus: palette:");
+		component.handleInput("\x1b[17~"); // F6 returns to the statusbar.
+		expect(render(component)).toContain("Focus: statusbar:");
+		component.handleInput("\x1b[20~"); // F9 cancels the editor.
+
+		expect(settings.get("statusLine.leftSegments")).toEqual(["model", "path"]);
+		expect(previews.at(-1)).toMatchObject({ leftSegments: ["model", "path"] });
+	});
+
 	it("adds hidden palette segments at an exact statusbar slot", () => {
 		settings.set("statusLine.preset", "custom");
 		settings.set("statusLine.leftSegments", ["path", "git"]);
@@ -187,6 +227,19 @@ describe("SettingsSelectorComponent status line custom editor", () => {
 		expect(render(component)).not.toContain("ACTUAL left=model,path");
 	});
 
+	it("focuses the segment moved to the palette after Delete", () => {
+		settings.set("statusLine.preset", "custom");
+		settings.set("statusLine.leftSegments", ["model", "path"]);
+		settings.set("statusLine.rightSegments", []);
+		const { component } = createSelector();
+
+		openCustomEditor(component);
+		component.handleInput("\x1b[3~");
+		component.handleInput("\n");
+
+		expect(render(component)).toContain("Selected: model");
+	});
+
 	it("applies separator and typed segment options through visible choice panels", () => {
 		settings.set("statusLine.preset", "custom");
 		settings.set("statusLine.leftSegments", ["model"]);
@@ -228,6 +281,37 @@ describe("SettingsSelectorComponent status line custom editor", () => {
 		component.handleInput("\x1b[C");
 		component.handleInput("\n");
 		expect(render(component)).toContain("[40]");
+	});
+
+	it("edits custom command values without leaking cancelled text", () => {
+		settings.set("statusLine.preset", "custom");
+		settings.set("statusLine.leftSegments", ["command"]);
+		settings.set("statusLine.rightSegments", []);
+		settings.set("statusLine.segmentOptions", { command: { command: "" } });
+		const { component, changedSettings } = createSelector();
+
+		openCustomEditor(component);
+		driveUntil(component, "Focus: separator-control");
+		for (let i = 0; i < 12; i++) component.handleInput("\x1b[C");
+		expect(render(component)).toContain("Focus: option:command.command");
+
+		component.handleInput("\n");
+		expect(render(component)).toContain("Status line command");
+		component.handleInput("discarded");
+		component.handleInput("\x1b");
+		expect(render(component)).toContain("Command: (empty)");
+
+		component.handleInput("\n");
+		component.handleInput("printf '界'");
+		component.handleInput("\n");
+		expect(render(component)).toContain("Command: printf '界'");
+
+		driveUntil(component, "Focus: confirm");
+		component.handleInput("\n");
+		expect(changedSettings).toContainEqual({
+			path: "statusLine.segmentOptions",
+			value: expect.objectContaining({ command: { command: "printf '界'" } }),
+		});
 	});
 
 	it("preserves empty custom layouts and moves a selected segment between statusbar and palette", () => {
@@ -272,6 +356,7 @@ describe("SettingsSelectorComponent status line custom editor", () => {
 		settings.set("statusLine.leftSegments", ["gajae", "hostname", "model", "mode", "path", "git"]);
 		settings.set("statusLine.rightSegments", ["context_pct", "time_spent"]);
 		const { component } = createSelector({
+			disableStatusLineStringPreview: true,
 			getStatusLinePreviewPartsForSettings: () => ({
 				left: ["🦞", "🖥 Suhoui-MacBookAir", "⬢ gpt-5.5", "📁 gajae-code/status-bar-improved", "⑂ branch"],
 				leftIds: ["gajae", "hostname", "model", "path", "git"],
@@ -290,6 +375,127 @@ describe("SettingsSelectorComponent status line custom editor", () => {
 		expect(output).not.toContain("┆ path ┆");
 		expect(output).not.toContain("┆ git ┆");
 		expect(output).toContain("right context pct / time spent / v0.16.1");
+	});
+
+	it("uses the simulation width and preserves unknown visibility in string preview fallback", () => {
+		settings.set("statusLine.preset", "custom");
+		settings.set("statusLine.leftSegments", ["model", "path"]);
+		settings.set("statusLine.rightSegments", []);
+		let receivedWidth: number | undefined;
+		const { component } = createSelector({
+			getStatusLinePreviewForSettings: (_preview, width) => {
+				receivedWidth = width;
+				return `FALLBACK-${width}`;
+			},
+		});
+
+		openCustomEditor(component);
+		const output = render(component, 80);
+
+		expect(receivedWidth).toBe(78);
+		expect(output).toContain("FALLBACK-78");
+		expect(output).not.toContain("┆ model ┆");
+		expect(output).not.toContain("┆ path ┆");
+	});
+
+	it("renders distinct left and right preview separators", () => {
+		settings.set("statusLine.preset", "custom");
+		settings.set("statusLine.leftSegments", ["model", "path"]);
+		settings.set("statusLine.rightSegments", ["jobs", "context_pct"]);
+		const { component } = createSelector({
+			disableStatusLineStringPreview: true,
+			getStatusLinePreviewPartsForSettings: () => ({
+				left: ["L1", "L2"],
+				leftIds: ["model", "path"],
+				right: ["R1", "R2"],
+				rightIds: ["jobs", "context_pct"],
+				separator: { left: "<", right: ">" },
+			}),
+		});
+
+		openCustomEditor(component);
+		const output = render(component, 120);
+
+		expect(output).toContain("L1 < L2");
+		expect(output).toContain("R1 > R2");
+	});
+
+	it("does not claim wrapping for a short narrow layout", () => {
+		settings.set("statusLine.preset", "custom");
+		settings.set("statusLine.leftSegments", ["model"]);
+		settings.set("statusLine.rightSegments", []);
+		const { component } = createSelector({
+			getStatusLinePreviewPartsForSettings: () => ({
+				left: ["model"],
+				leftIds: ["model"],
+				right: [],
+				rightIds: [],
+				separator: { left: "|", right: "|" },
+			}),
+		});
+
+		openCustomEditor(component);
+
+		expect(render(component, 48)).not.toContain("Warning: statusbar wrapped to 2 rows");
+	});
+
+	it("preserves draft focus and terminal-cell bounds across resize", () => {
+		settings.set("statusLine.preset", "custom");
+		settings.set("statusLine.leftSegments", ["model", "path"]);
+		settings.set("statusLine.rightSegments", ["jobs"]);
+		const { component } = createSelector();
+
+		openCustomEditor(component);
+		component.handleInput("\n");
+		component.handleInput("\x1b[C");
+		for (const width of [48, 120, 64]) {
+			const lines = component.render(width);
+			expect(Bun.stripANSI(lines.join("\n"))).toContain("Selected: model");
+			expect(lines.every(line => Bun.stringWidth(Bun.stripANSI(line)) <= width)).toBe(true);
+		}
+		component.handleInput("\n");
+		expect(render(component)).toContain("ACTUAL left=path,model");
+	});
+
+	it("ignores mouse reports without changing keyboard focus or draft", () => {
+		settings.set("statusLine.preset", "custom");
+		settings.set("statusLine.leftSegments", ["model", "path"]);
+		settings.set("statusLine.rightSegments", []);
+		const { component } = createSelector();
+
+		openCustomEditor(component);
+		const before = render(component);
+		component.handleInput("\x1b[<0;10;5M");
+		component.handleInput("\x1b[<0;10;5m");
+
+		expect(render(component)).toBe(before);
+	});
+
+	it("uses distinct theme roles for focused and selected segments", () => {
+		settings.set("statusLine.preset", "custom");
+		settings.set("statusLine.leftSegments", ["model"]);
+		settings.set("statusLine.rightSegments", []);
+		const { component } = createSelector();
+
+		openCustomEditor(component);
+		const focusBackground = theme.getFgAnsi("text").replace("\x1b[38;", "\x1b[48;");
+		const selectedBackground = theme.getFgAnsi("warning").replace("\x1b[38;", "\x1b[48;");
+		expect(component.render(80).join("\n")).toContain(focusBackground);
+		component.handleInput("\n");
+		expect(component.render(80).join("\n")).toContain(selectedBackground);
+		expect(selectedBackground).not.toBe(focusBackground);
+	});
+
+	it("keeps repeated resize rendering bounded", () => {
+		settings.set("statusLine.preset", "custom");
+		settings.set("statusLine.leftSegments", ["gajae", "hostname", "model", "mode", "path", "git", "pr"]);
+		settings.set("statusLine.rightSegments", ["session_name", "jobs", "context_pct", "time_spent", "subagents"]);
+		const { component } = createSelector();
+		openCustomEditor(component);
+
+		const started = performance.now();
+		for (let i = 0; i < 250; i++) component.render([40, 64, 80, 120][i % 4] ?? 80);
+		expect(performance.now() - started).toBeLessThan(1_500);
 	});
 
 	it("does not highlight a hidden slot segment when the selected segment moves next to it", () => {
@@ -387,6 +593,34 @@ describe("SettingsSelectorComponent status line custom editor", () => {
 			await fs.rm(agentDir, { recursive: true, force: true });
 			await Settings.init({ inMemory: true });
 		}
+	});
+
+	it("normalizes invalid segment entries while preserving opaque option sections", () => {
+		settings.set("statusLine.preset", "custom");
+		settings.set("statusLine.leftSegments", ["model", "future-segment", 42, "", "model"] as never);
+		settings.set("statusLine.rightSegments", ["future-segment", "jobs"] as never);
+		settings.set("statusLine.segmentOptions", {
+			model: { showThinkingLevel: false },
+			futurePlugin: { label: "界" },
+		});
+		const { component, changedSettings } = createSelector();
+
+		openCustomEditor(component);
+		const output = render(component);
+		expect(output).toContain("future-segment");
+		expect(output).toContain("42");
+		driveUntil(component, "Focus: confirm");
+		component.handleInput("\n");
+
+		expect(changedSettings).toContainEqual({
+			path: "statusLine.leftSegments",
+			value: ["model", "future-segment", "42"],
+		});
+		expect(changedSettings).toContainEqual({ path: "statusLine.rightSegments", value: ["jobs"] });
+		expect(changedSettings).toContainEqual({
+			path: "statusLine.segmentOptions",
+			value: expect.objectContaining({ futurePlugin: { label: "界" } }),
+		});
 	});
 
 	it("renders a two-row overflow warning at narrow width", () => {

--- a/packages/coding-agent/test/modes/components/settings-selector-status-line-custom.test.ts
+++ b/packages/coding-agent/test/modes/components/settings-selector-status-line-custom.test.ts
@@ -9,6 +9,7 @@ import {
 	type StatusLinePreviewSettings,
 } from "@gajae-code/coding-agent/modes/components/settings-selector";
 import { getPreset } from "@gajae-code/coding-agent/modes/components/status-line/presets";
+import type { StatusLineSegmentId } from "@gajae-code/coding-agent/modes/components/status-line/types";
 import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
 
 interface ChangedSetting {
@@ -18,6 +19,17 @@ interface ChangedSetting {
 
 interface SelectorOptions {
 	getStatusLinePreview?: (width?: number) => string;
+	getStatusLinePreviewForSettings?: (preview: StatusLinePreviewSettings, width?: number) => string;
+	getStatusLinePreviewPartsForSettings?: (
+		preview: StatusLinePreviewSettings,
+		width?: number,
+	) => {
+		left: string[];
+		leftIds: NonNullable<StatusLinePreviewSettings["leftSegments"]>;
+		right: string[];
+		rightIds: Array<StatusLineSegmentId | null>;
+		separator: { left: string; right: string };
+	};
 	onStatusLinePreview?: (preview: StatusLinePreviewSettings) => void;
 }
 
@@ -44,7 +56,7 @@ function createSelector(options: SelectorOptions = {}) {
 			cwd: process.cwd(),
 		},
 		{
-			onChange: (path, value) => changedSettings.push({ path, value }),
+			onChange: (settingPath, value) => changedSettings.push({ path: settingPath, value }),
 			onStatusLinePreview: preview => {
 				previews.push(preview);
 				options.onStatusLinePreview?.(preview);
@@ -53,11 +65,20 @@ function createSelector(options: SelectorOptions = {}) {
 				previewWidths.push(width);
 				return options.getStatusLinePreview?.(width) ?? `preview-${width ?? "current"}`;
 			},
+			getStatusLinePreviewForSettings: (preview, width) =>
+				options.getStatusLinePreviewForSettings?.(preview, width) ??
+				`ACTUAL left=${preview.leftSegments?.join(",") ?? ""} right=${preview.rightSegments?.join(",") ?? ""} sep=${preview.separator} width=${width ?? "current"}`,
+			getStatusLinePreviewPartsForSettings: options.getStatusLinePreviewPartsForSettings,
 			onCancel: () => {},
 		},
 	);
 	return { component, previews, changedSettings, previewWidths };
 }
+
+function render(component: SettingsSelectorComponent, width = 120): string {
+	return Bun.stripANSI(component.render(width).join("\n"));
+}
+
 function selectCustomEditor(component: SettingsSelectorComponent): void {
 	for (let i = 0; i < 6; i++) component.handleInput("\x1b[B");
 }
@@ -66,271 +87,280 @@ function openCustomEditor(component: SettingsSelectorComponent): void {
 	selectCustomEditor(component);
 	component.handleInput("\n");
 }
-describe("SettingsSelectorComponent status line custom editor", () => {
-	it("exposes a dedicated Appearance editor", () => {
-		const { component } = createSelector();
-		selectCustomEditor(component);
 
-		expect(Bun.stripANSI(component.render(120).join("\n"))).toContain("Status Line Custom Editor");
-	});
-	it("keeps Custom out of the generic preset selector", () => {
-		const { component } = createSelector();
-
-		for (let i = 0; i < 5; i++) component.handleInput("\x1b[B");
-
-		component.handleInput("\n");
-
-		const presetMenu = Bun.stripANSI(component.render(120).join("\n"));
-		expect(presetMenu).toContain("Status Line Preset");
-		expect(presetMenu).not.toContain("Custom");
-	});
-	it("shows usage mode on the appearance tab and persists it", () => {
-		settings.set("statusLine.preset", "default");
-		settings.set("statusLine.segmentOptions", {});
-		const { component, changedSettings, previews } = createSelector();
-
-		for (let i = 0; i < 40; i++) {
-			const rendered = Bun.stripANSI(component.render(120).join("\n"));
-			if (rendered.includes("❯ Status Line Usage Mode")) break;
-			component.handleInput("\x1b[B");
-		}
-
-		expect(Bun.stripANSI(component.render(120).join("\n"))).toContain("❯ Status Line Usage Mode");
-		component.handleInput("\n");
-
-		expect(settings.get("statusLine.segmentOptions")).toMatchObject({ usage: { mode: "remaining" } });
-		expect(changedSettings.at(-1)).toMatchObject({
-			path: "statusLine.segmentOptions",
-			value: { usage: { mode: "remaining" } },
-		});
-		expect(previews.at(-1)?.segmentOptions).toMatchObject({ usage: { mode: "remaining" } });
-	});
-	it("shows usage mode even when usage is hidden", () => {
-		settings.set("statusLine.preset", "custom");
-		settings.set("statusLine.leftSegments", ["model"]);
-		settings.set("statusLine.rightSegments", ["context_pct"]);
-		const { component } = createSelector();
-
-		for (let i = 0; i < 40; i++) {
-			const rendered = Bun.stripANSI(component.render(120).join("\n"));
-			if (rendered.includes("❯ Status Line Usage Mode")) break;
-			component.handleInput("\x1b[B");
-		}
-
-		expect(Bun.stripANSI(component.render(120).join("\n"))).toContain("❯ Status Line Usage Mode");
-	});
-	it("seeds custom layout from the active preset, previews segment options, and saves to settings", () => {
-		settings.set("statusLine.preset", "minimal");
-		settings.set("statusLine.leftSegments", []);
-		settings.set("statusLine.rightSegments", []);
-		settings.set("statusLine.segmentOptions", { path: { maxLength: 24 }, git: { showUntracked: false } });
-		const { component, previews, changedSettings } = createSelector();
-
-		openCustomEditor(component);
-
-		const opened = Bun.stripANSI(component.render(120).join("\n"));
-		expect(opened).toContain("Status Line Custom Editor");
-		expect(opened).not.toContain("Current width preview");
-		expect(opened).not.toContain("Narrow width preview");
-		expect(previews.at(-1)).toMatchObject({
-			preset: "custom",
-			leftSegments: getPreset("minimal").leftSegments,
-			rightSegments: getPreset("minimal").rightSegments,
-			segmentOptions: { path: { maxLength: 24 }, git: { showUntracked: false } },
-		});
-
-		component.handleInput("\n"); // Save custom status line.
-
-		expect(settings.get("statusLine.preset")).toBe("custom");
-		expect(settings.get("statusLine.leftSegments")).toEqual(getPreset("minimal").leftSegments);
-		expect(settings.get("statusLine.rightSegments")).toEqual(getPreset("minimal").rightSegments);
-		expect(changedSettings.map(change => change.path)).toEqual(
-			expect.arrayContaining([
-				"statusLine.preset",
-				"statusLine.leftSegments",
-				"statusLine.rightSegments",
-				"statusLine.separator",
-				"statusLine.segmentOptions",
-			]),
-		);
-	});
-	it("refreshes the parent preview while editing and cancelling custom rows", () => {
-		settings.set("statusLine.preset", "minimal");
-		let renderedPreview = "initial-preview";
-		const { component } = createSelector({
-			onStatusLinePreview: preview => {
-				renderedPreview = `preset:${preview.preset ?? "same"} left:${preview.leftSegments?.join(",") ?? "same"} highlight:${preview.previewHighlightSegment ?? "none"}`;
-			},
-			getStatusLinePreview: () => renderedPreview,
-		});
-
-		expect(Bun.stripANSI(component.render(120).join("\n"))).toContain("initial-preview");
-
-		openCustomEditor(component);
-		expect(Bun.stripANSI(component.render(120).join("\n"))).toContain("preset:custom");
-
-		for (let i = 0; i < 3; i++) component.handleInput("\x1b[B"); // Segment: gajae.
-		component.handleInput("\n"); // hidden -> left.
-		expect(Bun.stripANSI(component.render(120).join("\n"))).toContain("left:path,git,gajae");
-
-		component.handleInput("\x1b"); // Cancel restores the parent preview too.
-		const restored = Bun.stripANSI(component.render(120).join("\n"));
-		expect(restored).toContain("preset:minimal");
-		expect(restored).not.toContain("left:path,git,gajae");
-	});
-	it("keeps the description area height stable while navigating custom rows", () => {
-		settings.set("statusLine.preset", "minimal");
-		const { component } = createSelector();
-
-		openCustomEditor(component);
-
-		for (let i = 0; i < 5; i++) component.handleInput("\x1b[B"); // Segment: mode.
-		const segmentLines = component.render(120).length;
-		expect(Bun.stripANSI(component.render(120).join("\n"))).toContain("❯ Segment: mode");
-
-		component.handleInput("\x1b[B"); // Move left: mode.
-		const moveLines = component.render(120).length;
-		expect(Bun.stripANSI(component.render(120).join("\n"))).toContain("❯ Move left: mode");
-		expect(moveLines).toBe(segmentLines);
-	});
-	it("clones preset segment option defaults when saving from a preset", () => {
-		settings.set("statusLine.preset", "minimal");
-		settings.set("statusLine.segmentOptions", {});
-		const minimalSegmentOptions = getPreset("minimal").segmentOptions ?? {};
-		const { component, previews } = createSelector();
-
-		openCustomEditor(component);
-
-		expect(previews.at(-1)?.segmentOptions).toEqual(minimalSegmentOptions);
-
-		component.handleInput("\n");
-
-		expect(settings.get("statusLine.segmentOptions")).toEqual(minimalSegmentOptions as Record<string, unknown>);
-	});
-	it("preserves an intentionally empty saved custom layout", () => {
-		settings.set("statusLine.preset", "custom");
-		settings.set("statusLine.leftSegments", []);
-		settings.set("statusLine.rightSegments", []);
-		const { component, previews } = createSelector();
-
-		openCustomEditor(component);
-
-		expect(previews.at(-1)).toMatchObject({
-			preset: "custom",
-			leftSegments: [],
-			rightSegments: [],
-		});
-
-		component.handleInput("\n");
-
-		expect(settings.get("statusLine.leftSegments")).toEqual([]);
-		expect(settings.get("statusLine.rightSegments")).toEqual([]);
-	});
-
-	it("places usage mode next to the usage segment", () => {
-		settings.set("statusLine.preset", "minimal");
-		const { component } = createSelector();
-
-		openCustomEditor(component);
-
-		for (let i = 0; i < 80; i++) {
-			const rendered = Bun.stripANSI(component.render(120).join("\n"));
-			if (rendered.includes("❯ Segment: usage")) break;
-			component.handleInput("\x1b[B");
-		}
-
-		expect(Bun.stripANSI(component.render(120).join("\n"))).toContain("❯ Segment: usage");
+function driveUntil(component: SettingsSelectorComponent, witness: string, limit = 80): void {
+	for (let i = 0; i < limit; i++) {
+		if (render(component).includes(witness)) return;
 		component.handleInput("\x1b[B");
-		expect(Bun.stripANSI(component.render(120).join("\n"))).toContain("❯ Usage: mode");
-	});
+	}
+	expect(render(component)).toContain(witness);
+}
 
-	it("edits segment placement and typed options before saving", () => {
-		settings.set("statusLine.preset", "minimal");
-		const { component } = createSelector();
-
-		openCustomEditor(component);
-
-		for (let i = 0; i < 3; i++) component.handleInput("\x1b[B");
-		component.handleInput("\n"); // Segment: gajae hidden -> left.
-
-		component.handleInput("\x1b[A"); // Move back to the separator row; selection was preserved after refresh.
-		expect(Bun.stripANSI(component.render(120).join("\n"))).toContain("Separator");
-
-		component.handleInput("\x1b[A");
-		component.handleInput("\x1b[A");
-		component.handleInput("\n"); // Save.
-
-		expect(settings.get("statusLine.leftSegments")).toEqual([...getPreset("minimal").leftSegments, "gajae"]);
-	});
-
-	it("edits option rows and restores preview on cancel", () => {
+describe("SettingsSelectorComponent status line custom editor", () => {
+	it("opens a simulated statusbar editor instead of legacy segment/move rows", () => {
 		settings.set("statusLine.preset", "minimal");
 		const { component, previews } = createSelector();
 
 		openCustomEditor(component);
+		const output = render(component);
 
-		component.handleInput("\x1b[A"); // Wrap from Save to Time: show seconds.
-		expect(previews.at(-1)?.previewHighlightSegment).toBe("time");
-		component.handleInput("\n");
-		expect(previews.at(-1)?.segmentOptions?.time?.showSeconds).toBe(true);
-
-		component.handleInput("\x1b"); // Escape from the editor.
-
-		expect(previews.at(-1)).toMatchObject({
-			preset: "minimal",
-			leftSegments: [],
-			rightSegments: [],
-		});
-		expect(Object.hasOwn(previews.at(-1) ?? {}, "previewHighlightSegment")).toBe(true);
-		expect(previews.at(-1)?.previewHighlightSegment).toBeUndefined();
-		expect(settings.get("statusLine.preset")).toBe("minimal");
+		expect(output).toContain("Status Line Custom Editor");
+		expect(output).toContain("Simulated statusbar");
+		expect(output).toContain("ACTUAL left=");
+		expect(output).toContain("Hidden segment palette");
+		expect(output).toContain("Visible choices");
+		expect(output).toContain("Separator:");
+		expect(output).toContain("Model: show thinking level");
+		expect(output).not.toContain("Live preview:");
+		expect(output).not.toContain("Segment: gajae");
+		expect(output).not.toContain("Move left:");
+		expect(output).not.toContain("Move right:");
+		expect(output).toContain(getPreset("minimal").leftSegments[0] ?? "model");
+		expect(previews).toEqual([]);
 	});
-	it("moves segments between sides, reorders within a side, and saves separator changes", () => {
+
+	it("routes Left/Right to picked segment movement instead of tab navigation", () => {
 		settings.set("statusLine.preset", "custom");
 		settings.set("statusLine.leftSegments", ["model", "path"]);
 		settings.set("statusLine.rightSegments", []);
-		settings.set("statusLine.separator", "slash");
+		const { component } = createSelector();
+
+		openCustomEditor(component);
+		component.handleInput("\n"); // Pick model.
+		expect(render(component)).toContain("Selected: model");
+		expect(render(component)).not.toContain("Origin left");
+		expect(render(component)).not.toContain("Floating ghost");
+		expect(render(component)).toContain(" model ");
+
+		component.handleInput("\x1b[C"); // Move the drop slot right; parent tabs must not consume this.
+		component.handleInput("\n"); // Drop.
+
+		expect(render(component)).toContain("ACTUAL left=path,model");
+		expect(render(component)).toContain("Simulated statusbar");
+	});
+
+	it("adds hidden palette segments at an exact statusbar slot", () => {
+		settings.set("statusLine.preset", "custom");
+		settings.set("statusLine.leftSegments", ["path", "git"]);
+		settings.set("statusLine.rightSegments", []);
+		const { component } = createSelector();
+
+		openCustomEditor(component);
+		component.handleInput("\x1b[B"); // Palette.
+		expect(render(component)).toContain("Focus: palette:0");
+		component.handleInput("\n"); // Pick first hidden segment, gajae.
+		component.handleInput("\x1b[D"); // Exact slot between path and git.
+		component.handleInput("\n");
+
+		expect(render(component)).toContain("ACTUAL left=path,gajae,git");
+	});
+
+	it("hides visible segments with Delete and restores draft changes on Exit", () => {
+		settings.set("statusLine.preset", "custom");
+		settings.set("statusLine.leftSegments", ["model", "path"]);
+		settings.set("statusLine.rightSegments", []);
 		const { component, previews } = createSelector();
 
 		openCustomEditor(component);
+		component.handleInput("\x1b[3~");
+		expect(render(component)).toContain("ACTUAL left=path");
+		driveUntil(component, "Focus: exit");
+		component.handleInput("\n");
 
-		for (let i = 0; i < 9; i++) component.handleInput("\x1b[B");
-		component.handleInput("\n"); // Move left: path before model.
-		expect(previews.at(-1)?.leftSegments).toEqual(["path", "model"]);
-
-		for (let i = 0; i < 5; i++) component.handleInput("\x1b[A");
-		component.handleInput("\n"); // Segment: model left -> right.
-
-		for (let i = 0; i < 2; i++) component.handleInput("\x1b[A");
-		component.handleInput("\n"); // Open separator submenu.
-		component.handleInput("\x1b[B");
-		component.handleInput("\n"); // slash -> pipe.
+		expect(settings.get("statusLine.leftSegments")).toEqual(["model", "path"]);
 		expect(previews.at(-1)).toMatchObject({
-			leftSegments: ["path"],
-			rightSegments: ["model"],
-			separator: "pipe",
+			preset: "custom",
+			leftSegments: ["model", "path"],
+		});
+	});
+
+	it("treats forward-delete chords including macOS Fn+Backspace as hide-segment delete", () => {
+		settings.set("statusLine.preset", "custom");
+		settings.set("statusLine.leftSegments", ["model", "path"]);
+		settings.set("statusLine.rightSegments", []);
+		const { component } = createSelector();
+
+		openCustomEditor(component);
+		component.handleInput("\x04"); // default tui.editor.deleteCharForward, same action as Delete/Fn+Backspace.
+
+		expect(render(component)).toContain("ACTUAL left=path");
+		expect(render(component)).not.toContain("ACTUAL left=model,path");
+	});
+
+	it("applies separator and typed segment options through visible choice panels", () => {
+		settings.set("statusLine.preset", "custom");
+		settings.set("statusLine.leftSegments", ["model"]);
+		settings.set("statusLine.rightSegments", []);
+		settings.set("statusLine.separator", "slash");
+		settings.set("statusLine.segmentOptions", { path: { maxLength: 32 } });
+		const { component } = createSelector();
+
+		openCustomEditor(component);
+		driveUntil(component, "Focus: separator-control");
+		component.handleInput("\n");
+		expect(render(component)).toContain("Choices: Separator");
+		component.handleInput("\x1b[B");
+		expect(render(component)).toContain(" Model: show thinking level ");
+		expect(render(component)).toContain("Choices: Model: show thinking level");
+		component.handleInput("\x1b[A");
+		expect(render(component)).toContain(" Separator ");
+		expect(render(component)).toContain("Choices: Separator");
+		component.handleInput("\x1b[C"); // slash -> pipe.
+		component.handleInput(" ");
+		expect(render(component)).toContain("[Slash]");
+		component.handleInput("\x1b");
+		expect(render(component)).toContain("[Slash]");
+		component.handleInput("\n");
+		component.handleInput("\x1b[C"); // slash -> pipe.
+		component.handleInput("\n");
+		expect(render(component)).toContain("[Pipe]");
+
+		component.handleInput("\x1b[C");
+		component.handleInput("\x1b[C");
+		component.handleInput("\x1b[C");
+		expect(render(component)).toContain("Focus: option:path.maxLength");
+		component.handleInput("\n");
+		expect(render(component)).toContain("Choices: Path: max length");
+		component.handleInput("\x1b[B");
+		expect(render(component)).toContain("Choices: Path: strip work prefix");
+		component.handleInput("\x1b[A");
+		expect(render(component)).toContain("Choices: Path: max length");
+		component.handleInput("\x1b[C");
+		component.handleInput("\n");
+		expect(render(component)).toContain("[40]");
+	});
+
+	it("preserves empty custom layouts and moves a selected segment between statusbar and palette", () => {
+		settings.set("statusLine.preset", "custom");
+		settings.set("statusLine.leftSegments", []);
+		settings.set("statusLine.rightSegments", []);
+		const { component } = createSelector();
+
+		openCustomEditor(component);
+		expect(render(component)).toContain("left (empty)");
+		expect(render(component)).toContain("right (empty)");
+		component.handleInput("\n"); // Pick palette item into a left drop slot.
+		component.handleInput("\x1b[B");
+		expect(render(component)).toContain("Focus: palette:0");
+		component.handleInput("\x1b[A");
+		expect(render(component)).toContain("Focus: statusbar:left:0");
+		component.handleInput("\n");
+
+		expect(render(component)).toContain("ACTUAL left=gajae");
+		expect(render(component)).toContain("Simulated statusbar");
+	});
+
+	it("keeps draft navigation inside the simulated editor instead of updating the real status preview", () => {
+		settings.set("statusLine.preset", "custom");
+		settings.set("statusLine.leftSegments", ["model", "path"]);
+		settings.set("statusLine.rightSegments", []);
+		const { component, previews } = createSelector({ getStatusLinePreview: () => "REAL STATUSBAR" });
+
+		openCustomEditor(component);
+		component.handleInput("\n");
+		component.handleInput("\x1b[C");
+		component.handleInput("\n");
+
+		const output = render(component);
+		expect(output).toContain("Simulated statusbar");
+		expect(output).not.toContain("REAL STATUSBAR");
+		expect(previews).toEqual([]);
+	});
+
+	it("only marks slot labels dashed when the real simulated statusbar hides that segment", () => {
+		settings.set("statusLine.preset", "custom");
+		settings.set("statusLine.leftSegments", ["gajae", "hostname", "model", "mode", "path", "git"]);
+		settings.set("statusLine.rightSegments", ["context_pct", "time_spent"]);
+		const { component } = createSelector({
+			getStatusLinePreviewPartsForSettings: () => ({
+				left: ["🦞", "🖥 Suhoui-MacBookAir", "⬢ gpt-5.5", "📁 gajae-code/status-bar-improved", "⑂ branch"],
+				leftIds: ["gajae", "hostname", "model", "path", "git"],
+				right: ["◫ 5.9%/272K", "⏱ 24.1s", "v0.16.1"],
+				rightIds: ["context_pct", "time_spent", null],
+				separator: { left: "|", right: "|" },
+			}),
 		});
 
-		component.handleInput("\x1b[A");
-		component.handleInput("\x1b[A");
-		component.handleInput("\n"); // Save.
+		openCustomEditor(component);
+		const output = render(component, 120);
 
-		expect(settings.get("statusLine.leftSegments")).toEqual(["path"]);
-		expect(settings.get("statusLine.rightSegments")).toEqual(["model"]);
-		expect(settings.get("statusLine.separator")).toBe("pipe");
+		expect(output).toContain("┆ mode ┆");
+		expect(output).not.toContain("┆ gajae ┆");
+		expect(output).not.toContain("┆ hostname ┆");
+		expect(output).not.toContain("┆ path ┆");
+		expect(output).not.toContain("┆ git ┆");
+		expect(output).toContain("right context pct / time spent / v0.16.1");
 	});
-	it("persists approved custom settings across settings reload", async () => {
+
+	it("does not highlight a hidden slot segment when the selected segment moves next to it", () => {
+		settings.set("statusLine.preset", "custom");
+		settings.set("statusLine.leftSegments", ["gajae", "hostname", "model", "mode", "path", "git", "pr"]);
+		settings.set("statusLine.rightSegments", []);
+		const { component } = createSelector({
+			getStatusLinePreviewPartsForSettings: () => ({
+				left: ["🦞", "🖥 host", "⬢ gpt-5.5", "📁 repo", "⑂ branch"],
+				leftIds: ["gajae", "hostname", "model", "path", "git"],
+				right: ["v0.16.1"],
+				rightIds: [null],
+				separator: { left: "|", right: "|" },
+			}),
+		});
+
+		openCustomEditor(component);
+		for (let i = 0; i < 5; i++) component.handleInput("\x1b[C"); // git
+		component.handleInput("\n");
+		component.handleInput("\x1b[D");
+		component.handleInput("\x1b[D");
+		const output = render(component, 120);
+
+		expect(output).toContain("> git <");
+		expect(output).toContain("┆ mode ┆");
+		expect(output).not.toContain("> mode <");
+	});
+
+	it("moves selected segment vertically down to palette and up back to statusbar", () => {
+		settings.set("statusLine.preset", "custom");
+		settings.set("statusLine.leftSegments", ["model", "path"]);
+		settings.set("statusLine.rightSegments", []);
+		const { component } = createSelector();
+
+		openCustomEditor(component);
+		component.handleInput("\n");
+		expect(render(component)).toContain("Selected: model");
+		expect(render(component)).toContain("Focus: statusbar:left:0");
+		expect(render(component)).not.toContain("> {model} <");
+
+		component.handleInput("\x1b[A");
+		expect(render(component)).toContain("Focus: statusbar:left:0");
+		expect(render(component)).not.toContain("> {model} <");
+
+		component.handleInput("\x1b[B");
+		expect(render(component)).toContain("Focus: palette:");
+		expect(render(component)).toContain("> {model} <");
+
+		component.handleInput("\x1b[B");
+		expect(render(component)).toContain("Focus: palette:");
+		expect(render(component)).toContain("> {model} <");
+
+		component.handleInput("\x1b[A");
+		expect(render(component)).toContain("Focus: statusbar:left:0");
+	});
+
+	it("confirms custom settings and preserves them across settings reload", async () => {
 		const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-status-line-settings-"));
 		try {
 			resetSettingsForTest();
 			await Settings.init({ agentDir });
-			settings.set("statusLine.preset", "minimal");
-			settings.set("statusLine.leftSegments", []);
+			settings.set("statusLine.preset", "custom");
+			settings.set("statusLine.leftSegments", ["model", "path"]);
 			settings.set("statusLine.rightSegments", []);
+			settings.set("statusLine.separator", "slash");
 			settings.set("statusLine.segmentOptions", { time: { showSeconds: true } });
 
-			const { component } = createSelector();
+			const { component, changedSettings } = createSelector();
 			openCustomEditor(component);
+			component.handleInput("\x1b[3~");
+			driveUntil(component, "Focus: confirm");
 			component.handleInput("\n");
 
 			await Bun.sleep(150);
@@ -339,16 +369,37 @@ describe("SettingsSelectorComponent status line custom editor", () => {
 			await Settings.init({ agentDir });
 
 			expect(settings.get("statusLine.preset")).toBe("custom");
-			expect(settings.get("statusLine.leftSegments")).toEqual(getPreset("minimal").leftSegments);
-			expect(settings.get("statusLine.rightSegments")).toEqual(getPreset("minimal").rightSegments);
-			expect(settings.get("statusLine.segmentOptions")).toEqual({
-				...getPreset("minimal").segmentOptions,
-				time: { showSeconds: true },
-			});
+			expect(settings.get("statusLine.leftSegments")).toEqual(["path"]);
+			expect(settings.get("statusLine.rightSegments")).toEqual([]);
+			expect(settings.get("statusLine.separator")).toBe("slash");
+			expect(settings.get("statusLine.segmentOptions")).toEqual({ time: { showSeconds: true } });
+			expect(changedSettings.map(change => change.path)).toEqual(
+				expect.arrayContaining([
+					"statusLine.preset",
+					"statusLine.leftSegments",
+					"statusLine.rightSegments",
+					"statusLine.separator",
+					"statusLine.segmentOptions",
+				]),
+			);
 		} finally {
 			resetSettingsForTest();
 			await fs.rm(agentDir, { recursive: true, force: true });
 			await Settings.init({ inMemory: true });
 		}
+	});
+
+	it("renders a two-row overflow warning at narrow width", () => {
+		settings.set("statusLine.preset", "custom");
+		settings.set("statusLine.leftSegments", ["gajae", "hostname", "model", "mode", "path"]);
+		settings.set("statusLine.rightSegments", ["session_name", "jobs", "context_pct"]);
+		const { component } = createSelector();
+
+		openCustomEditor(component);
+		const output = render(component, 48);
+
+		expect(output).toContain("Warning: statusbar wrapped to 2 rows");
+		expect(output).toContain("left");
+		expect(output).toContain("right");
 	});
 });

--- a/packages/coding-agent/test/status-line-command.test.ts
+++ b/packages/coding-agent/test/status-line-command.test.ts
@@ -142,6 +142,29 @@ describe("status line command segment", () => {
 		}
 	});
 
+	it("does not abort a committed command when a draft preview hides it", async () => {
+		const marker = path.join(os.tmpdir(), `gjc-status-line-preview-${Date.now()}.txt`);
+		const quotedMarker = marker.replaceAll("'", "'\\''");
+		const component = makeComponent(`sleep 0.2; printf preview-safe > '${quotedMarker}'; printf done`, {
+			timeoutMs: 1_000,
+		});
+		try {
+			component.render(120);
+			component.getPreviewContentForSettings(120, {
+				preset: "custom",
+				leftSegments: [],
+				rightSegments: [],
+				segmentOptions: {},
+			});
+			await Bun.sleep(300);
+
+			expect(await Bun.file(marker).text()).toBe("preview-safe");
+		} finally {
+			component.dispose();
+			await fs.rm(marker, { force: true });
+		}
+	});
+
 	it("refreshes an idle command without another incidental render", async () => {
 		const marker = path.join(os.tmpdir(), `gjc-status-line-refresh-${Date.now()}.txt`);
 		const quotedMarker = marker.replaceAll("'", "'\\''");

--- a/packages/coding-agent/test/status-line-custom-editor-showcase.test.ts
+++ b/packages/coding-agent/test/status-line-custom-editor-showcase.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	renderStatusLineCustomEditorShowcase,
+	STATUS_LINE_CUSTOM_EDITOR_SHOWCASE_ENTRIES,
+	STATUS_LINE_CUSTOM_EDITOR_SHOWCASE_EXPECTED_ENTRY_COUNT,
+} from "./fixtures/tui/status-line-custom-editor-showcase";
+
+describe("status line custom editor showcase", () => {
+	it("defines unique canonical showcase entries", () => {
+		const keys = STATUS_LINE_CUSTOM_EDITOR_SHOWCASE_ENTRIES.map(
+			entry => `${entry.stateId}/${entry.columns}x${entry.rows}/${entry.renderMode}`,
+		);
+		expect(new Set(keys).size).toBe(STATUS_LINE_CUSTOM_EDITOR_SHOWCASE_EXPECTED_ENTRY_COUNT);
+		expect(keys).toContain("root-statusbar/80x24/unicode-color");
+		expect(keys).toContain("overflow-two-row-warning/48x36/unicode-color");
+		expect(keys).toContain("option-numeric-choice-focused/80x24/ascii-no-color");
+	});
+
+	it("renders required editor witnesses from the production settings selector", async () => {
+		const root = await renderStatusLineCustomEditorShowcase(STATUS_LINE_CUSTOM_EDITOR_SHOWCASE_ENTRIES[0]);
+		const picked = await renderStatusLineCustomEditorShowcase({
+			stateId: "picked-origin-slot",
+			columns: 80,
+			rows: 24,
+			renderMode: "ascii-no-color",
+		});
+		const choice = await renderStatusLineCustomEditorShowcase({
+			stateId: "separator-choice-focused",
+			columns: 80,
+			rows: 24,
+			renderMode: "ascii-no-color",
+		});
+		const narrow = await renderStatusLineCustomEditorShowcase({
+			stateId: "overflow-two-row-warning",
+			columns: 48,
+			rows: 36,
+			renderMode: "ascii-no-color",
+		});
+
+		expect(Bun.stripANSI(root)).toContain("Simulated statusbar");
+		expect(Bun.stripANSI(root)).not.toContain("Move left:");
+		expect(picked).toContain("Selected: model");
+		expect(picked).not.toContain("Floating ghost");
+		expect(picked).not.toContain("Origin");
+		expect(choice).toContain("Choices: Separator");
+		expect(narrow).toContain("Warning: statusbar wrapped to 2 rows");
+	});
+
+	it("captures and verifies the deterministic artifact bundle", async () => {
+		const outputRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-status-line-showcase-"));
+		try {
+			const capture = Bun.spawnSync({
+				cmd: [
+					"bun",
+					"packages/coding-agent/scripts/capture-status-line-custom-editor-showcase.ts",
+					"--out",
+					outputRoot,
+				],
+				stdout: "pipe",
+				stderr: "pipe",
+			});
+			expect(capture.exitCode).toBe(0);
+
+			const verify = Bun.spawnSync({
+				cmd: [
+					"bun",
+					"packages/coding-agent/scripts/verify-status-line-custom-editor-showcase.ts",
+					"--root",
+					outputRoot,
+				],
+				stdout: "pipe",
+				stderr: "pipe",
+			});
+			expect(verify.exitCode).toBe(0);
+
+			const strictVerify = Bun.spawnSync({
+				cmd: [
+					"bun",
+					"packages/coding-agent/scripts/verify-status-line-custom-editor-showcase.ts",
+					"--root",
+					outputRoot,
+					"--require-independent-review",
+				],
+				stdout: "pipe",
+				stderr: "pipe",
+			});
+			expect(strictVerify.exitCode).not.toBe(0);
+			expect(strictVerify.stderr.toString()).toContain("Missing approved independent review");
+		} finally {
+			await fs.rm(outputRoot, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/coding-agent/test/status-line-custom-editor-showcase.test.ts
+++ b/packages/coding-agent/test/status-line-custom-editor-showcase.test.ts
@@ -13,10 +13,35 @@ describe("status line custom editor showcase", () => {
 		const keys = STATUS_LINE_CUSTOM_EDITOR_SHOWCASE_ENTRIES.map(
 			entry => `${entry.stateId}/${entry.columns}x${entry.rows}/${entry.renderMode}`,
 		);
+		const expectedKeys = new Set([
+			...[
+				"root-statusbar",
+				"picked-origin-slot",
+				"palette-exact-insert",
+				"separator-control",
+				"separator-choice-focused",
+				"separator-choice-applied",
+				"option-boolean-choice-focused",
+				"option-enum-choice-focused",
+				"option-numeric-choice-focused",
+				"option-choice-applied",
+				"exit-restored",
+				"confirm-persisted",
+				"overflow-two-row-warning",
+			].map(state => `${state}/80x32/unicode-color`),
+			"overflow-two-row-warning/48x40/unicode-color",
+			"narrow-cjk/48x40/unicode-color",
+			...[
+				"root-statusbar",
+				"picked-origin-slot",
+				"separator-choice-focused",
+				"option-boolean-choice-focused",
+				"option-enum-choice-focused",
+				"option-numeric-choice-focused",
+			].map(state => `${state}/80x32/ascii-no-color`),
+		]);
 		expect(new Set(keys).size).toBe(STATUS_LINE_CUSTOM_EDITOR_SHOWCASE_EXPECTED_ENTRY_COUNT);
-		expect(keys).toContain("root-statusbar/80x24/unicode-color");
-		expect(keys).toContain("overflow-two-row-warning/48x36/unicode-color");
-		expect(keys).toContain("option-numeric-choice-focused/80x24/ascii-no-color");
+		expect(new Set(keys)).toEqual(expectedKeys);
 	});
 
 	it("renders required editor witnesses from the production settings selector", async () => {
@@ -24,19 +49,19 @@ describe("status line custom editor showcase", () => {
 		const picked = await renderStatusLineCustomEditorShowcase({
 			stateId: "picked-origin-slot",
 			columns: 80,
-			rows: 24,
+			rows: 32,
 			renderMode: "ascii-no-color",
 		});
 		const choice = await renderStatusLineCustomEditorShowcase({
 			stateId: "separator-choice-focused",
 			columns: 80,
-			rows: 24,
+			rows: 32,
 			renderMode: "ascii-no-color",
 		});
 		const narrow = await renderStatusLineCustomEditorShowcase({
 			stateId: "overflow-two-row-warning",
 			columns: 48,
-			rows: 36,
+			rows: 40,
 			renderMode: "ascii-no-color",
 		});
 
@@ -89,8 +114,40 @@ describe("status line custom editor showcase", () => {
 			});
 			expect(strictVerify.exitCode).not.toBe(0);
 			expect(strictVerify.stderr.toString()).toContain("Missing approved independent review");
+
+			const manifestText = await Bun.file(path.join(outputRoot, "manifest.json")).text();
+			const manifest = JSON.parse(manifestText) as { sourceHead: string; sourceHash: string; captureActor: string };
+			const manifestSha256 = new Bun.CryptoHasher("sha256").update(manifestText).digest("hex");
+			await Bun.write(
+				path.join(outputRoot, "independent-review.json"),
+				`${JSON.stringify(
+					{
+						reviewer: `${manifest.captureActor}-independent`,
+						reviewerAssociation: "MEMBER",
+						verdict: "approved",
+						evidence: "https://github.com/Yeachan-Heo/gajae-code/pull/5278#pullrequestreview-1",
+						manifestSha256,
+						sourceHash: manifest.sourceHash,
+						headSha: manifest.sourceHead,
+					},
+					null,
+					2,
+				)}\n`,
+			);
+			const approvedVerify = Bun.spawnSync({
+				cmd: [
+					"bun",
+					"packages/coding-agent/scripts/verify-status-line-custom-editor-showcase.ts",
+					"--root",
+					outputRoot,
+					"--require-independent-review",
+				],
+				stdout: "pipe",
+				stderr: "pipe",
+			});
+			expect(approvedVerify.exitCode).toBe(0);
 		} finally {
 			await fs.rm(outputRoot, { recursive: true, force: true });
 		}
-	});
+	}, 15_000);
 });

--- a/packages/coding-agent/test/status-line-min-width.test.ts
+++ b/packages/coding-agent/test/status-line-min-width.test.ts
@@ -155,7 +155,7 @@ describe("status rail survives very small widths", () => {
 		expect(strip(buildRail().render(24)[0])).toBe(`18.3%/200K·${goalGlyph}·sonnet-4.5`);
 		expect(strip(buildRail().render(30)[0])).toBe(`18.3%/200K·${goalLabel}·sonnet-4.5`);
 		// Wide enough for the normal rail: the priority row must not hijack it.
-		const wide = strip(buildRail().render(80)[0]);
+		const wide = strip(buildRail().render(120)[0]);
 		expect(wide).toContain("sonnet-4.5");
 		expect(wide).toContain("Goal");
 		expect(wide).toContain("MinWidth");

--- a/packages/coding-agent/test/status-line-overflow.test.ts
+++ b/packages/coding-agent/test/status-line-overflow.test.ts
@@ -134,11 +134,12 @@ describe("status line preview highlight", () => {
 			previewHighlightSegment: "gajae",
 		});
 
-		expect(component.getTopBorder(80).content).toContain("\x1b[7m");
+		const focusBackground = theme.getFgAnsi("text").replace("\x1b[38;", "\x1b[48;");
+		expect(component.getTopBorder(80).content).toContain(focusBackground);
 
 		component.updateSettings({ separator: "pipe" });
 
-		expect(component.getTopBorder(80).content).not.toContain("\x1b[7m");
+		expect(component.getTopBorder(80).content).not.toContain(focusBackground);
 	});
 });
 

--- a/packages/tui/src/components/settings-list.ts
+++ b/packages/tui/src/components/settings-list.ts
@@ -62,6 +62,11 @@ export class SettingsList implements Component {
 		this.#notifySelectionChange();
 	}
 
+	get navigationLocked(): boolean {
+		const submenu = this.#submenuComponent as (Component & { navigationLocked?: boolean }) | null;
+		return submenu?.navigationLocked === true;
+	}
+
 	#clampSelectedIndex(): void {
 		if (this.#items.length === 0) {
 			this.#selectedIndex = 0;


### PR DESCRIPTION
## What

- Add a draft-local spatial Status Line Custom Editor under settings.
- Preserve current command-segment configuration, opaque option sections, and explicit invalid-value migration while supporting exact-slot add/remove/reorder behavior.
- Use the live multi-row status renderer for draft previews without executing, aborting, or mutating committed status commands.
- Add deterministic, source-bound visual capture and verification for narrow terminals, resize, Unicode/wide glyphs, color/no-color modes, focus/selection roles, and independent review provenance.

## Why

The contributor editor provided the requested spatial workflow, but replay onto current `dev` exposed command editing, configurable keybinding, preview lifecycle, renderer fidelity, and evidence-integrity regressions. The fix-forward preserves the contributor UX while restoring current status-line contracts and failing closed on stale visual approval.

## Testing

- `bun test packages/coding-agent/test/modes/components/settings-selector-status-line-custom.test.ts packages/coding-agent/test/status-line-custom-editor-showcase.test.ts packages/coding-agent/test/status-line-command.test.ts` — 38 passed.
- Adjacent status-line/settings/TUI/controller suites — 276 passed.
- `bun --cwd=packages/coding-agent run check`.
- `bun --cwd=packages/coding-agent run build`.
- `bun scripts/verify-gjc-state-writers.ts --fail --root .`.
- Deterministic capture/verification at `/tmp/pr-5278-evidence-f69c51b02b4`, bound to exact head `f69c51b02b420db767e297b60945d605c7d52bff`.

## Risk classification

- [ ] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [x] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:bec1685c0a388e9e20809afa60aac3a36b98ddc84ef4dedb18141d6eee4fa0c8 reviewer:human reviewer-id:Yeachan-Heo evidence:focused-and-adjacent-tests-package-check-build-and-source-bound-visual-verification
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken