### PR TITLE
fix(cli): allow explicit --thinking off

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 
 - SDK-hosted workflow tools now retain the logical session id for ask, skill, deep-interview, and ultragoal state paths while job, monitor, bash, cron, task, and subagent ownership routes through a separate opaque async endpoint key. Explicit provider session identities no longer create encoded duplicate workflow trees or redirect endpoint-owned work to another live session.
+- Explicit root startup `--thinking off` and `--thinking=off` now override a configured higher startup default while leaving the provider `Effort` catalog unchanged.
 - Plain and explicit-model launches now refresh a missing provider's cached dynamic catalog before resolving a qualified startup selector, so configured models such as `glm-zcode/glm-5.3` no longer open in `no-model` state while preserving cache-only startup for already available models.
 - The explicit thinking-choice gate for xAI models now derives from the parsed grok generation (4.5+) shared with `@gajae-code/ai`, instead of the exact ids `grok-4.5`/`grok-4.6`. A future grok release failed the id list, so `supportsReasoningEffort` stayed `false` and the user's thinking level was silently dropped from requests; reseller-hosted grok routes (OpenRouter & co.) keep their existing audited-transport behavior.
 

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -2,12 +2,18 @@
  * CLI argument parsing
  */
 import * as path from "node:path";
-import { type Effort, THINKING_EFFORTS } from "@gajae-code/ai/core";
+import { ThinkingLevel } from "@gajae-code/agent-core";
 import { logger } from "@gajae-code/utils";
 import { CliParseError } from "@gajae-code/utils/cli";
-import { parseEffort } from "../thinking";
+import { parseThinkingLevel } from "../thinking";
 import { BUILTIN_TOOLS } from "../tools";
-import { type ConsumerLaunchFlagName, LAUNCH_PARSE_FLAGS, launchFlagIsOwnedBy } from "./root-flags";
+import {
+	type ConsumerLaunchFlagName,
+	LAUNCH_PARSE_FLAGS,
+	launchFlagIsOwnedBy,
+	ROOT_THINKING_LEVELS,
+	type RootThinkingLevel,
+} from "./root-flags";
 
 const ROOT_FLAG_TOKENS = new Set<string>();
 for (const [name, descriptor] of Object.entries(LAUNCH_PARSE_FLAGS)) {
@@ -55,7 +61,7 @@ export interface Args {
 	mcpConfig?: string;
 	/** Opt a standalone session out of conventional MCP autoload (mutually exclusive with --mcp-config). */
 	noMcp?: boolean;
-	thinking?: Effort;
+	thinking?: RootThinkingLevel;
 	continue?: boolean;
 	resume?: string | true;
 	help?: boolean;
@@ -348,15 +354,15 @@ export function parseArgs(args: string[], authority: ParseArgsAuthority = "local
 			// a usage error, not a silent no-op / accidental consumption of `-p`.
 			const next = args[i + 1];
 			if (!next || next.startsWith("-")) {
-				throw new CliParseError(`--thinking requires <level> (${THINKING_EFFORTS.join(", ")})`);
+				throw new CliParseError(`--thinking requires <level> (${ROOT_THINKING_LEVELS.join(", ")})`);
 			}
 			const rawThinking = args[++i];
-			const thinking = parseEffort(rawThinking);
-			if (thinking === undefined) {
+			const thinking = parseThinkingLevel(rawThinking);
+			if (thinking === undefined || thinking === ThinkingLevel.Inherit) {
 				// Fail closed: a silent ignore left users believing `ultra` (or any typo)
-				// was applied. Help / Flags.options advertise the real Effort enum.
+				// was applied. Help / Flags.options advertise the root thinking levels.
 				throw new CliParseError(
-					`Invalid --thinking level "${rawThinking}". Expected one of: ${THINKING_EFFORTS.join(", ")}`,
+					`Invalid --thinking level "${rawThinking}". Expected one of: ${ROOT_THINKING_LEVELS.join(", ")}`,
 				);
 			}
 			result.thinking = thinking;

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -144,6 +144,7 @@ export function parseArgs(args: string[], authority: ParseArgsAuthority = "local
 		unknownFlags: new Map(),
 	};
 	const consumerFlags = new Map<ConsumerLaunchFlagName, string>();
+	let hasThinkingFlag = false;
 
 	for (let i = 0; i < args.length; i++) {
 		let arg = args[i];
@@ -350,6 +351,10 @@ export function parseArgs(args: string[], authority: ParseArgsAuthority = "local
 			}
 			result.tools = validTools;
 		} else if (arg === "--thinking") {
+			if (hasThinkingFlag) {
+				throw new CliParseError("--thinking can only be specified once");
+			}
+			hasThinkingFlag = true;
 			// Match --credential / --mcp-config: a missing value or a following flag is
 			// a usage error, not a silent no-op / accidental consumption of `-p`.
 			const next = args[i + 1];

--- a/packages/coding-agent/src/cli/root-flags.ts
+++ b/packages/coding-agent/src/cli/root-flags.ts
@@ -1,6 +1,8 @@
+import { THINKING_EFFORTS } from "@gajae-code/ai/core";
 import { type FlagDescriptor, Flags } from "@gajae-code/utils/cli";
 
-const ROOT_THINKING_EFFORTS = ["minimal", "low", "medium", "high", "xhigh", "max"] as const;
+export const ROOT_THINKING_LEVELS = ["off", ...THINKING_EFFORTS] as const;
+export type RootThinkingLevel = (typeof ROOT_THINKING_LEVELS)[number];
 
 /** Public launch flags shared by root help, completion, and the launch command. */
 export const ROOT_LAUNCH_FLAGS = {
@@ -63,8 +65,8 @@ export const ROOT_LAUNCH_FLAGS = {
 	tmux: Flags.boolean({ description: "Launch interactive startup inside tmux" }),
 	tools: Flags.string({ description: "Comma-separated list of tools to enable (default: all)" }),
 	thinking: Flags.string({
-		description: `Set thinking level: ${ROOT_THINKING_EFFORTS.join(", ")}`,
-		options: ROOT_THINKING_EFFORTS,
+		description: `Set thinking level: ${ROOT_THINKING_LEVELS.join(", ")}`,
+		options: ROOT_THINKING_LEVELS,
 	}),
 	"no-rules": Flags.boolean({ description: "Disable rules discovery and loading" }),
 	export: Flags.string({ description: "Export session file to HTML and exit" }),

--- a/packages/coding-agent/test/acp-startup-options.test.ts
+++ b/packages/coding-agent/test/acp-startup-options.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "bun:test";
 import * as path from "node:path";
 import type { AgentSideConnection } from "@agentclientprotocol/sdk";
+import { ThinkingLevel } from "@gajae-code/agent-core";
 import { type CliConfig, CliParseError } from "@gajae-code/utils/cli";
 import { parseArgs } from "../src/cli/args";
 import Acp from "../src/commands/acp";
@@ -635,6 +636,10 @@ test("ACP fails closed for local-only startup flags while translating model and 
 	expect(resolveAcpStartupOptions(parsed, { model, thinkingLevel: "high" as never })).toEqual({
 		modelId: "openai-codex/gpt-5.6",
 		thinkingLevel: "high",
+	});
+	const thinkingOff = parseArgs(["--thinking=off"]);
+	expect(resolveAcpStartupOptions(thinkingOff, { thinkingLevel: ThinkingLevel.Off })).toEqual({
+		thinkingLevel: "off",
 	});
 
 	const unsupported = parseArgs(["--model", "gpt-5.6", "--no-lsp", "initial prompt"]);

--- a/packages/coding-agent/test/cli-args-mpreset.test.ts
+++ b/packages/coding-agent/test/cli-args-mpreset.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, spyOn, test, vi } from "bun:test";
 import { ThinkingLevel } from "@gajae-code/agent-core";
-import { type Model, THINKING_EFFORTS } from "@gajae-code/ai";
+import type { Model } from "@gajae-code/ai";
 import { CliParseError } from "@gajae-code/utils/cli";
 import { parseArgs } from "../src/cli/args";
+import { ROOT_THINKING_LEVELS } from "../src/cli/root-flags";
 import type { ModelProfileDefinition } from "../src/config/model-profiles";
 import { Settings } from "../src/config/settings";
 import {
@@ -13,6 +14,7 @@ import {
 } from "../src/main";
 import { parseCliCredentialSelector } from "../src/runtime-credential-selector";
 import type { AgentSession } from "../src/session/agent-session";
+import { toReasoningEffort } from "../src/thinking";
 
 const model = (provider: string, id: string): Model =>
 	({ provider, id, name: id, api: "openai-responses", contextWindow: 1000, maxTokens: 1000 }) as Model;
@@ -938,23 +940,59 @@ test("thinking-only startup uses authoritative override semantics", async () => 
 	]);
 });
 
+test("explicit CLI --thinking off overrides a high default without provider effort", async () => {
+	const settings = Settings.isolated({
+		"modelProfile.default": "default-profile",
+		defaultThinkingLevel: ThinkingLevel.High,
+	});
+	const session = fakeSession();
+	const parsedArgs = parseArgs(["--thinking", "off"]);
+
+	await applyStartupModelProfiles({
+		session,
+		settings,
+		modelRegistry: fakeRegistry([
+			{
+				name: "default-profile",
+				requiredProviders: ["profile-provider"],
+				modelMapping: { default: "profile-provider/default:medium" },
+				source: "user",
+			},
+		]) as never,
+		parsedArgs,
+		startupModel: undefined,
+		startupThinkingLevel: undefined,
+	});
+
+	expect(
+		session.setModelTemporaryCalls.map(call => `${call.model.provider}/${call.model.id}:${call.thinkingLevel}`),
+	).toEqual(["profile-provider/default:high", "profile-provider/default:off"]);
+	expect(session.thinkingLevel).toBe(ThinkingLevel.Off);
+	expect(toReasoningEffort(ThinkingLevel.Off)).toBeUndefined();
+});
+
 describe("CLI --thinking contract", () => {
-	test("accepts every Effort level advertised by help", () => {
-		for (const level of THINKING_EFFORTS) {
+	test("accepts every root thinking level in separate and equals forms", () => {
+		for (const level of ROOT_THINKING_LEVELS) {
 			expect(parseArgs(["--thinking", level]).thinking).toBe(level);
+			expect(parseArgs([`--thinking=${level}`]).thinking).toBe(level);
 		}
 	});
 
 	test("rejects the retired ultra token instead of silently ignoring it", () => {
 		expect(() => parseArgs(["--thinking", "ultra"])).toThrow(CliParseError);
 		expect(() => parseArgs(["--thinking", "ultra"])).toThrow(
-			/Invalid --thinking level "ultra".*minimal, low, medium, high, xhigh, max/,
+			/Invalid --thinking level "ultra".*off, minimal, low, medium, high, xhigh, max/,
 		);
 	});
 
-	test("rejects unknown tokens fail-closed", () => {
-		expect(() => parseArgs(["--thinking", "ludicrous"])).toThrow(CliParseError);
-		expect(() => parseArgs(["--thinking", "off"])).toThrow(CliParseError);
+	test("rejects inherit and unknown tokens with the advertised levels", () => {
+		for (const rawThinking of ["inherit", "ludicrous"]) {
+			expect(() => parseArgs(["--thinking", rawThinking])).toThrow(CliParseError);
+			expect(() => parseArgs(["--thinking", rawThinking])).toThrow(
+				`Invalid --thinking level "${rawThinking}". Expected one of: ${ROOT_THINKING_LEVELS.join(", ")}`,
+			);
+		}
 	});
 
 	test("rejects a bare --thinking with no value", () => {

--- a/packages/coding-agent/test/cli-args-mpreset.test.ts
+++ b/packages/coding-agent/test/cli-args-mpreset.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, spyOn, test, vi } from "bun:test";
 import { ThinkingLevel } from "@gajae-code/agent-core";
-import type { Model } from "@gajae-code/ai";
+import { type Model, THINKING_EFFORTS } from "@gajae-code/ai";
 import { CliParseError } from "@gajae-code/utils/cli";
 import { parseArgs } from "../src/cli/args";
 import { ROOT_THINKING_LEVELS } from "../src/cli/root-flags";
@@ -940,13 +940,14 @@ test("thinking-only startup uses authoritative override semantics", async () => 
 	]);
 });
 
-test("explicit CLI --thinking off overrides a high default without provider effort", async () => {
+test("explicit CLI --thinking off overrides a resumed high default without provider effort", async () => {
 	const settings = Settings.isolated({
 		"modelProfile.default": "default-profile",
 		defaultThinkingLevel: ThinkingLevel.High,
 	});
 	const session = fakeSession();
-	const parsedArgs = parseArgs(["--thinking", "off"]);
+	const parsedArgs = parseArgs(["--resume", "session-1", "--thinking", "off"]);
+	expect(parsedArgs.resume).toBe("session-1");
 
 	await applyStartupModelProfiles({
 		session,
@@ -979,6 +980,21 @@ describe("CLI --thinking contract", () => {
 		}
 	});
 
+	test("accepts off unchanged in JSON non-interactive startup", () => {
+		expect(parseArgs(["--mode=json", "--print", "--thinking=off", "prompt"])).toMatchObject({
+			mode: "json",
+			print: true,
+			thinking: ThinkingLevel.Off,
+			messages: ["prompt"],
+		});
+	});
+
+	test("keeps off agent-local instead of expanding the provider effort catalog", () => {
+		expect(ROOT_THINKING_LEVELS).toEqual([ThinkingLevel.Off, ...THINKING_EFFORTS]);
+		expect(new Set<string>(THINKING_EFFORTS).has(ThinkingLevel.Off)).toBe(false);
+		expect(toReasoningEffort(ThinkingLevel.Off)).toBeUndefined();
+	});
+
 	test("rejects the retired ultra token instead of silently ignoring it", () => {
 		expect(() => parseArgs(["--thinking", "ultra"])).toThrow(CliParseError);
 		expect(() => parseArgs(["--thinking", "ultra"])).toThrow(
@@ -1008,5 +1024,14 @@ describe("CLI --thinking contract", () => {
 
 	test("rejects an empty --thinking= value", () => {
 		expect(() => parseArgs(["--thinking="])).toThrow(CliParseError);
+	});
+
+	test("rejects duplicate thinking flags instead of applying order-dependent precedence", () => {
+		for (const args of [
+			["--thinking", "off", "--thinking", "off"],
+			["--thinking=high", "--thinking=off"],
+		]) {
+			expect(() => parseArgs(args)).toThrow("--thinking can only be specified once");
+		}
 	});
 });

--- a/packages/coding-agent/test/completion-cli.test.ts
+++ b/packages/coding-agent/test/completion-cli.test.ts
@@ -118,8 +118,9 @@ describe("GJC inshellisense completion spec", () => {
 			expect(findSubcommand(spec, command), command).toBeDefined();
 		}
 		expect(names(findSubcommand(spec, "web-search")!.name)).toContain("q");
-		// Root help must advertise the real Effort enum — not the retired `ultra` token.
+		// Root help must advertise the real thinking selector — not the retired `ultra` token.
 		expect(findOption(spec.options, "--thinking")?.args?.suggestions).toEqual([
+			"off",
 			"minimal",
 			"low",
 			"medium",


### PR DESCRIPTION
## What

- Allow `--thinking off` and `--thinking=off` at the root CLI boundary.
- Keep provider effort catalogs unchanged; `off` remains an agent-local thinking level.
- Reuse one root-level value list for parsing, help, and shell completion.
- Add startup precedence and fail-closed parser coverage.

## Why

GJC already supports `off` in settings and interactive reasoning controls, but the root CLI rejects it. That prevents callers from explicitly overriding a configured non-off default at startup and forces local launch wrappers to omit `--thinking` instead.

No exact issue or duplicate PR was found. Related merged work: #3200 and #3204 established the fail-closed root parser contract; #4907 normalized model thinking capabilities. This change extends that contract without adding `off` to provider `Effort` values.

## Testing

- `bun check` (exit 0 on the complete second run)
- `bun test packages/coding-agent/test/cli-args-mpreset.test.ts packages/coding-agent/test/completion-cli.test.ts` (63 passed, 0 failed, 183 assertions)
- `bun --cwd=packages/coding-agent run check:types`
- `bun run dev --thinking off --thinking` (exit 2 on the deliberate second bare flag; diagnostic advertises `off`)
- `bun scripts/verify-gjc-state-writers.ts --fail --root .`
- `git diff --check upstream/dev...HEAD`

The first complete `bun check` run hit an unrelated 5-second timeout in `sdk-host-wiring.test.ts`; the failing test passed in isolation, and the complete second run passed.

## Risk classification

- [ ] `low-risk` - ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk` - fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [x] `high-risk` - large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:a8b42b2ef4993bb1784b159345696743494b6c4776471f5a8c7a5960e50b6a60 reviewer:human reviewer-id:Yeachan-Heo evidence:focused-232-tests-package-check-build-and-exact-head-review
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken

