### PR TITLE
fix(web-search): enforce Perplexity response contract

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 
+- Perplexity web search now clamps upstream search breadth to the API's 3–100 contract, retries one structurally empty completion, rejects malformed or ungrounded success payloads through the provider fallback path, and preserves valid grounded responses.
 - SDK-hosted workflow tools now retain the logical session id for ask, skill, deep-interview, and ultragoal state paths while job, monitor, bash, cron, task, and subagent ownership routes through a separate opaque async endpoint key. Explicit provider session identities no longer create encoded duplicate workflow trees or redirect endpoint-owned work to another live session.
 - Explicit root startup `--thinking off` and `--thinking=off` now override a configured higher startup default while leaving the provider `Effort` catalog unchanged.
 - Skills installed from marketplace plugins are now enumerated into sessions instead of only resolving by exact name. `loadSkills` asked the `native` provider alone, so every installed plugin skill was absent from `/` autocomplete and from the `skill` tool's `Available:` list while `gjc skill list` reported it and the discovery fallback still loaded it — 46 installed skills presented as 5. The already-registered marketplace provider is now loaded alongside `native`, keeping `<plugin>:<skill>` namespacing and per-item scope trust.

--- a/packages/coding-agent/src/web/search/providers/perplexity.ts
+++ b/packages/coding-agent/src/web/search/providers/perplexity.ts
@@ -9,16 +9,9 @@
 
 import { type AuthStorage, getEnvApiKey } from "@gajae-code/ai/core";
 import { $env, readSseJson } from "@gajae-code/utils";
-import type {
-	PerplexityMessageOutput,
-	PerplexityRequest,
-	PerplexityResponse,
-	SearchCitation,
-	SearchResponse,
-	SearchSource,
-} from "../../../web/search/types";
+import type { PerplexityRequest, SearchCitation, SearchResponse, SearchSource } from "../../../web/search/types";
 import { SearchProviderError } from "../../../web/search/types";
-import { dateToAgeSeconds } from "../utils";
+import { clampNumResults, dateToAgeSeconds } from "../utils";
 import type { SearchParams } from "./base";
 import { SearchProvider } from "./base";
 import { classifyProviderHttpError, withHardTimeout } from "./utils";
@@ -29,6 +22,8 @@ const PERPLEXITY_OAUTH_ASK_URL = "https://www.perplexity.ai/rest/sse/perplexity_
 const DEFAULT_MAX_TOKENS = 8192;
 const DEFAULT_TEMPERATURE = 0.2;
 const DEFAULT_NUM_SEARCH_RESULTS = 10;
+const MIN_NUM_SEARCH_RESULTS = 3;
+const MAX_NUM_SEARCH_RESULTS = 100;
 const OAUTH_EXPIRY_BUFFER_MS = 5 * 60 * 1000;
 const OAUTH_API_VERSION = "2.18";
 const OAUTH_USER_AGENT = "Perplexity/641 CFNetwork/1568 Darwin/25.2.0";
@@ -239,11 +234,7 @@ async function findPerplexityAuth(
 }
 
 /** Call Perplexity API-key endpoint. */
-async function callPerplexityApi(
-	apiKey: string,
-	request: PerplexityRequest,
-	signal?: AbortSignal,
-): Promise<PerplexityResponse> {
+async function callPerplexityApi(apiKey: string, request: PerplexityRequest, signal?: AbortSignal): Promise<unknown> {
 	const response = await fetch(PERPLEXITY_API_URL, {
 		method: "POST",
 		headers: {
@@ -265,7 +256,11 @@ async function callPerplexityApi(
 		);
 	}
 
-	return response.json() as Promise<PerplexityResponse>;
+	try {
+		return await response.json();
+	} catch {
+		throw new SearchProviderError("perplexity", "Perplexity API returned invalid JSON", 502);
+	}
 }
 
 function buildOAuthSources(event: PerplexityOAuthStreamEvent): SearchSource[] {
@@ -426,22 +421,79 @@ async function callPerplexityOAuth(
 	};
 }
 
-function messageContentToText(content: PerplexityMessageOutput["content"]): string {
-	if (!content) return "";
+type JsonObject = Record<string, unknown>;
+
+function malformedResponse(detail: string): never {
+	throw new SearchProviderError("perplexity", `Perplexity API returned malformed response body (${detail})`, 502);
+}
+
+function isJsonObject(value: unknown): value is JsonObject {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function optionalArray(value: unknown, detail: string): unknown[] {
+	if (value === undefined || value === null) return [];
+	if (!Array.isArray(value)) malformedResponse(detail);
+	return value;
+}
+
+function messageContentToText(content: unknown): string {
+	if (content === undefined || content === null) return "";
 	if (typeof content === "string") return content;
-	return content.map(chunk => (chunk.type === "text" ? chunk.text : "")).join("");
+	if (!Array.isArray(content)) malformedResponse("message content must be a string or array");
+
+	return content
+		.map(chunk => {
+			if (!isJsonObject(chunk) || typeof chunk.type !== "string") {
+				malformedResponse("message content chunks must be objects with a type");
+			}
+			if (chunk.type !== "text") return "";
+			if (typeof chunk.text !== "string") malformedResponse("text content chunks must contain text");
+			return chunk.text;
+		})
+		.join("");
 }
 
 /** Parse API response into unified SearchResponse */
-function parseResponse(response: PerplexityResponse): SearchResponse {
-	const messageContent = response.choices[0]?.message?.content ?? null;
+function parseResponse(value: unknown): SearchResponse {
+	if (!isJsonObject(value)) malformedResponse("expected a JSON object");
+
+	const choices = optionalArray(value.choices, "choices must be an array");
+	const firstChoice = choices[0];
+	if (firstChoice !== undefined && !isJsonObject(firstChoice)) malformedResponse("choices must contain objects");
+	const message = firstChoice?.message;
+	if (message !== undefined && !isJsonObject(message)) malformedResponse("choice message must be an object");
+	const messageContent = message?.content;
 	const answer = messageContentToText(messageContent);
 
 	const sources: SearchSource[] = [];
 	const citations: SearchCitation[] = [];
 
-	const citationUrls = response.citations ?? [];
-	const searchResults = response.search_results ?? [];
+	const citationUrls = optionalArray(value.citations, "citations must be an array").map(url => {
+		if (typeof url !== "string" || url.length === 0) malformedResponse("citations must contain non-empty URLs");
+		return url;
+	});
+	const searchResults = optionalArray(value.search_results, "search_results must be an array").map(result => {
+		if (!isJsonObject(result)) malformedResponse("search_results must contain objects");
+		if (typeof result.url !== "string" || result.url.length === 0) {
+			malformedResponse("search_results entries must contain a non-empty URL");
+		}
+		if (result.title !== undefined && typeof result.title !== "string") {
+			malformedResponse("search_results titles must be strings");
+		}
+		if (result.snippet !== undefined && typeof result.snippet !== "string") {
+			malformedResponse("search_results snippets must be strings");
+		}
+		if (result.date !== undefined && result.date !== null && typeof result.date !== "string") {
+			malformedResponse("search_results dates must be strings");
+		}
+		return {
+			title: result.title ?? result.url,
+			url: result.url,
+			snippet: result.snippet,
+			date: result.date,
+		};
+	});
 
 	if (citationUrls.length > 0) {
 		for (const url of citationUrls) {
@@ -475,16 +527,21 @@ function parseResponse(response: PerplexityResponse): SearchResponse {
 		answer: answer || undefined,
 		sources,
 		citations: citations.length > 0 ? citations : undefined,
-		usage: response.usage
+		usage: isJsonObject(value.usage)
 			? {
-					inputTokens: response.usage.prompt_tokens,
-					outputTokens: response.usage.completion_tokens,
-					totalTokens: response.usage.total_tokens,
+					inputTokens: typeof value.usage.prompt_tokens === "number" ? value.usage.prompt_tokens : undefined,
+					outputTokens:
+						typeof value.usage.completion_tokens === "number" ? value.usage.completion_tokens : undefined,
+					totalTokens: typeof value.usage.total_tokens === "number" ? value.usage.total_tokens : undefined,
 				}
 			: undefined,
-		model: response.model,
-		requestId: response.id,
+		model: typeof value.model === "string" ? value.model : undefined,
+		requestId: typeof value.id === "string" ? value.id : undefined,
 	};
+}
+
+function normalizeNumSearchResults(value: number | undefined): number {
+	return Math.max(MIN_NUM_SEARCH_RESULTS, clampNumResults(value, DEFAULT_NUM_SEARCH_RESULTS, MAX_NUM_SEARCH_RESULTS));
 }
 
 function applySourceLimit(result: SearchResponse, limit?: number): SearchResponse {
@@ -503,6 +560,9 @@ export async function searchPerplexity(params: PerplexitySearchParams): Promise<
 
 	if (auth.type === "oauth" || auth.type === "cookies") {
 		const oauthResult = await callPerplexityOAuth(auth, params);
+		if (!oauthResult.answer.trim()) {
+			throw new SearchProviderError("perplexity", "Perplexity web search returned no answer", 424);
+		}
 		return applySourceLimit(
 			{
 				provider: "perplexity",
@@ -529,7 +589,7 @@ export async function searchPerplexity(params: PerplexitySearchParams): Promise<
 		max_tokens: params.max_tokens ?? DEFAULT_MAX_TOKENS,
 		temperature: params.temperature ?? DEFAULT_TEMPERATURE,
 		search_mode: "web",
-		num_search_results: params.num_search_results ?? DEFAULT_NUM_SEARCH_RESULTS,
+		num_search_results: normalizeNumSearchResults(params.num_search_results),
 		web_search_options: {
 			search_type: "pro",
 			search_context_size: "medium",
@@ -543,8 +603,16 @@ export async function searchPerplexity(params: PerplexitySearchParams): Promise<
 		request.search_recency_filter = params.search_recency_filter;
 	}
 
-	const response = await callPerplexityApi(auth.token, request, params.signal);
-	const result = parseResponse(response);
+	let result: SearchResponse | undefined;
+	for (let attempt = 0; attempt < 2; attempt++) {
+		const response = await callPerplexityApi(auth.token, request, params.signal);
+		result = parseResponse(response);
+		if (result.answer?.trim()) break;
+	}
+
+	if (!result?.answer?.trim()) {
+		throw new SearchProviderError("perplexity", "Perplexity web search returned no answer", 424);
+	}
 	result.authMode = "api_key";
 	return applySourceLimit(result, params.num_results);
 }

--- a/packages/coding-agent/src/web/search/providers/perplexity.ts
+++ b/packages/coding-agent/src/web/search/providers/perplexity.ts
@@ -249,16 +249,13 @@ async function callPerplexityApi(apiKey: string, request: PerplexityRequest, sig
 		const errorText = await response.text();
 		const classified = classifyProviderHttpError("perplexity", response.status, errorText);
 		if (classified) throw classified;
-		throw new SearchProviderError(
-			"perplexity",
-			`Perplexity API error (${response.status}): ${errorText}`,
-			response.status,
-		);
+		throw new SearchProviderError("perplexity", `Perplexity API error (${response.status})`, response.status);
 	}
 
 	try {
 		return await response.json();
-	} catch {
+	} catch (error) {
+		if (error instanceof Error && error.name === "AbortError") throw error;
 		throw new SearchProviderError("perplexity", "Perplexity API returned invalid JSON", 502);
 	}
 }
@@ -372,11 +369,7 @@ async function callPerplexityOAuth(
 		const errorText = await response.text();
 		const classified = classifyProviderHttpError("perplexity", response.status, errorText);
 		if (classified) throw classified;
-		throw new SearchProviderError(
-			"perplexity",
-			`Perplexity OAuth API error (${response.status}): ${errorText}`,
-			response.status,
-		);
+		throw new SearchProviderError("perplexity", `Perplexity OAuth API error (${response.status})`, response.status);
 	}
 
 	if (!response.body) {

--- a/packages/coding-agent/test/web/search/execute-search-fallback.test.ts
+++ b/packages/coding-agent/test/web/search/execute-search-fallback.test.ts
@@ -120,6 +120,43 @@ describe("executeSearch fallback", () => {
 		expect(result.details.warning).toContain("Perplexity web search returned no answer");
 	});
 
+	it("preserves a caller abort while Perplexity consumes the response body", async () => {
+		process.env.PERPLEXITY_API_KEY = "test-key";
+		const controller = new AbortController();
+		const fallback = vi.fn(async () => ({
+			provider: "exa" as const,
+			sources: [{ title: "Exa", url: "https://exa.example" }],
+		}));
+		using _hook = hookFetch(async () => {
+			controller.abort();
+			return new Response(
+				new ReadableStream({
+					start(streamController) {
+						streamController.error(new DOMException("aborted", "AbortError"));
+					},
+				}),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			);
+		});
+		vi.spyOn(provider, "resolveProviderChain").mockResolvedValue([
+			new PerplexityProvider(),
+			fakeProvider("exa", fallback),
+		]);
+
+		await expect(
+			runSearchQuery(
+				{ query: "anything" },
+				{
+					authStorage: {
+						getOAuthAccess: async () => undefined,
+					} as unknown as AuthStorage,
+					signal: controller.signal,
+				},
+			),
+		).rejects.toBeInstanceOf(ToolAbortError);
+		expect(fallback).not.toHaveBeenCalled();
+	});
+
 	it("rethrows caller abort instead of falling through", async () => {
 		const second = vi.fn();
 		vi.spyOn(provider, "resolveProviderChain").mockResolvedValue([

--- a/packages/coding-agent/test/web/search/execute-search-fallback.test.ts
+++ b/packages/coding-agent/test/web/search/execute-search-fallback.test.ts
@@ -6,6 +6,7 @@ import { runSearchQuery } from "../../../src/web/search";
 import * as provider from "../../../src/web/search/provider";
 import type { SearchParams } from "../../../src/web/search/providers/base";
 import { OpenAICompatibleSearchProvider } from "../../../src/web/search/providers/openai-compatible";
+import { PerplexityProvider } from "../../../src/web/search/providers/perplexity";
 import { SearchProviderError, type SearchProviderId, type SearchResponse } from "../../../src/web/search/types";
 
 function fakeProvider(
@@ -16,8 +17,13 @@ function fakeProvider(
 }
 
 const authStorage = {} as AuthStorage;
+const originalPerplexityApiKey = process.env.PERPLEXITY_API_KEY;
 
-afterEach(() => vi.restoreAllMocks());
+afterEach(() => {
+	vi.restoreAllMocks();
+	if (originalPerplexityApiKey === undefined) delete process.env.PERPLEXITY_API_KEY;
+	else process.env.PERPLEXITY_API_KEY = originalPerplexityApiKey;
+});
 
 describe("executeSearch fallback", () => {
 	it("falls through after a no-citation generic failure and preserves ordering", async () => {
@@ -73,6 +79,45 @@ describe("executeSearch fallback", () => {
 		expect(result.content[0]?.text).toContain("https://exa.example");
 		expect(result.content[0]?.text).not.toContain(secret);
 		expect(result.details.warning).not.toContain(secret);
+	});
+
+	it("falls through after Perplexity repeats a structural-empty response", async () => {
+		process.env.PERPLEXITY_API_KEY = "test-key";
+		let calls = 0;
+		using _hook = hookFetch(async () => {
+			calls++;
+			return Response.json({
+				id: `empty-${calls}`,
+				model: "sonar-pro",
+				created: 1,
+				choices: [
+					{ index: 0, message: { role: "assistant", content: "" }, delta: { role: "assistant", content: "" } },
+				],
+				citations: ["https://example.com/source"],
+				search_results: [{ title: "Source", url: "https://example.com/source" }],
+				usage: { prompt_tokens: 10, completion_tokens: 0, total_tokens: 10 },
+			});
+		});
+		vi.spyOn(provider, "resolveProviderChain").mockResolvedValue([
+			new PerplexityProvider(),
+			fakeProvider("exa", async () => ({
+				provider: "exa",
+				sources: [{ title: "Exa", url: "https://exa.example" }],
+			})),
+		]);
+
+		const result = await runSearchQuery(
+			{ query: "anything" },
+			{
+				authStorage: {
+					getOAuthAccess: async () => undefined,
+				} as unknown as AuthStorage,
+			},
+		);
+
+		expect(calls).toBe(2);
+		expect(result.content[0]?.text).toContain("https://exa.example");
+		expect(result.details.warning).toContain("Perplexity web search returned no answer");
 	});
 
 	it("rethrows caller abort instead of falling through", async () => {

--- a/packages/coding-agent/test/web/search/perplexity-provider.test.ts
+++ b/packages/coding-agent/test/web/search/perplexity-provider.test.ts
@@ -168,6 +168,23 @@ describe("Perplexity web search provider", () => {
 		}
 	});
 
+	it("does not expose unclassified non-2xx response bodies", async () => {
+		process.env.PERPLEXITY_API_KEY = "test-key";
+		delete process.env.PERPLEXITY_COOKIES;
+		const secret = "provider-secret-payload";
+		using _hook = hookFetch(async () => new Response(secret, { status: 500 }));
+
+		try {
+			await searchPerplexity(params());
+			throw new Error("Expected provider failure");
+		} catch (error) {
+			expect(error).toBeInstanceOf(SearchProviderError);
+			expect(error).toMatchObject({ provider: "perplexity", status: 500 });
+			expect((error as Error).message).toBe("Perplexity API error (500)");
+			expect((error as Error).message).not.toContain(secret);
+		}
+	});
+
 	it("preserves a valid answer when citation and result structures are empty", async () => {
 		process.env.PERPLEXITY_API_KEY = "test-key";
 		delete process.env.PERPLEXITY_COOKIES;

--- a/packages/coding-agent/test/web/search/perplexity-provider.test.ts
+++ b/packages/coding-agent/test/web/search/perplexity-provider.test.ts
@@ -1,0 +1,231 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import type { AuthStorage } from "@gajae-code/ai";
+import { hookFetch } from "@gajae-code/utils";
+import { searchPerplexity } from "../../../src/web/search/providers/perplexity";
+import { SearchProviderError } from "../../../src/web/search/types";
+
+const originalApiKey = process.env.PERPLEXITY_API_KEY;
+const originalCookies = process.env.PERPLEXITY_COOKIES;
+
+const authStorage = {
+	hasAuth: (provider: string) => provider === "perplexity",
+	getOAuthAccess: async () => undefined,
+} as unknown as AuthStorage;
+
+function validResponse() {
+	return {
+		id: "response-1",
+		model: "sonar-pro",
+		created: 1,
+		choices: [
+			{
+				index: 0,
+				finish_reason: "stop",
+				message: { role: "assistant", content: "A grounded answer." },
+				delta: { role: "assistant", content: "" },
+			},
+		],
+		citations: ["https://example.com/source"],
+		search_results: [
+			{
+				title: "Example source",
+				url: "https://example.com/source",
+				snippet: "Evidence",
+				date: "2026-09-04",
+			},
+		],
+		usage: {
+			prompt_tokens: 10,
+			completion_tokens: 5,
+			total_tokens: 15,
+			cost: {
+				input_tokens_cost: 0,
+				output_tokens_cost: 0,
+				total_cost: 0,
+			},
+		},
+	};
+}
+
+function params(numSearchResults?: number) {
+	return {
+		query: "Perplexity contract test",
+		num_search_results: numSearchResults,
+		authStorage,
+	};
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	if (originalApiKey === undefined) delete process.env.PERPLEXITY_API_KEY;
+	else process.env.PERPLEXITY_API_KEY = originalApiKey;
+	if (originalCookies === undefined) delete process.env.PERPLEXITY_COOKIES;
+	else process.env.PERPLEXITY_COOKIES = originalCookies;
+});
+
+describe("Perplexity web search provider", () => {
+	it.each([
+		[0, 10],
+		[2, 3],
+		[3, 3],
+		[100, 100],
+		[101, 100],
+	] as const)("normalizes num_search_results %d to %d", async (requested, expected) => {
+		process.env.PERPLEXITY_API_KEY = "test-key";
+		delete process.env.PERPLEXITY_COOKIES;
+		let capturedBody: Record<string, unknown> | undefined;
+		using _hook = hookFetch(async (_input, init) => {
+			capturedBody = JSON.parse(String(init?.body));
+			return Response.json(validResponse());
+		});
+
+		await searchPerplexity(params(requested));
+
+		expect(capturedBody?.num_search_results).toBe(expected);
+	});
+
+	it("retries one structural-empty response and returns the valid retry", async () => {
+		process.env.PERPLEXITY_API_KEY = "test-key";
+		delete process.env.PERPLEXITY_COOKIES;
+		let calls = 0;
+		using _hook = hookFetch(async () => {
+			calls++;
+			if (calls === 1) {
+				const response = validResponse();
+				response.choices[0]!.message.content = "";
+				response.usage.completion_tokens = 0;
+				return Response.json(response);
+			}
+			return Response.json(validResponse());
+		});
+
+		const result = await searchPerplexity(params());
+
+		expect(calls).toBe(2);
+		expect(result.answer).toBe("A grounded answer.");
+		expect(result.sources).toHaveLength(1);
+	});
+
+	it("propagates a provider error after repeated structural-empty responses", async () => {
+		process.env.PERPLEXITY_API_KEY = "test-key";
+		delete process.env.PERPLEXITY_COOKIES;
+		let calls = 0;
+		using _hook = hookFetch(async () => {
+			calls++;
+			const response = validResponse();
+			response.choices[0]!.message.content = "";
+			response.usage.completion_tokens = 0;
+			return Response.json(response);
+		});
+
+		try {
+			await searchPerplexity(params());
+			throw new Error("Expected structural-empty response to fail");
+		} catch (error) {
+			expect(calls).toBe(2);
+			expect(error).toBeInstanceOf(SearchProviderError);
+			expect(error).toMatchObject({ provider: "perplexity", status: 424 });
+			expect((error as Error).message).toContain("returned no answer");
+		}
+	});
+
+	it.each([
+		{ choices: "not-an-array" },
+		{ citations: "not-an-array" },
+		{ search_results: "not-an-array" },
+		{ choices: [{ message: { content: { unexpected: true } } }] },
+		{ citations: ["https://example.com", 42] },
+		{ search_results: [{ title: "Missing URL" }] },
+	])("rejects malformed response structures without leaking provider data", async patch => {
+		process.env.PERPLEXITY_API_KEY = "test-key";
+		delete process.env.PERPLEXITY_COOKIES;
+		const secret = "provider-secret-payload";
+		using _hook = hookFetch(async () => Response.json({ ...validResponse(), ...patch, secret }));
+
+		try {
+			await searchPerplexity(params());
+			throw new Error("Expected malformed response to fail");
+		} catch (error) {
+			expect(error).toBeInstanceOf(SearchProviderError);
+			expect(error).toMatchObject({ provider: "perplexity", status: 502 });
+			expect((error as Error).message).toContain("malformed response body");
+			expect((error as Error).message).not.toContain(secret);
+		}
+	});
+
+	it("wraps invalid JSON as a sanitized provider error", async () => {
+		process.env.PERPLEXITY_API_KEY = "test-key";
+		delete process.env.PERPLEXITY_COOKIES;
+		using _hook = hookFetch(async () => new Response("provider-secret-payload", { status: 200 }));
+
+		try {
+			await searchPerplexity(params());
+			throw new Error("Expected invalid JSON to fail");
+		} catch (error) {
+			expect(error).toBeInstanceOf(SearchProviderError);
+			expect(error).toMatchObject({ provider: "perplexity", status: 502 });
+			expect((error as Error).message).toBe("Perplexity API returned invalid JSON");
+		}
+	});
+
+	it("preserves a valid answer when citation and result structures are empty", async () => {
+		process.env.PERPLEXITY_API_KEY = "test-key";
+		delete process.env.PERPLEXITY_COOKIES;
+		using _hook = hookFetch(async () =>
+			Response.json({
+				...validResponse(),
+				citations: [],
+				search_results: [],
+			}),
+		);
+
+		const result = await searchPerplexity(params());
+
+		expect(result.answer).toBe("A grounded answer.");
+		expect(result.sources).toEqual([]);
+		expect(result.citations).toBeUndefined();
+	});
+
+	it("rejects an empty OAuth stream instead of returning an empty success", async () => {
+		delete process.env.PERPLEXITY_API_KEY;
+		process.env.PERPLEXITY_COOKIES = "session=test";
+		using _hook = hookFetch(
+			async () =>
+				new Response("", {
+					status: 200,
+					headers: { "Content-Type": "text/event-stream" },
+				}),
+		);
+
+		await expect(searchPerplexity(params())).rejects.toMatchObject({
+			provider: "perplexity",
+			status: 424,
+		});
+	});
+
+	it("preserves valid answers, citations, sources, usage, and identifiers", async () => {
+		process.env.PERPLEXITY_API_KEY = "test-key";
+		delete process.env.PERPLEXITY_COOKIES;
+		using _hook = hookFetch(async () => Response.json(validResponse()));
+
+		const result = await searchPerplexity(params(10));
+
+		expect(result).toMatchObject({
+			provider: "perplexity",
+			authMode: "api_key",
+			answer: "A grounded answer.",
+			model: "sonar-pro",
+			requestId: "response-1",
+			usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+			citations: [{ title: "Example source", url: "https://example.com/source" }],
+			sources: [
+				{
+					title: "Example source",
+					url: "https://example.com/source",
+					snippet: "Evidence",
+					publishedDate: "2026-09-04",
+				},
+			],
+		});
+	});
+});


### PR DESCRIPTION
## What

- clamp Perplexity API-key `num_search_results` to its 3–100 upstream contract using the shared result-count normalization semantics
- validate API response JSON and consumed structures before mapping them into the provider-neutral `SearchResponse`
- retry one reported structural-empty completion, then propagate a typed provider error into the existing fallback chain
- reject empty OAuth streams, preserve cancellation, sanitize upstream failure bodies, and retain valid answers, sources, citations, usage, and identifiers

## Why

Fixes #5293. Perplexity rejected breadth below 3 with `invalid_num_search_results`, while empty or malformed success bodies could be rendered as successful searches.

## Testing

- `bun test packages/coding-agent/test/web/search/perplexity-provider.test.ts packages/coding-agent/test/web/search/execute-search-fallback.test.ts` (23 pass)
- `bun test packages/coding-agent/test/web/search` (209 pass)
- `bun --cwd=packages/coding-agent run check`
- `bun --cwd=packages/coding-agent run build`

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:720055a2240f508ed1b1bddac3a37b6e8bd8344775a3f9ffa465481941bde18b reviewer:human reviewer-id:Yeachan-Heo evidence:bun test packages/coding-agent/test/web/search (209 pass); package check and build pass; adversarial exact-head review
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken