### PR TITLE
fix(sdk): separate workflow session identity from the async endpoint key

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 
+- SDK-hosted workflow tools now retain the logical session id for ask, skill, deep-interview, and ultragoal state paths while job, monitor, bash, cron, task, and subagent ownership routes through a separate opaque async endpoint key. Explicit provider session identities no longer create encoded duplicate workflow trees or redirect endpoint-owned work to another live session.
 - Plain and explicit-model launches now refresh a missing provider's cached dynamic catalog before resolving a qualified startup selector, so configured models such as `glm-zcode/glm-5.3` no longer open in `no-model` state while preserving cache-only startup for already available models.
 - The explicit thinking-choice gate for xAI models now derives from the parsed grok generation (4.5+) shared with `@gajae-code/ai`, instead of the exact ids `grok-4.5`/`grok-4.6`. A future grok release failed the id list, so `supportsReasoningEffort` stayed `false` and the user's thinking level was silently dropped from requests; reseller-hosted grok routes (OpenRouter & co.) keep their existing audited-transport behavior.
 

--- a/packages/coding-agent/src/sdk/session.ts
+++ b/packages/coding-agent/src/sdk/session.ts
@@ -2708,13 +2708,14 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				else signal.addEventListener("abort", () => resolve(), { once: true });
 				return promise;
 			},
+			getSessionId: () => sessionManager.getSessionId(),
 			// Subagents inherit the parent's manager; its registered endpoint is
 			// authoritative for owned-registration keying and endpoint-first
 			// manager lookup (the child's own id is never registered), so tools
 			// pass the same endpoint the manager's completion callback resolves
 			// (review thread P1). For a top-level session this equals the
 			// session id.
-			getSessionId: () => AsyncJobManager.endpointIdOf(asyncJobManager) ?? asyncJobEndpointId,
+			getAsyncEndpointId: () => AsyncJobManager.endpointIdOf(asyncJobManager) ?? asyncJobEndpointId,
 			registerForegroundFoldParticipant: adapter =>
 				session?.registerForegroundFoldParticipant(adapter) ?? (() => {}),
 			hasForegroundBashBackgroundRequestHandler: () => session?.hasForegroundBashBackgroundRequestHandler() ?? false,

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -300,7 +300,8 @@ export interface ExecutorOptions {
 	managedPersistence?: ManagedTaskPersistence;
 	/**
 	 * The parent session's ENDPOINT-owned AsyncJobManager (resolved by the
-	 * TaskTool via forEndpoint(sessionId) ?? instance()). Model metadata and
+	 * TaskTool via its opaque async endpoint accessor, then the process-global
+	 * fallback). Model metadata and
 	 * live-handle state for THIS subagent are recorded in the SAME manager the
 	 * task job runs in — with concurrent top-level sessions the process-global
 	 * instance belongs to a different session and would surface this subagent

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -888,7 +888,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 	 * thread P1).
 	 */
 	#resolveOwnedJobManager(): AsyncJobManager | undefined {
-		const endpointId = this.session.getSessionId?.() ?? undefined;
+		const endpointId = this.session.getAsyncEndpointId?.() ?? this.session.getSessionId?.() ?? undefined;
 		return (
 			this.session.getAsyncJobManager?.() ?? AsyncJobManager.forEndpoint(endpointId) ?? AsyncJobManager.instance()
 		);
@@ -1245,7 +1245,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 					manager,
 					resumeToolCallId ?? descriptor.toolCallId,
 					resumeJobId,
-					this.session.getSessionId?.() ?? undefined,
+					this.session.getAsyncEndpointId?.() ?? this.session.getSessionId?.() ?? undefined,
 				);
 				return resumeJobId;
 			};
@@ -1477,7 +1477,12 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 						},
 					},
 				);
-				registerOwnedIfLineaged(manager, _toolCallId, jobId, this.session.getSessionId?.() ?? undefined);
+				registerOwnedIfLineaged(
+					manager,
+					_toolCallId,
+					jobId,
+					this.session.getAsyncEndpointId?.() ?? this.session.getSessionId?.() ?? undefined,
+				);
 				startedJobs.push({ jobId, taskId: taskItem.id });
 				if (typeof manager.registerResumeDescriptor === "function") {
 					manager.registerResumeDescriptor(

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -1107,7 +1107,12 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 			manager.failNow(jobId, jobGeneration, "Bash job owner was torn down.");
 		});
 		void completion.promise.finally(unregisterOwnerCleanup);
-		registerOwnedIfLineaged(manager, options.toolCallId, jobId, this.session.getSessionId?.() ?? undefined);
+		registerOwnedIfLineaged(
+			manager,
+			options.toolCallId,
+			jobId,
+			this.session.getAsyncEndpointId?.() ?? this.session.getSessionId?.() ?? undefined,
+		);
 
 		return {
 			jobId,
@@ -1132,7 +1137,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 	 * running (review thread P1).
 	 */
 	#resolveOwnedJobManager(): AsyncJobManager | undefined {
-		const endpointId = this.session.getSessionId?.() ?? undefined;
+		const endpointId = this.session.getAsyncEndpointId?.() ?? this.session.getSessionId?.() ?? undefined;
 		if (this.session.getAsyncJobManager) return this.session.getAsyncJobManager();
 		return AsyncJobManager.forEndpoint(endpointId) ?? AsyncJobManager.instance();
 	}
@@ -1681,7 +1686,12 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 		// Monitor jobs are exact owned background work of the turn that started
 		// them: register the five-tuple so scope:"owned" terminal abort stops the
 		// monitor too (review thread P2).
-		registerOwnedIfLineaged(manager, opts.toolCallId, jobId, this.session.getSessionId?.() ?? undefined);
+		registerOwnedIfLineaged(
+			manager,
+			opts.toolCallId,
+			jobId,
+			this.session.getAsyncEndpointId?.() ?? this.session.getSessionId?.() ?? undefined,
+		);
 		currentJobId = jobId;
 		return { jobId, label, commandCwd: prepared.commandCwd };
 	}
@@ -1883,19 +1893,31 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 			}
 			if (waitResult.kind === "completed") {
 				ownedManager.acknowledgeDeliveries([job.jobId]);
-				unregisterForegroundOwnedBash(ownedManager, job.jobId, this.session.getSessionId?.() ?? "local");
+				unregisterForegroundOwnedBash(
+					ownedManager,
+					job.jobId,
+					this.session.getAsyncEndpointId?.() ?? this.session.getSessionId?.() ?? "local",
+				);
 				return waitResult.result;
 			}
 			if (waitResult.kind === "failed") {
 				ownedManager.acknowledgeDeliveries([job.jobId]);
-				unregisterForegroundOwnedBash(ownedManager, job.jobId, this.session.getSessionId?.() ?? "local");
+				unregisterForegroundOwnedBash(
+					ownedManager,
+					job.jobId,
+					this.session.getAsyncEndpointId?.() ?? this.session.getSessionId?.() ?? "local",
+				);
 				throw waitResult.error;
 			}
 			if (waitResult.kind === "aborted") {
 				ownedManager.cancel(job.jobId);
 				const terminal = await job.completion;
 				ownedManager.acknowledgeDeliveries([job.jobId]);
-				unregisterForegroundOwnedBash(ownedManager, job.jobId, this.session.getSessionId?.() ?? "local");
+				unregisterForegroundOwnedBash(
+					ownedManager,
+					job.jobId,
+					this.session.getAsyncEndpointId?.() ?? this.session.getSessionId?.() ?? "local",
+				);
 				if (terminal.kind === "failed") {
 					throw new ToolAbortError(
 						formatManagedAbortFailure(terminal.error, terminal.result, job.getLatestText()),
@@ -2621,7 +2643,12 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 							throw error;
 						}
 						const ptyGeneration = ptyManager.getJob(ptyJobId)?.generation ?? ptyJobId;
-						registerOwnedIfLineaged(ptyManager, toolCallId, ptyJobId, this.session.getSessionId?.() ?? undefined);
+						registerOwnedIfLineaged(
+							ptyManager,
+							toolCallId,
+							ptyJobId,
+							this.session.getAsyncEndpointId?.() ?? this.session.getSessionId?.() ?? undefined,
+						);
 						const unregisterPtyOwnerCleanup = ptyManager.registerOwnerCleanup(ptyOwnerId, () => {
 							killPtyOnce();
 							ptyManager.failNow(ptyJobId, ptyGeneration, ownerTeardownText());

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -2379,7 +2379,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 			// already ran above, so exactly ONE remote handle exists and is retained
 			// across the fold.
 			const bridgeManager = ownedManager;
-			const bridgeEndpointId = this.session.getSessionId?.() ?? "local";
+			const bridgeEndpointId = this.session.getAsyncEndpointId?.() ?? this.session.getSessionId?.() ?? "local";
 			const bridgeLabel = command.length > 120 ? `${command.slice(0, 117)}...` : command;
 			const bridgeCompletion = Promise.withResolvers<ManagedBashJobCompletion>();
 			let bridgeForegroundSettled = false;

--- a/packages/coding-agent/src/tools/cron.ts
+++ b/packages/coding-agent/src/tools/cron.ts
@@ -592,7 +592,7 @@ export class CronTool implements AgentTool<typeof cronSchema, CronToolDetails> {
 	}
 
 	#resolveOwnedJobManager(): AsyncJobManager | undefined {
-		const endpointId = this.session.getSessionId?.() ?? undefined;
+		const endpointId = this.session.getAsyncEndpointId?.() ?? this.session.getSessionId?.() ?? undefined;
 		return (
 			this.session.getAsyncJobManager?.() ?? AsyncJobManager.forEndpoint(endpointId) ?? AsyncJobManager.instance()
 		);

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -249,6 +249,15 @@ export interface ToolSession {
 	waitForUserSteering?: (signal: AbortSignal) => Promise<void>;
 	/** Get session ID */
 	getSessionId?: () => string | null;
+	/**
+	 * Async-job ownership/lookup endpoint key. For SDK sessions created with an
+	 * explicit provider session id this is a JSON tuple (see async/support.ts),
+	 * NOT a path-safe session id — workflow/session-identity consumers must use
+	 * getSessionId(); only AsyncJobManager ownership and endpoint-first lookup
+	 * may use this (subagent-inherited managers are registered under the
+	 * parent's endpoint only; review thread P1).
+	 */
+	getAsyncEndpointId?: () => string | null;
 	/** Get credential-selection session identity. */
 	getCredentialSessionId?: () => string | null;
 	/** Scope-held MCP facade for mcp:// resolution. */

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -250,12 +250,11 @@ export interface ToolSession {
 	/** Get session ID */
 	getSessionId?: () => string | null;
 	/**
-	 * Async-job ownership/lookup endpoint key. For SDK sessions created with an
-	 * explicit provider session id this is a JSON tuple (see async/support.ts),
-	 * NOT a path-safe session id — workflow/session-identity consumers must use
-	 * getSessionId(); only AsyncJobManager ownership and endpoint-first lookup
-	 * may use this (subagent-inherited managers are registered under the
-	 * parent's endpoint only; review thread P1).
+	 * Opaque async-job ownership/lookup endpoint key. This is not a workflow or
+	 * path identity: workflow/session consumers must use getSessionId(). Only
+	 * AsyncJobManager ownership and endpoint-first lookup may use this accessor
+	 * (subagent-inherited managers are registered under the parent's endpoint;
+	 * review thread P1).
 	 */
 	getAsyncEndpointId?: () => string | null;
 	/** Get credential-selection session identity. */

--- a/packages/coding-agent/src/tools/job.ts
+++ b/packages/coding-agent/src/tools/job.ts
@@ -396,7 +396,11 @@ export class JobTool implements AgentTool<typeof jobSchema, JobToolDetails> {
 			const generation = manager.getJob?.(job.id)?.generation;
 			if (!generation) continue;
 			// The endpoint disambiguates concurrent sessions' same job ids (review P1).
-			const registration = lookupOwnedRegistration(job.id, generation, this.session.getSessionId?.() ?? "local");
+			const registration = lookupOwnedRegistration(
+				job.id,
+				generation,
+				this.session.getAsyncEndpointId?.() ?? this.session.getSessionId?.() ?? "local",
+			);
 			if (registration) unregisterOwnedRegistration(registration);
 		}
 

--- a/packages/coding-agent/src/tools/job.ts
+++ b/packages/coding-agent/src/tools/job.ts
@@ -105,7 +105,9 @@ export class JobTool implements AgentTool<typeof jobSchema, JobToolDetails> {
 	): Promise<AgentToolResult<JobToolDetails>> {
 		const manager =
 			this.session.getAsyncJobManager?.() ??
-			AsyncJobManager.forEndpoint(this.session.getSessionId?.() ?? undefined) ??
+			AsyncJobManager.forEndpoint(
+				this.session.getAsyncEndpointId?.() ?? this.session.getSessionId?.() ?? undefined,
+			) ??
 			AsyncJobManager.instance();
 		if (!manager) {
 			return {

--- a/packages/coding-agent/src/tools/monitor.ts
+++ b/packages/coding-agent/src/tools/monitor.ts
@@ -119,7 +119,9 @@ export class MonitorTool implements AgentTool<typeof monitorSchema, MonitorToolD
 		// different concurrent top-level session (review thread P1).
 		const manager =
 			this.session.getAsyncJobManager?.() ??
-			AsyncJobManager.forEndpoint(this.session.getSessionId?.() ?? undefined) ??
+			AsyncJobManager.forEndpoint(
+				this.session.getAsyncEndpointId?.() ?? this.session.getSessionId?.() ?? undefined,
+			) ??
 			AsyncJobManager.instance();
 		if (!manager) {
 			throw new ToolError("Async execution is disabled; the monitor tool is unavailable in this session.");
@@ -197,7 +199,11 @@ export class MonitorTool implements AgentTool<typeof monitorSchema, MonitorToolD
 			// endpoint-less fallback scan could attach a foreign session's
 			// registration (review thread P2).
 			const registration = generation
-				? lookupOwnedRegistration(jobId, generation, this.session.getSessionId?.() ?? "local")
+				? lookupOwnedRegistration(
+						jobId,
+						generation,
+						this.session.getAsyncEndpointId?.() ?? this.session.getSessionId?.() ?? "local",
+					)
 				: undefined;
 			const ownedCompletion = registration
 				? {

--- a/packages/coding-agent/src/tools/subagent.ts
+++ b/packages/coding-agent/src/tools/subagent.ts
@@ -227,7 +227,9 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 		// or belong to a same-id subagent of another session (review thread P1).
 		const manager =
 			this.session.getAsyncJobManager?.() ??
-			AsyncJobManager.forEndpoint(this.session.getSessionId?.() ?? undefined) ??
+			AsyncJobManager.forEndpoint(
+				this.session.getAsyncEndpointId?.() ?? this.session.getSessionId?.() ?? undefined,
+			) ??
 			AsyncJobManager.instance();
 		if (!manager) {
 			return {

--- a/packages/coding-agent/test/bash-acp-terminal-fold.test.ts
+++ b/packages/coding-agent/test/bash-acp-terminal-fold.test.ts
@@ -8,6 +8,11 @@ import type {
 	ClientBridgeTerminalOutput,
 } from "../src/session/client-bridge";
 import { type FoldAdapter, FoldCoordinator } from "../src/session/fold-coordinator";
+import {
+	bindToolLineage,
+	lookupOwnedRegistration,
+	resetTerminalAbortRegistriesForTests,
+} from "../src/session/terminal-abort";
 import type { ToolSession } from "../src/tools";
 import { BashTool, STEER_FOLD_GRACE_MS, steerFoldReasonLine } from "../src/tools/bash";
 
@@ -20,7 +25,12 @@ interface Harness {
 
 function makeHarness(
 	bridge: ClientBridge,
-	options: { autoBackgroundEnabled?: boolean; thresholdMs?: number; maxRunningJobs?: number } = {},
+	options: {
+		autoBackgroundEnabled?: boolean;
+		thresholdMs?: number;
+		maxRunningJobs?: number;
+		asyncEndpointId?: string;
+	} = {},
 ): Harness {
 	const delivered: Array<{ jobId: string; text: string }> = [];
 	const manager = new AsyncJobManager({
@@ -53,6 +63,7 @@ function makeHarness(
 		},
 		getClientBridge: () => bridge,
 		getSessionId: () => "acp-session",
+		getAsyncEndpointId: () => options.asyncEndpointId ?? "acp-session",
 		getAgentId: () => "0-Main",
 		getAsyncJobManager: () => manager,
 		registerForegroundFoldParticipant: (adapter: FoldAdapter) => {
@@ -88,10 +99,47 @@ async function waitFor(predicate: () => boolean, timeoutMs = 5_000): Promise<voi
 
 afterEach(() => {
 	mock.restore();
+	resetTerminalAbortRegistriesForTests();
 	AsyncJobManager.resetForTests();
 });
 
 describe("BashTool ACP terminal fold", () => {
+	it("registers client terminal ownership under the opaque async endpoint", async () => {
+		const exit = Promise.withResolvers<{ exitCode: number; signal: null }>();
+		const handle: ClientBridgeTerminalHandle = {
+			terminalId: "term-endpoint-ownership",
+			waitForExit: () => exit.promise,
+			currentOutput: async () => ({ output: "endpoint output\n", truncated: false }),
+			kill: async () => {},
+			release: async () => {},
+		};
+		const bridge: ClientBridge = { capabilities: { terminal: true }, createTerminal: async () => handle };
+		const endpointId = '["async-job-endpoint","provider","/tmp/session.jsonl"]';
+		const h = makeHarness(bridge, { asyncEndpointId: endpointId });
+		bindToolLineage("call-endpoint-ownership", {
+			lineageIdHash: "client-terminal-lineage",
+			promptAttemptEpoch: 7,
+			endpointGeneration: 0,
+			endpointId,
+		});
+
+		const resultPromise = new BashTool(h.session).execute(
+			"call-endpoint-ownership",
+			{ command: "sleep 30" },
+			undefined,
+			() => {},
+		);
+		await waitFor(() => h.adapters.length === 1);
+		const adapter = h.adapters[0]!;
+		expect(lookupOwnedRegistration(adapter.jobId, adapter.jobGeneration, endpointId)).toBeDefined();
+		expect(lookupOwnedRegistration(adapter.jobId, adapter.jobGeneration, "acp-session")).toBeUndefined();
+
+		foldVia(adapter);
+		await resultPromise;
+		exit.resolve({ exitCode: 0, signal: null });
+		await waitFor(() => h.delivered.length === 1);
+	}, 10_000);
+
 	it("folds a client terminal, retaining exactly one remote handle across the fold", async () => {
 		const exit = Promise.withResolvers<{ exitCode: number; signal: null }>();
 		const handle: ClientBridgeTerminalHandle = {

--- a/packages/coding-agent/test/sdk-session-workflow-identity.test.ts
+++ b/packages/coding-agent/test/sdk-session-workflow-identity.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { deepInterviewStatePath } from "@gajae-code/coding-agent/gjc-runtime/deep-interview-runtime";
+import { createAgentSession } from "@gajae-code/coding-agent/sdk";
+import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
+import type { ToolSession } from "@gajae-code/coding-agent/tools";
+import { Snowflake } from "@gajae-code/utils";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+	for (const tempDir of tempDirs.splice(0)) {
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	}
+});
+
+test("SDK tool session separates workflow identity from async endpoint identity", async () => {
+	const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), `gjc-sdk-workflow-identity-${Snowflake.next()}-`));
+	tempDirs.push(tempDir);
+	const cwd = path.join(tempDir, "project");
+	const agentDir = path.join(tempDir, "agent");
+	fs.mkdirSync(cwd, { recursive: true });
+
+	const sessionManager = SessionManager.create(cwd, SessionManager.managedDestination(cwd, agentDir));
+	sessionManager.appendMessage({ role: "user", content: "persist transcript", timestamp: Date.now() });
+	await sessionManager.flush();
+	expect(sessionManager.getSessionFile()).not.toBeNull();
+
+	const { session } = await createAgentSession({
+		cwd,
+		agentDir,
+		sessionManager,
+		providerSessionId: "provider-session-id",
+		settings: Settings.isolated(),
+		disableExtensionDiscovery: true,
+		skills: [],
+		contextFiles: [],
+		promptTemplates: [],
+		slashCommands: [],
+		enableMCP: false,
+		enableLsp: false,
+		toolNames: ["job"],
+	});
+
+	try {
+		const job = session.getToolByName("job") as unknown as
+			| { materializeForTests?: () => Promise<{ session?: ToolSession }> }
+			| undefined;
+		if (!job) throw new Error(`Job tool unavailable: ${session.getAllToolNames().join(", ")}`);
+		const toolSession = (await job.materializeForTests?.())?.session;
+		expect(toolSession).toBeDefined();
+
+		const sessionId = toolSession?.getSessionId?.();
+		const endpointId = toolSession?.getAsyncEndpointId?.();
+		if (!sessionId || !endpointId) throw new Error("Expected SDK tool session identities");
+		expect(sessionId).toBe(sessionManager.getSessionId());
+		expect(sessionId).toMatch(/^[^/\\]+$/);
+		expect(endpointId).not.toBe(sessionId);
+		expect(JSON.parse(endpointId)).toEqual([
+			"async-job-endpoint",
+			"provider-session-id",
+			sessionManager.getSessionFile(),
+		]);
+
+		const statePath = deepInterviewStatePath(cwd, sessionId);
+		expect(statePath).toBe(path.join(cwd, ".gjc", `_session-${sessionId}`, "state", "deep-interview-state.json"));
+		expect(statePath).not.toContain("%5B");
+	} finally {
+		await session.dispose();
+	}
+});

--- a/packages/coding-agent/test/sdk-session-workflow-identity.test.ts
+++ b/packages/coding-agent/test/sdk-session-workflow-identity.test.ts
@@ -2,11 +2,16 @@ import { afterEach, expect, test } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { AsyncJobManager, asyncJobEndpointId } from "@gajae-code/coding-agent/async";
 import { Settings } from "@gajae-code/coding-agent/config/settings";
 import { deepInterviewStatePath } from "@gajae-code/coding-agent/gjc-runtime/deep-interview-runtime";
+import { sessionUltragoalDir } from "@gajae-code/coding-agent/gjc-runtime/session-layout";
 import { createAgentSession } from "@gajae-code/coding-agent/sdk";
 import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
 import type { ToolSession } from "@gajae-code/coding-agent/tools";
+import { JobTool } from "@gajae-code/coding-agent/tools/job";
+import { MonitorTool } from "@gajae-code/coding-agent/tools/monitor";
+import { SubagentTool } from "@gajae-code/coding-agent/tools/subagent";
 import { Snowflake } from "@gajae-code/utils";
 
 const tempDirs: string[] = [];
@@ -59,16 +64,90 @@ test("SDK tool session separates workflow identity from async endpoint identity"
 		expect(sessionId).toBe(sessionManager.getSessionId());
 		expect(sessionId).toMatch(/^[^/\\]+$/);
 		expect(endpointId).not.toBe(sessionId);
-		expect(JSON.parse(endpointId)).toEqual([
-			"async-job-endpoint",
-			"provider-session-id",
-			sessionManager.getSessionFile(),
-		]);
+		expect(endpointId).toBe(
+			asyncJobEndpointId("provider-session-id", sessionManager.getSessionId(), sessionManager.getSessionFile()),
+		);
 
 		const statePath = deepInterviewStatePath(cwd, sessionId);
 		expect(statePath).toBe(path.join(cwd, ".gjc", `_session-${sessionId}`, "state", "deep-interview-state.json"));
 		expect(statePath).not.toContain("%5B");
+		expect(sessionUltragoalDir(cwd, sessionId)).toBe(path.join(cwd, ".gjc", `_session-${sessionId}`, "ultragoal"));
 	} finally {
 		await session.dispose();
+	}
+});
+
+test("async tools use the opaque endpoint while workflow consumers retain the logical id", async () => {
+	const previousManager = AsyncJobManager.instance();
+	const endpointManager = new AsyncJobManager({ onJobComplete: async () => {} });
+	const foreignManager = new AsyncJobManager({ onJobComplete: async () => {} });
+	const logicalSessionId = "workflow-session";
+	const endpointId = asyncJobEndpointId("provider-session", logicalSessionId, "/tmp/workflow-session.jsonl");
+	const endpointJobId = endpointManager.register("bash", "endpoint-owned", async () => "done");
+	const foreignJobId = foreignManager.register("bash", "foreign", async () => "done");
+	endpointManager.registerSubagentRecord({
+		subagentId: "0-Endpoint",
+		currentJobId: endpointJobId,
+		historicalJobIds: [],
+		status: "running",
+		sessionFile: null,
+		resumable: false,
+	});
+	foreignManager.registerSubagentRecord({
+		subagentId: "0-Foreign",
+		currentJobId: foreignJobId,
+		historicalJobIds: [],
+		status: "running",
+		sessionFile: null,
+		resumable: false,
+	});
+
+	try {
+		expect(AsyncJobManager.registerForEndpoint(endpointId, endpointManager)).toBe(true);
+		AsyncJobManager.setInstance(foreignManager);
+		const session = {
+			cwd: process.cwd(),
+			hasUI: false,
+			settings: Settings.isolated(),
+			getSessionId: () => logicalSessionId,
+			getAsyncEndpointId: () => endpointId,
+			getSessionFile: () => null,
+			getSessionSpawns: () => "*",
+			getAgentId: () => undefined,
+			sendCustomMessage: async () => {},
+			purgeQueuedCustomMessages: () => ({
+				agentSteering: 0,
+				agentFollowUp: 0,
+				pendingNextTurn: 0,
+				displaySteering: 0,
+				displayFollowUp: 0,
+				totalExecutable: 0,
+			}),
+			allocateOutputArtifact: async () => ({}),
+		} as unknown as ToolSession;
+
+		const jobs = await new JobTool(session).execute("job-list", { list: true });
+		expect(jobs.details?.jobs.map(job => job.label)).toContain("endpoint-owned");
+		expect(jobs.details?.jobs.map(job => job.label)).not.toContain("foreign");
+
+		const subagents = await new SubagentTool(session).execute("subagent-list", { action: "list" });
+		expect(subagents.details?.subagents.map(subagent => subagent.id)).toContain("0-Endpoint");
+		expect(subagents.details?.subagents.map(subagent => subagent.id)).not.toContain("0-Foreign");
+
+		const endpointJobsBeforeMonitor = endpointManager.getAllJobs().length;
+		const foreignJobsBeforeMonitor = foreignManager.getAllJobs().length;
+		await new MonitorTool(session).execute("monitor-create", {
+			command: "printf 'endpoint-routed\\n'",
+			kind: "other",
+			description: "endpoint routing regression",
+			persistent: false,
+		});
+		expect(endpointManager.getAllJobs()).toHaveLength(endpointJobsBeforeMonitor + 1);
+		expect(foreignManager.getAllJobs()).toHaveLength(foreignJobsBeforeMonitor);
+	} finally {
+		AsyncJobManager.unregisterManager(endpointManager);
+		await endpointManager.dispose({ timeoutMs: 500 });
+		await foreignManager.dispose({ timeoutMs: 500 });
+		AsyncJobManager.setInstance(previousManager);
 	}
 });


### PR DESCRIPTION
## Problem

SDK tool sessions conflated the logical workflow session id with the AsyncJobManager endpoint key. Explicit provider identities plus persisted transcripts produce an opaque composite endpoint; workflow consumers used that value as a path component and created duplicate encoded `.gjc/_session-*` trees.

## Fix

- `ToolSession.getSessionId()` remains the logical, path-safe workflow identity.
- `ToolSession.getAsyncEndpointId()` carries the opaque async ownership key.
- Job, monitor, subagent, bash (ordinary, PTY, and client-terminal bridge), cron, and task manager lookup, lineage registration, and terminal retirement use the endpoint accessor with the legacy logical-id fallback.
- Ask, skill, deep-interview, ultragoal, plan-mode, and other workflow state consumers continue using the logical id.
- Child sessions inherit the parent's endpoint-owned manager without registering child workflow ids as async endpoints.

## Testing

- Focused identity and endpoint compatibility regressions, including provider/transcript path aliases, collisions, lifecycle rekey, job/monitor/subagent/client-terminal routing, and workflow paths.
- Adjacent async ownership, workflow state, SDK ACP/MCP/daemon adapters, resume, and move suites.
- `bun run check:sdk-closure`
- `bun --cwd=packages/coding-agent run check`
- `bun --cwd=packages/coding-agent run build`
- `bun run ci:check:full`
- Authenticated exact-head approval recorded for `941056d2db7d80b23e1bbc33cd12987cb6b1e3a2`.

## Risk classification

- [ ] `low-risk`
- [x] `regression-risk`
- [ ] `high-risk`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:5475347e7e8f8ff70b6deebbf7a242a53e84c048daa6d2a0080a0356a392fcd0 reviewer:human reviewer-id:Yeachan-Heo evidence:independent-exact-head-review-and-local-ci-check-full
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated
- [x] Verdict matches exact PR head `941056d2db7d80b23e1bbc33cd12987cb6b1e3a2`
- [x] Risk classification matches the independent-review path