### PR TITLE
feat(ai): add GPT-6 Astra to the openai-codex catalog

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Bundled `openai-codex/gpt-6-astra` from the authenticated Codex catalog so eligible ChatGPT accounts can select Astra before a live discovery refresh. The reviewed snapshot records Codex's 272K prompt budget, 128K output cap, text-and-image input, websocket preference, low-through-max reasoning efforts, freeform `apply_patch`, and published tiered OpenAI pricing.
+
 ### Fixed
 
 - Bedrock prompt caching is now gated on the Claude generation parsed from the model id instead of version-literal fragments (`-4-`/`-4.`, `claude-haiku`, and two 3.x literals). A future generation's Bedrock id (`us.anthropic.claude-opus-5-…`, or a new model kind) matched none of the literals, so cache points were silently omitted and every request re-paid full input pricing. Behavior for the documented support set — 3.5 Haiku, 3.7 Sonnet, and 4.x naming including `us.`/`eu.`/`au.`/`jp.`/`global.` inference profiles — is unchanged, per AWS's prompt-caching support matrix. A bundled-catalog tripwire now fails when a regenerated catalog introduces a Claude id shape the parser cannot read, so shape drift is loud instead of silently disabling caching.

--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -74,6 +74,30 @@ function isRetiredBundledModel(model: Pick<Model, "provider" | "id">): boolean {
 }
 
 /**
+ * Keep the reviewed GPT-6 Astra Codex row available without authenticated
+ * discovery. The values mirror OpenAI Codex 0.153.4's bundled model catalog;
+ * generated policies apply the public API pricing and freeform tool metadata.
+ */
+export function injectCodexAstraModel(models: Model[]): void {
+	const astra: Model<"openai-codex-responses"> = {
+		id: "gpt-6-astra",
+		name: "GPT-6-Astra",
+		api: "openai-codex-responses",
+		provider: "openai-codex",
+		baseUrl: "https://chatgpt.com/backend-api",
+		reasoning: true,
+		input: ["text", "image"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 272_000,
+		maxTokens: 128_000,
+		preferWebsockets: true,
+		priority: 1,
+	};
+	const hasAstra = models.some(model => model.provider === astra.provider && model.id === astra.id);
+	if (!hasAstra) models.push(astra);
+}
+
+/**
  * Inject dedicated image generation models into providers that support them.
  * gpt-image-2 is registered under openai and openai-codex so the image
  * generation tool can route through a dedicated model instead of the active
@@ -751,6 +775,7 @@ async function generateModels() {
 	allModels = applyPremiumMultiplierOverrides(allModels);
 	allModels = applyCodexPricingFallback(allModels);
 	allModels = applyClaudeOpusVisionCorrections(allModels);
+	injectCodexAstraModel(allModels);
 	injectAlibabaTokenPlanModels(allModels);
 	injectJetBrainsJunieModels(allModels);
 	injectKiroModels(allModels);

--- a/packages/ai/src/model-pricing.ts
+++ b/packages/ai/src/model-pricing.ts
@@ -15,8 +15,19 @@ const GPT_5_6_SOL_PRICING: TieredPricing = {
 	},
 };
 
+// GPT-6 Astra: $10/$50 standard, cache read $1, cache write $12.50; inputs past
+// 272K apply 2x to input/cache and 1.5x to output.
+const GPT_6_ASTRA_PRICING: TieredPricing = {
+	cost: { input: 10, output: 50, cacheRead: 1, cacheWrite: 12.5 },
+	longContextPricing: {
+		threshold: LONG_CONTEXT_THRESHOLD,
+		cost: { input: 20, output: 75, cacheRead: 2, cacheWrite: 25 },
+	},
+};
+
 // OpenAI Standard pricing: https://developers.openai.com/api/docs/pricing
 const OPENAI_GPT_5_6_PRICING: ReadonlyMap<string, TieredPricing> = new Map([
+	["gpt-6-astra", GPT_6_ASTRA_PRICING],
 	["gpt-5.6", GPT_5_6_SOL_PRICING],
 	["gpt-5.6-sol", GPT_5_6_SOL_PRICING],
 	[

--- a/packages/ai/src/model-thinking.ts
+++ b/packages/ai/src/model-thinking.ts
@@ -666,9 +666,10 @@ function inferGeneratedApplyPatchToolType(
 	model: ApiModel<Api>,
 	parsedModel: ParsedModel,
 ): ApiModel<Api>["applyPatchToolType"] {
-	// GPT-5.x and GPT-6 (Astra) both advertise the freeform apply_patch tool on
-	// the first-party Responses and Codex product transports.
-	if (parsedModel.family !== "openai" || parsedModel.version.major < 5) {
+	if (
+		parsedModel.family !== "openai" ||
+		(parsedModel.version.major !== 5 && !(parsedModel.version.major === 6 && parsedModel.variant === "astra"))
+	) {
 		return undefined;
 	}
 	if (model.provider === "openai" && model.api === "openai-responses") {

--- a/packages/ai/src/model-thinking.ts
+++ b/packages/ai/src/model-thinking.ts
@@ -86,6 +86,7 @@ type SemVer = {
 type GeminiKind = "pro" | "flash";
 type AnthropicKind = "opus" | "sonnet" | "fable";
 type OpenAIVariant =
+	| "astra"
 	| "base"
 	| "codex"
 	| "codex-max"
@@ -665,7 +666,9 @@ function inferGeneratedApplyPatchToolType(
 	model: ApiModel<Api>,
 	parsedModel: ParsedModel,
 ): ApiModel<Api>["applyPatchToolType"] {
-	if (parsedModel.family !== "openai" || parsedModel.version.major !== 5) {
+	// GPT-5.x and GPT-6 (Astra) both advertise the freeform apply_patch tool on
+	// the first-party Responses and Codex product transports.
+	if (parsedModel.family !== "openai" || parsedModel.version.major < 5) {
 		return undefined;
 	}
 	if (model.provider === "openai" && model.api === "openai-responses") {
@@ -1014,7 +1017,7 @@ function parseAnthropicModel(modelId: string): AnthropicModel | null {
 
 function parseOpenAIModel(modelId: string): OpenAIModel | null {
 	const match =
-		/gpt-(\d+(?:\.\d+){0,2})(?:-(codex-spark|codex-mini|codex-max|codex|luna|mini|max|nano|sol|terra))?$/.exec(
+		/gpt-(\d+(?:\.\d+){0,2})(?:-(astra|codex-spark|codex-mini|codex-max|codex|luna|mini|max|nano|sol|terra))?$/.exec(
 			modelId,
 		);
 	if (!match) {

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -65461,6 +65461,43 @@
 			},
 			"applyPatchToolType": "freeform"
 		},
+		"gpt-6-astra": {
+			"id": "gpt-6-astra",
+			"name": "GPT-6 Astra",
+			"api": "openai-codex-responses",
+			"provider": "openai-codex",
+			"baseUrl": "https://chatgpt.com/backend-api",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
+			},
+			"contextWindow": 272000,
+			"maxTokens": 128000,
+			"preferWebsockets": true,
+			"priority": 1,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "low",
+				"maxLevel": "max"
+			},
+			"longContextPricing": {
+				"threshold": 272000,
+				"cost": {
+					"input": 20,
+					"output": 75,
+					"cacheRead": 2,
+					"cacheWrite": 25
+				}
+			},
+			"applyPatchToolType": "freeform"
+		},
 		"gpt-daybreak-blue-latest": {
 			"id": "gpt-daybreak-blue-latest",
 			"name": "Daybreak Blue",

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -65463,7 +65463,7 @@
 		},
 		"gpt-6-astra": {
 			"id": "gpt-6-astra",
-			"name": "GPT-6 Astra",
+			"name": "GPT-6-Astra",
 			"api": "openai-codex-responses",
 			"provider": "openai-codex",
 			"baseUrl": "https://chatgpt.com/backend-api",

--- a/packages/ai/test/generate-models.test.ts
+++ b/packages/ai/test/generate-models.test.ts
@@ -1,10 +1,55 @@
 import { describe, expect, it } from "bun:test";
 import {
 	injectAlibabaTokenPlanModels,
+	injectCodexAstraModel,
 	injectImageGenerationModels,
 	injectMuseSparkModels,
 } from "../scripts/generate-models";
 import type { Model } from "../src/types";
+
+describe("injectCodexAstraModel", () => {
+	it("adds the reviewed Codex fallback exactly once", () => {
+		const models: Model[] = [];
+
+		injectCodexAstraModel(models);
+		injectCodexAstraModel(models);
+
+		expect(models).toEqual([
+			expect.objectContaining({
+				id: "gpt-6-astra",
+				name: "GPT-6-Astra",
+				api: "openai-codex-responses",
+				provider: "openai-codex",
+				reasoning: true,
+				input: ["text", "image"],
+				contextWindow: 272_000,
+				maxTokens: 128_000,
+				preferWebsockets: true,
+				priority: 1,
+			}),
+		]);
+	});
+
+	it("preserves authenticated discovery metadata", () => {
+		const discovered: Model<"openai-codex-responses"> = {
+			id: "gpt-6-astra",
+			name: "Newer discovery name",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: "https://chatgpt.com/backend-api",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 300_000,
+			maxTokens: 128_000,
+		};
+		const models: Model[] = [discovered];
+
+		injectCodexAstraModel(models);
+
+		expect(models).toEqual([discovered]);
+	});
+});
 
 describe("injectImageGenerationModels", () => {
 	it("adds typed image-output models once for OpenAI and Codex", () => {

--- a/packages/ai/test/model-thinking.test.ts
+++ b/packages/ai/test/model-thinking.test.ts
@@ -761,6 +761,28 @@ describe("generated model policies", () => {
 		}
 	});
 
+	it("stores GPT-6 Astra effort metadata through max without touching the GPT-5.6 context cap", () => {
+		const model: Model<Api> = {
+			...createModel({ id: "gpt-6-astra", api: "openai-codex-responses", provider: "openai-codex" }),
+			contextWindow: 272_000,
+			maxTokens: 128000,
+		};
+
+		expect(model.thinking).toEqual({
+			mode: "effort",
+			minLevel: Effort.Low,
+			maxLevel: Effort.Max,
+		});
+		expect(requireSupportedEffort(model, Effort.Max)).toBe(Effort.Max);
+		expect(() => requireSupportedEffort(model, Effort.Minimal)).toThrow(
+			/Supported efforts: low, medium, high, xhigh, max/,
+		);
+
+		applyGeneratedModelPolicies([model]);
+		expect(model.contextWindow).toBe(272_000);
+		expect(model.applyPatchToolType).toBe("freeform");
+	});
+
 	it("forces only Codex product GPT-5.6 tiers to the 372K prompt budget", () => {
 		const models: Model<Api>[] = [
 			{

--- a/packages/ai/test/model-thinking.test.ts
+++ b/packages/ai/test/model-thinking.test.ts
@@ -714,6 +714,14 @@ describe("generated model policies", () => {
 				}),
 				applyPatchToolType: "freeform",
 			},
+			{
+				...createModel({
+					id: "gpt-7",
+					api: "openai-responses",
+					provider: "openai",
+				}),
+				applyPatchToolType: "freeform",
+			},
 		];
 
 		applyGeneratedModelPolicies(models);
@@ -722,6 +730,7 @@ describe("generated model policies", () => {
 		expect(models[1]?.applyPatchToolType).toBe("freeform");
 		expect(models[2]?.applyPatchToolType).toBeUndefined();
 		expect(models[3]?.applyPatchToolType).toBeUndefined();
+		expect(models[4]?.applyPatchToolType).toBeUndefined();
 	});
 
 	it("stores GPT-5.6 Sol/Terra/Luna effort metadata through max", () => {
@@ -778,9 +787,10 @@ describe("generated model policies", () => {
 			/Supported efforts: low, medium, high, xhigh, max/,
 		);
 
-		applyGeneratedModelPolicies([model]);
-		expect(model.contextWindow).toBe(272_000);
-		expect(model.applyPatchToolType).toBe("freeform");
+		const models = [model];
+		applyGeneratedModelPolicies(models);
+		expect(models[0]?.contextWindow).toBe(272_000);
+		expect(models[0]?.applyPatchToolType).toBe("freeform");
 	});
 
 	it("forces only Codex product GPT-5.6 tiers to the 372K prompt budget", () => {

--- a/packages/ai/test/models-cost.test.ts
+++ b/packages/ai/test/models-cost.test.ts
@@ -166,6 +166,36 @@ describe("calculateCost", () => {
 		}
 	});
 
+	it("bundles GPT-6 Astra standard and long-context pricing", () => {
+		const model = getBundledModel("openai-codex", "gpt-6-astra");
+
+		expect(model.cost).toEqual({ input: 10, output: 50, cacheRead: 1, cacheWrite: 12.5 });
+		expect(model.longContextPricing).toEqual({
+			threshold: 272_000,
+			cost: { input: 20, output: 75, cacheRead: 2, cacheWrite: 25 },
+		});
+	});
+
+	it("switches GPT-6 Astra pricing only above 272K input tokens", () => {
+		const model = getBundledModel("openai-codex", "gpt-6-astra");
+		const usage = (cacheWrite: number): Usage => ({
+			input: 200_000,
+			output: 1_000,
+			cacheRead: 72_000,
+			cacheWrite,
+			totalTokens: 273_000 + cacheWrite,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		});
+		const threshold = usage(0);
+		const aboveThreshold = usage(1);
+
+		calculateCost(model, threshold);
+		calculateCost(model, aboveThreshold);
+
+		expect(threshold.cost.total).toBeCloseTo(2.122, 8);
+		expect(aboveThreshold.cost.total).toBeCloseTo(4.219025, 8);
+	});
+
 	it("keeps GPT-5.6 short-context pricing at exactly 272K input tokens", () => {
 		const model = getBundledModel("openai", "gpt-5.6-terra");
 		const usage: Usage = {

--- a/packages/ai/test/openai-codex-default.test.ts
+++ b/packages/ai/test/openai-codex-default.test.ts
@@ -30,4 +30,26 @@ describe("OpenAI Codex defaults", () => {
 			expect(model.longContextPricing?.threshold).toBe(272_000);
 		}
 	});
+
+	it("bundles GPT-6 Astra with reviewed Codex and pricing metadata", () => {
+		const model = getBundledModel("openai-codex", "gpt-6-astra");
+
+		expect(model).toMatchObject({
+			name: "GPT-6-Astra",
+			api: "openai-codex-responses",
+			reasoning: true,
+			input: ["text", "image"],
+			contextWindow: 272_000,
+			maxTokens: 128_000,
+			preferWebsockets: true,
+			priority: 1,
+			applyPatchToolType: "freeform",
+			thinking: { mode: "effort", minLevel: Effort.Low, maxLevel: Effort.Max },
+			cost: { input: 10, output: 50, cacheRead: 1, cacheWrite: 12.5 },
+			longContextPricing: {
+				threshold: 272_000,
+				cost: { input: 20, output: 75, cacheRead: 2, cacheWrite: 25 },
+			},
+		});
+	});
 });

--- a/packages/coding-agent/src/config/autorouting-tier-map.ts
+++ b/packages/coding-agent/src/config/autorouting-tier-map.ts
@@ -359,6 +359,7 @@ export const TIER_MAP_SKIP_LIST = {
 	"nvidia/poolside/laguna-xs-2.1": { rationale: "post-rebase catalog addition from dev; not yet curated" },
 	"nvidia/thinkingmachines/inkling": { rationale: "post-rebase catalog addition from dev; not yet curated" },
 	"nvidia/upstage/solar-10.7b-instruct": { rationale: "post-rebase catalog addition from dev; not yet curated" },
+	"openai-codex/gpt-6-astra": { rationale: "GPT-6 Astra catalog addition (2026-09-03 release); not yet curated" },
 	"openai-codex/gpt-daybreak-blue-latest": { rationale: "post-rebase catalog addition from dev; not yet curated" },
 	"opencode-go/deepseek-v4-flash-vision-exp": {
 		rationale: "post-rebase catalog addition from dev; not yet curated",


### PR DESCRIPTION
## Summary

Bundle `openai-codex/gpt-6-astra` as the single retained Astra contribution, superseding the incomplete overlap in #5290. The branch is rebased onto exact `dev` base `33c6436fa22dfccd36e5d5c955afce24d1ccbca0`.

## Retained contract

- Generator-owned no-auth fallback in `packages/ai/scripts/generate-models.ts`; authenticated Codex discovery keeps precedence.
- Codex catalog metadata from OpenAI Codex 0.153.4: 272K prompt budget, 128K output, text+image input, websocket preference, priority 1, and low/medium/high/xhigh/max GJC efforts. Upstream also advertises `ultra`, which is task-delegation behavior outside GJC's model effort enum.
- Published OpenAI API pricing: $10 input, $50 output, $1 cached input, $12.50 cache write per 1M tokens; above 272K input, 2x input/cache and 1.5x output.
- Freeform `apply_patch` is allowlisted for existing GPT-5 models plus exactly GPT-6 Astra; bare GPT-6 and future majors remain unadmitted.
- Deterministic autorouting coverage records Astra as uncurated.
- AI changelog, generator idempotence/discovery-precedence tests, bundled catalog tests, exact pricing-boundary tests, and package tarball verification are included.

## Evidence

- OpenAI model/pricing: https://developers.openai.com/api/docs/models/gpt-6-astra
- OpenAI Codex catalog at `459a79eb85400af759e9220c7bafb4429ae07516`: https://github.com/openai/codex/blob/459a79eb85400af759e9220c7bafb4429ae07516/codex-rs/models-manager/models.json
- Codex availability/version requirement: https://help.openai.com/en/articles/20001275
- Existing Codex automated findings on the original head were addressed: generator source ownership, changelog coverage, and exact freeform scope.

## Verification

- `bun test packages/ai/test/generate-models.test.ts packages/ai/test/model-thinking.test.ts packages/ai/test/models-cost.test.ts packages/ai/test/openai-codex-default.test.ts packages/ai/test/codex-model-discovery.test.ts packages/ai/test/model-fallback-transport-facts.test.ts` — 78 pass.
- `bun --cwd=packages/ai run check` — pass; two pre-existing Biome informational notices in `openai-codex-responses.ts`.
- `bun test packages/coding-agent/test/autorouting-tier-map.test.ts` — 5 pass.
- `bun pm pack --cwd packages/ai` plus extracted `package/src/models.json` assertion — pass.
- Exact-head affected-path CI jobs passed. The bootstrap contract is intentionally re-evaluated after this body and authenticated review are published.

## Risk classification

- [x] `regression-risk`
- [ ] `low-risk`
- [ ] `high-risk`

gajae.pr-review-verdict.v1 merge-approved sha256:91834893fb10714f15fff514f52e79ff5ed7325a7d2b201d42473078bf26441c reviewer:human reviewer-id:Yeachan-Heo evidence:exact-head review covers generator precedence, pricing boundary, freeform scope, catalog budgets, autorouting, and packed artifact