### PR TITLE
feat(ai): bundle Codex GPT-6-Astra in the model catalog

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Bundled `openai-codex/gpt-6-astra` (GPT-6-Astra) from `/codex/models` discovery so ChatGPT accounts with Astra access can select it from the static `/model` fallback without a live discovery pass. The entry carries the discovered 272K prompt budget, 128K output cap, text+image input, websocket preference, and low–max reasoning efforts; cost stays zero because no first-party pricing is published. The OpenAI model-id parser now recognizes the `astra` variant, so `gpt-6-astra` receives the post-5.6 effort ladder instead of falling through as an unknown model.
+- Bundled `openai-codex/gpt-6-astra` (GPT-6 Astra) from `/codex/models` discovery so ChatGPT accounts with Astra access can select it from the static `/model` fallback without a live discovery pass. The entry carries the discovered 272K Codex prompt budget, 128K output cap, text+image input, websocket preference, low–max reasoning efforts, freeform `apply_patch` support, and first-party Standard API pricing with the published long-context multiplier. The OpenAI model-id parser now recognizes the `astra` variant, so generated and dynamically discovered entries receive the same policy.
 
 ### Fixed
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Bundled `openai-codex/gpt-6-astra` (GPT-6-Astra) from `/codex/models` discovery so ChatGPT accounts with Astra access can select it from the static `/model` fallback without a live discovery pass. The entry carries the discovered 272K prompt budget, 128K output cap, text+image input, websocket preference, and low–max reasoning efforts; cost stays zero because no first-party pricing is published. The OpenAI model-id parser now recognizes the `astra` variant, so `gpt-6-astra` receives the post-5.6 effort ladder instead of falling through as an unknown model.
+
 ### Fixed
 
 - Bedrock prompt caching is now gated on the Claude generation parsed from the model id instead of version-literal fragments (`-4-`/`-4.`, `claude-haiku`, and two 3.x literals). A future generation's Bedrock id (`us.anthropic.claude-opus-5-…`, or a new model kind) matched none of the literals, so cache points were silently omitted and every request re-paid full input pricing. Behavior for the documented support set — 3.5 Haiku, 3.7 Sonnet, and 4.x naming including `us.`/`eu.`/`au.`/`jp.`/`global.` inference profiles — is unchanged, per AWS's prompt-caching support matrix. A bundled-catalog tripwire now fails when a regenerated catalog introduces a Claude id shape the parser cannot read, so shape drift is loud instead of silently disabling caching.

--- a/packages/ai/src/model-pricing.ts
+++ b/packages/ai/src/model-pricing.ts
@@ -15,8 +15,17 @@ const GPT_5_6_SOL_PRICING: TieredPricing = {
 	},
 };
 
+const GPT_6_ASTRA_PRICING: TieredPricing = {
+	cost: { input: 10, output: 50, cacheRead: 1, cacheWrite: 12.5 },
+	longContextPricing: {
+		threshold: LONG_CONTEXT_THRESHOLD,
+		cost: { input: 20, output: 75, cacheRead: 2, cacheWrite: 25 },
+	},
+};
+
 // OpenAI Standard pricing: https://developers.openai.com/api/docs/pricing
 const OPENAI_GPT_5_6_PRICING: ReadonlyMap<string, TieredPricing> = new Map([
+	["gpt-6-astra", GPT_6_ASTRA_PRICING],
 	["gpt-5.6", GPT_5_6_SOL_PRICING],
 	["gpt-5.6-sol", GPT_5_6_SOL_PRICING],
 	[

--- a/packages/ai/src/model-thinking.ts
+++ b/packages/ai/src/model-thinking.ts
@@ -666,7 +666,7 @@ function inferGeneratedApplyPatchToolType(
 	model: ApiModel<Api>,
 	parsedModel: ParsedModel,
 ): ApiModel<Api>["applyPatchToolType"] {
-	if (parsedModel.family !== "openai" || parsedModel.version.major !== 5) {
+	if (parsedModel.family !== "openai" || (parsedModel.version.major !== 5 && parsedModel.variant !== "astra")) {
 		return undefined;
 	}
 	if (model.provider === "openai" && model.api === "openai-responses") {
@@ -711,6 +711,9 @@ function applyGpt56ContextWindow(model: ApiModel<Api>): boolean {
 }
 
 function applyOpenAICatalogPolicy(model: ApiModel<Api>, parsedModel: OpenAIModel): void {
+	if (parsedModel.variant === "astra") {
+		model.name = "GPT-6 Astra";
+	}
 	if (applyGpt55ContextWindow(model, parsedModel)) {
 		return;
 	}

--- a/packages/ai/src/model-thinking.ts
+++ b/packages/ai/src/model-thinking.ts
@@ -86,6 +86,7 @@ type SemVer = {
 type GeminiKind = "pro" | "flash";
 type AnthropicKind = "opus" | "sonnet" | "fable";
 type OpenAIVariant =
+	| "astra"
 	| "base"
 	| "codex"
 	| "codex-max"
@@ -1014,7 +1015,7 @@ function parseAnthropicModel(modelId: string): AnthropicModel | null {
 
 function parseOpenAIModel(modelId: string): OpenAIModel | null {
 	const match =
-		/gpt-(\d+(?:\.\d+){0,2})(?:-(codex-spark|codex-mini|codex-max|codex|luna|mini|max|nano|sol|terra))?$/.exec(
+		/gpt-(\d+(?:\.\d+){0,2})(?:-(astra|codex-spark|codex-mini|codex-max|codex|luna|mini|max|nano|sol|terra))?$/.exec(
 			modelId,
 		);
 	if (!match) {

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -65463,7 +65463,7 @@
 		},
 		"gpt-6-astra": {
 			"id": "gpt-6-astra",
-			"name": "GPT-6-Astra",
+			"name": "GPT-6 Astra",
 			"api": "openai-codex-responses",
 			"provider": "openai-codex",
 			"baseUrl": "https://chatgpt.com/backend-api",
@@ -65473,10 +65473,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
@@ -65486,7 +65486,17 @@
 				"mode": "effort",
 				"minLevel": "low",
 				"maxLevel": "max"
-			}
+			},
+			"longContextPricing": {
+				"threshold": 272000,
+				"cost": {
+					"input": 20,
+					"output": 75,
+					"cacheRead": 2,
+					"cacheWrite": 25
+				}
+			},
+			"applyPatchToolType": "freeform"
 		},
 		"gpt-daybreak-blue-latest": {
 			"id": "gpt-daybreak-blue-latest",

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -65461,6 +65461,33 @@
 			},
 			"applyPatchToolType": "freeform"
 		},
+		"gpt-6-astra": {
+			"id": "gpt-6-astra",
+			"name": "GPT-6-Astra",
+			"api": "openai-codex-responses",
+			"provider": "openai-codex",
+			"baseUrl": "https://chatgpt.com/backend-api",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 272000,
+			"maxTokens": 128000,
+			"preferWebsockets": true,
+			"priority": 1,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "low",
+				"maxLevel": "max"
+			}
+		},
 		"gpt-daybreak-blue-latest": {
 			"id": "gpt-daybreak-blue-latest",
 			"name": "Daybreak Blue",

--- a/packages/ai/test/model-thinking.test.ts
+++ b/packages/ai/test/model-thinking.test.ts
@@ -761,6 +761,16 @@ describe("generated model policies", () => {
 		}
 	});
 
+	it("parses the GPT-6 Astra variant as a post-5.6 OpenAI model", () => {
+		const model = createModel({ id: "gpt-6-astra", api: "openai-codex-responses", provider: "openai-codex" });
+
+		expect(model.thinking).toEqual({ mode: "effort", minLevel: Effort.Low, maxLevel: Effort.Max });
+		expect(requireSupportedEffort(model, Effort.Max)).toBe(Effort.Max);
+		expect(() => requireSupportedEffort(model, Effort.Minimal)).toThrow(
+			/Supported efforts: low, medium, high, xhigh, max/,
+		);
+	});
+
 	it("forces only Codex product GPT-5.6 tiers to the 372K prompt budget", () => {
 		const models: Model<Api>[] = [
 			{

--- a/packages/ai/test/model-thinking.test.ts
+++ b/packages/ai/test/model-thinking.test.ts
@@ -762,9 +762,14 @@ describe("generated model policies", () => {
 	});
 
 	it("parses the GPT-6 Astra variant as a post-5.6 OpenAI model", () => {
-		const model = createModel({ id: "gpt-6-astra", api: "openai-codex-responses", provider: "openai-codex" });
+		const models: Model<Api>[] = [
+			createModel({ id: "gpt-6-astra", api: "openai-codex-responses", provider: "openai-codex" }),
+		];
+		applyGeneratedModelPolicies(models);
+		const model = models[0]!;
 
 		expect(model.thinking).toEqual({ mode: "effort", minLevel: Effort.Low, maxLevel: Effort.Max });
+		expect(model.applyPatchToolType).toBe("freeform");
 		expect(requireSupportedEffort(model, Effort.Max)).toBe(Effort.Max);
 		expect(() => requireSupportedEffort(model, Effort.Minimal)).toThrow(
 			/Supported efforts: low, medium, high, xhigh, max/,

--- a/packages/ai/test/openai-codex-default.test.ts
+++ b/packages/ai/test/openai-codex-default.test.ts
@@ -30,4 +30,20 @@ describe("OpenAI Codex defaults", () => {
 			expect(model.longContextPricing?.threshold).toBe(272_000);
 		}
 	});
+
+	it("bundles GPT-6-Astra with the discovered Codex metadata", () => {
+		const model = getBundledModel("openai-codex", "gpt-6-astra");
+
+		expect(model.name).toBe("GPT-6-Astra");
+		expect(model.api).toBe("openai-codex-responses");
+		expect(model.reasoning).toBe(true);
+		expect(model.input).toEqual(["text", "image"]);
+		expect(model.preferWebsockets).toBe(true);
+		// `/codex/models` reports a 272K prompt budget for Astra; it is not in the
+		// forced 372K GPT-5.6 tier and no first-party pricing has been published.
+		expect(model.contextWindow).toBe(272_000);
+		expect(model.maxTokens).toBe(128_000);
+		expect(model.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+		expect(model.thinking).toEqual({ mode: "effort", minLevel: Effort.Low, maxLevel: Effort.Max });
+	});
 });

--- a/packages/ai/test/openai-codex-default.test.ts
+++ b/packages/ai/test/openai-codex-default.test.ts
@@ -31,19 +31,24 @@ describe("OpenAI Codex defaults", () => {
 		}
 	});
 
-	it("bundles GPT-6-Astra with the discovered Codex metadata", () => {
+	it("bundles GPT-6 Astra with discovered Codex limits and first-party pricing", () => {
 		const model = getBundledModel("openai-codex", "gpt-6-astra");
 
-		expect(model.name).toBe("GPT-6-Astra");
+		expect(model.name).toBe("GPT-6 Astra");
 		expect(model.api).toBe("openai-codex-responses");
 		expect(model.reasoning).toBe(true);
 		expect(model.input).toEqual(["text", "image"]);
 		expect(model.preferWebsockets).toBe(true);
-		// `/codex/models` reports a 272K prompt budget for Astra; it is not in the
-		// forced 372K GPT-5.6 tier and no first-party pricing has been published.
+		expect(model.applyPatchToolType).toBe("freeform");
+		// `/codex/models` reports the Codex product's usable prompt budget; the
+		// direct API's larger published window must not override discovery here.
 		expect(model.contextWindow).toBe(272_000);
 		expect(model.maxTokens).toBe(128_000);
-		expect(model.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+		expect(model.cost).toEqual({ input: 10, output: 50, cacheRead: 1, cacheWrite: 12.5 });
+		expect(model.longContextPricing).toEqual({
+			threshold: 272_000,
+			cost: { input: 20, output: 75, cacheRead: 2, cacheWrite: 25 },
+		});
 		expect(model.thinking).toEqual({ mode: "effort", minLevel: Effort.Low, maxLevel: Effort.Max });
 	});
 });

--- a/packages/coding-agent/src/config/autorouting-tier-map.ts
+++ b/packages/coding-agent/src/config/autorouting-tier-map.ts
@@ -359,6 +359,7 @@ export const TIER_MAP_SKIP_LIST = {
 	"nvidia/poolside/laguna-xs-2.1": { rationale: "post-rebase catalog addition from dev; not yet curated" },
 	"nvidia/thinkingmachines/inkling": { rationale: "post-rebase catalog addition from dev; not yet curated" },
 	"nvidia/upstage/solar-10.7b-instruct": { rationale: "post-rebase catalog addition from dev; not yet curated" },
+	"openai-codex/gpt-6-astra": { rationale: "new frontier model; awaiting measured autorouting calibration" },
 	"openai-codex/gpt-daybreak-blue-latest": { rationale: "post-rebase catalog addition from dev; not yet curated" },
 	"opencode-go/deepseek-v4-flash-vision-exp": {
 		rationale: "post-rebase catalog addition from dev; not yet curated",


### PR DESCRIPTION
## Summary

Bundle `openai-codex/gpt-6-astra` in the offline model catalog while preserving the Codex discovery contract and applying generated first-party policy.

- Preserve the authenticated `/codex/models` prompt budget of 272K, 128K output cap, text+image input, priority, and websocket preference.
- Recognize the `astra` model-id variant and expose the supported low/medium/high/xhigh/max effort ladder.
- Apply official Standard API pricing with the published long-context threshold and mark the Responses `apply_patch` tool as freeform.
- Cover the new selector in the autorouting aggregate and record the package change under AI Unreleased.
- Retain yazzang-homelab's original catalog commit and authorship; owner fix-forward commit: `b4e176f4faa11f17b03914a695148adf71e0ed71`.

## Adversarial comparison

Retained path: PR #5290 on `dev`, exact head `b4e176f4faa11f17b03914a695148adf71e0ed71`.

PR #5294 exact head `9de9336bbaada0f9fcb522589f213afd3ff3c150` supplied useful pricing/freeform/autorouting clues, but targets `main@9d2176a04291e9126b053786b84676881941174c`, omitted the AI changelog and offline bundled-entry test, and broadened freeform policy to every future GPT major. #5290 keeps the current-dev contribution and scopes the fix-forward to audited Astra behavior.

## Evidence

- Contributor capture: authenticated `GET /codex/models` reported `slug=gpt-6-astra`, `context_window=272000`, text+image, low/medium/high/xhigh/max, and `prefer_websockets=true`; authenticated response smoke returned HTTP 200 with the same wire model id.
- Official direct API docs publish a 1,050K total window, 922K maximum input, 128K output, low..max effort, `apply_patch`, and Standard pricing of 10/50 with 1 cached-read and 12.5 cache-write; requests above 272K use 20/75, 2, and 25. The Codex catalog intentionally keeps the smaller discovered 272K usable prompt budget.
- Deterministic AI tarball: two independent `bun pm pack` outputs matched byte-for-byte at SHA-256 `d5a3de1002087a51426ccaee1e81cbc750f2b4faa556db646e42991fd80c235f`; extracted `package/src/models.json` contained the exact Astra contract.

## Verification

- 52/52 focused policy/catalog/cost tests passed.
- 23/23 freeform tool tests passed.
- `@gajae-code/ai` check passed; `@gajae-code/coding-agent` check passed.
- Autorouting aggregate passed: 4,314 in-scope keys, no uncovered Astra selector.
- Release evidence tests passed: 21/21.
- Native package prerequisite built; coding-agent package build completed.
- Full AI package one-process run was not used as acceptance evidence: it exposed existing cross-file global `fetch` spy leakage and one pre-existing immutable evidence mismatch, while all affected focused tests and CI-planned shards pass independently.

## Risk classification

- [ ] `low-risk`
- [x] `regression-risk`
- [ ] `high-risk`

gajae.pr-review-verdict.v1 merge-blocked sha256:c7f613fa5136d3c2fb26c6e778b2a0e3cdb3b9ae15a322ef7497d5c37fd32d9e reviewer:human reviewer-id:Yeachan-Heo evidence:superseded by merged PR #5294 exact head 5098a559b2a1461d265233f98babf9a505d6441d