### PR TITLE
fix(contribution-prep): redact complete AWS credentials in outbound artifacts

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 
+- Contribution-prep outbound artifacts now redact complete AWS credentials, including AKIA/ASIA access-key IDs and SecretAccessKey/SessionToken values in shell-style and escaped JSON forms, while preserving structured output and existing GitHub, Slack, authorization-header, and cookie redaction.
 - Perplexity web search now clamps upstream search breadth to the API's 3–100 contract, retries one structurally empty completion, rejects malformed or ungrounded success payloads through the provider fallback path, and preserves valid grounded responses.
 - Architect/task subagents now retry API-key lookup without the parent session id after a scoped miss, so broker OAuth that works for `gjc -p --no-session` is not thrown away as `Agent run failed` / 0 tokens (#5081 follow-up). Failures still throw `provider_unavailable` without leaking the token.
 - Python work that completes after strict session disposal now returns its result without attempting to append to the closed session transcript.

--- a/packages/coding-agent/src/session/contribution-prep.ts
+++ b/packages/coding-agent/src/session/contribution-prep.ts
@@ -91,7 +91,8 @@ function isAwsSecretField(value: string): boolean {
 		normalized === "secretaccesskey" ||
 		normalized === "sessiontoken" ||
 		normalized === "awssecretaccesskey" ||
-		normalized === "awssessiontoken"
+		normalized === "awssessiontoken" ||
+		normalized === "xamzsecuritytoken"
 	);
 }
 
@@ -462,7 +463,7 @@ export async function prepareContributionPrep(
 			});
 		const command = resolveGjcCommand();
 		await spawn(
-			[command.cmd, ...command.args, "--no-skills", "--", `@${workerPromptPath}`],
+			[command.cmd, ...command.args, "--no-skills", "--", `@${path.basename(workerPromptPath)}`],
 			artifactDir,
 			command.shell,
 		);

--- a/packages/coding-agent/src/session/contribution-prep.ts
+++ b/packages/coding-agent/src/session/contribution-prep.ts
@@ -175,14 +175,21 @@ export function redactContributionPrepText(
 	redacted = redactAwsAccessKeyIds(redacted, state);
 	redacted = replaceRegex(
 		redacted,
-		/(^|[^A-Za-z0-9_-])(["']?(?:(?:aws[_-]?)?secret[_-]?access[_-]?key|(?:aws[_-]?)?session[_-]?token)["']?\s*[=:]\s*)(["'])([^"'\r\n]{8,})\3/gi,
-		"$1$2$3[REDACTED_SECRET]$3",
+		/(<((?:[A-Za-z_][\w.-]*:)?(?:SecretAccessKey|SessionToken))>)[^<\r\n]{8,}(<\/\2>)/gi,
+		"$1[REDACTED_SECRET]$3",
 		state,
 		"aws_keys",
 	);
 	redacted = replaceRegex(
 		redacted,
-		/(^|[^A-Za-z0-9_-])(["']?(?:(?:aws[_-]?)?secret[_-]?access[_-]?key|(?:aws[_-]?)?session[_-]?token)["']?\s*[=:]\s*)[^\s"',;{}[\]()]{8,}/gi,
+		/(^|[^A-Za-z0-9_-])(["']?(?:(?:aws[_-]?)?secret[_-]?access[_-]?key|(?:aws[_-]?)?session[_-]?token)["']?\s*[=:]\s*)(\$?)(["'`])([^"'`\r\n]{8,})\4/gi,
+		"$1$2$3$4[REDACTED_SECRET]$4",
+		state,
+		"aws_keys",
+	);
+	redacted = replaceRegex(
+		redacted,
+		/(^|[^A-Za-z0-9_-])(["']?(?:(?:aws[_-]?)?secret[_-]?access[_-]?key|(?:aws[_-]?)?session[_-]?token)["']?\s*[=:]\s*)[^\s"'`,;{}[\]()&<>#]{8,}/gi,
 		"$1$2[REDACTED_SECRET]",
 		state,
 		"aws_keys",
@@ -379,7 +386,7 @@ export async function prepareContributionPrep(
 
 	const manifest: ContributionPrepManifest = {
 		schema_version: CONTRIBUTION_PREP_SCHEMA_VERSION,
-		source_session_id: context.sessionId,
+		source_session_id: redact(context.sessionId),
 		created_at: createdAt,
 		cwd: redact(context.cwd),
 		git_head: gitHead,

--- a/packages/coding-agent/src/session/contribution-prep.ts
+++ b/packages/coding-agent/src/session/contribution-prep.ts
@@ -111,7 +111,10 @@ function redactAwsLabeledValues(text: string, state: RedactionState): string {
 	let redacted = redactAwsAccessKeyIds(text, state);
 	redacted = replaceRegex(
 		redacted,
-		/(<((?:[A-Za-z_][\w.-]*:)?(?:SecretAccessKey|SessionToken))>)[^<\r\n]{8,}(<\/\2>)/gi,
+		// STS XML responses are commonly pretty-printed, so the value sits on its own
+		// line between the tags. `[^<]` still refuses to cross into another element,
+		// and the length bound keeps an empty or whitespace-only body from matching.
+		/(<((?:[A-Za-z_][\w.-]*:)?(?:SecretAccessKey|SessionToken))>)[^<]{8,4096}(<\/\2>)/gi,
 		"$1[REDACTED_SECRET]$3",
 		state,
 		"aws_keys",

--- a/packages/coding-agent/src/session/contribution-prep.ts
+++ b/packages/coding-agent/src/session/contribution-prep.ts
@@ -92,6 +92,19 @@ export function redactContributionPrepText(
 		state,
 		"tokens",
 	);
+	// AKIA is the long-term access key id, ASIA the temporary/STS one. The id is
+	// not the credential on its own: an STS payload carries `SecretAccessKey` and
+	// `SessionToken` beside it, and neither canonical field name is matched by the
+	// `ENV_*=value` rule below, which only sees shell-style `AWS_SECRET_ACCESS_KEY=`.
+	// The crash-log scrubber already covers both shapes; this is the outbound path.
+	redacted = replaceRegex(redacted, /\b(?:AKIA|ASIA)[0-9A-Z]{16}\b/g, "[REDACTED_AWS_KEY_ID]", state, "aws_keys");
+	redacted = replaceRegex(
+		redacted,
+		/(["']?(?:secret[_-]?access[_-]?key|session[_-]?token)["']?\s*[=:]\s*["']?)[^\s"',;}\]]{8,}/gi,
+		"$1[REDACTED_SECRET]",
+		state,
+		"aws_keys",
+	);
 	redacted = replaceRegex(
 		redacted,
 		/\b((?:ANTHROPIC|OPENAI|GITHUB|GOOGLE|GEMINI|KAGI|TAVILY|EXA|PERPLEXITY|ZAI|KIMI|BRAVE|SEARXNG|AWS)_[A-Z0-9_]*(?:KEY|TOKEN|SECRET|COOKIE|PASSWORD))\s*=\s*[^\s\n]+/gi,

--- a/packages/coding-agent/src/session/contribution-prep.ts
+++ b/packages/coding-agent/src/session/contribution-prep.ts
@@ -92,7 +92,7 @@ function isAwsSecretField(value: string): boolean {
 	);
 }
 
-function redactAwsJsonStrings(text: string, state: RedactionState): string {
+function redactAwsJsonStrings(text: string, state: RedactionState, depth = 0): string {
 	const tokens = [...text.matchAll(/"(?:\\(?:["\\/bfnrt]|u[0-9A-Fa-f]{4})|[^"\\\r\n])*"/g)].map(match => ({
 		start: match.index,
 		end: match.index + match[0].length,
@@ -123,7 +123,11 @@ function redactAwsJsonStrings(text: string, state: RedactionState): string {
 			}
 		}
 
-		const redacted = decoded.replace(
+		const nestedRedacted =
+			depth < 3 && decoded.length <= MAX_GIT_OUTPUT_CHARS
+				? redactAwsJsonStrings(decoded, state, depth + 1)
+				: decoded;
+		const redacted = nestedRedacted.replace(
 			/(^|[^0-9A-Za-z])(?:AKIA|ASIA)[0-9A-Z]{16}(?![0-9A-Za-z])/g,
 			"$1[REDACTED_AWS_KEY_ID]",
 		);
@@ -139,6 +143,14 @@ function redactAwsJsonStrings(text: string, state: RedactionState): string {
 		redacted = `${redacted.slice(0, start)}${replacement.value}${redacted.slice(replacement.end)}`;
 	}
 	return redacted;
+}
+
+function assertSafeArtifactPath(artifactDir: string): void {
+	const state: RedactionState = { labels: new Set() };
+	redactContributionPrepText(artifactDir, path.join(artifactDir, "__gjc_path_probe__"), state);
+	if (["tokens", "aws_keys", "provider_keys", "auth_headers", "cookies"].some(label => state.labels.has(label))) {
+		throw new Error("Contribution prep artifact path contains credential-like material.");
+	}
 }
 
 export function redactContributionPrepText(
@@ -283,6 +295,7 @@ export async function prepareContributionPrep(
 		options.artifactRoot ?? path.join(context.cwd, ".gjc", "contribution-prep"),
 		safeTimestamp,
 	);
+	assertSafeArtifactPath(artifactDir);
 	await fs.mkdir(artifactDir, { recursive: true });
 
 	const redactions: RedactionState = { labels: new Set() };

--- a/packages/coding-agent/src/session/contribution-prep.ts
+++ b/packages/coding-agent/src/session/contribution-prep.ts
@@ -12,6 +12,9 @@ export const CONTRIBUTION_PREP_SCHEMA_VERSION = 1;
 const MAX_TRANSCRIPT_MESSAGES = 20;
 const MAX_TEXT_CHARS = 12000;
 const MAX_GIT_OUTPUT_CHARS = 60000;
+const MAX_REDACTION_INPUT_CHARS = 1_000_000;
+const MAX_JSON_TOKENS = 20_000;
+const MAX_JSON_REPLACEMENTS = 10_000;
 
 export interface ContributionPrepArtifact {
 	path: string;
@@ -103,12 +106,48 @@ function isSerializedJson(value: string): boolean {
 	}
 }
 
+function redactAwsLabeledValues(text: string, state: RedactionState): string {
+	let redacted = redactAwsAccessKeyIds(text, state);
+	redacted = replaceRegex(
+		redacted,
+		/(<((?:[A-Za-z_][\w.-]*:)?(?:SecretAccessKey|SessionToken))>)[^<\r\n]{8,}(<\/\2>)/gi,
+		"$1[REDACTED_SECRET]$3",
+		state,
+		"aws_keys",
+	);
+	redacted = replaceRegex(
+		redacted,
+		/(^|[^A-Za-z0-9_-])(["']?(?:(?:aws[_-]?)?secret[_-]?access[_-]?key|(?:aws[_-]?)?session[_-]?token)["']?\s*[=:]\s*)(\$?)(["'`])([^"'`\r\n]{8,})\4/gi,
+		"$1$2$3$4[REDACTED_SECRET]$4",
+		state,
+		"aws_keys",
+	);
+	redacted = replaceRegex(
+		redacted,
+		/(^|[^A-Za-z0-9_-])(["']?(?:(?:aws[_-]?)?secret[_-]?access[_-]?key|(?:aws[_-]?)?session[_-]?token)["']?\s*[=:]\s*)[^\s"'`,;{}[\]()&<>#]{8,}/gi,
+		"$1$2[REDACTED_SECRET]",
+		state,
+		"aws_keys",
+	);
+	return replaceRegex(
+		redacted,
+		/(^|[?&;\s])(X-Amz-Security-Token)(\s*[=:]\s*)[^\s"'`,;&<>#]{8,}/gi,
+		"$1$2$3[REDACTED_SECRET]",
+		state,
+		"aws_keys",
+	);
+}
+
 function redactAwsJsonStrings(text: string, state: RedactionState, depth = 0): string {
 	const tokens = [...text.matchAll(/"(?:\\(?:["\\/bfnrt]|u[0-9A-Fa-f]{4})|[^"\\\r\n])*"/g)].map(match => ({
 		start: match.index,
 		end: match.index + match[0].length,
 		raw: match[0],
 	}));
+	if (tokens.length > MAX_JSON_TOKENS) {
+		state.labels.add("oversized_content");
+		return "[REDACTED_OVERSIZED_CONTENT]";
+	}
 	const replacements = new Map<number, { end: number; value: string }>();
 
 	for (const [index, token] of tokens.entries()) {
@@ -140,22 +179,26 @@ function redactAwsJsonStrings(text: string, state: RedactionState, depth = 0): s
 				? "[REDACTED_NESTED_JSON]"
 				: decoded
 			: redactAwsJsonStrings(decoded, state, depth + 1);
-		const redacted = nestedRedacted.replace(
-			/(^|[^0-9A-Za-z])(?:AKIA|ASIA)[0-9A-Z]{16}(?![0-9A-Za-z])/g,
-			"$1[REDACTED_AWS_KEY_ID]",
-		);
+		const redacted = redactAwsLabeledValues(nestedRedacted, state);
 		if (redacted !== decoded && !replacements.has(token.start)) {
 			replacements.set(token.start, { end: token.end, value: JSON.stringify(redacted) });
 		}
 	}
 
 	if (replacements.size === 0) return text;
-	state.labels.add("aws_keys");
-	let redacted = text;
-	for (const [start, replacement] of [...replacements.entries()].sort(([left], [right]) => right - left)) {
-		redacted = `${redacted.slice(0, start)}${replacement.value}${redacted.slice(replacement.end)}`;
+	if (replacements.size > MAX_JSON_REPLACEMENTS) {
+		state.labels.add("oversized_content");
+		return "[REDACTED_OVERSIZED_CONTENT]";
 	}
-	return redacted;
+	state.labels.add("aws_keys");
+	const chunks: string[] = [];
+	let cursor = 0;
+	for (const [start, replacement] of [...replacements.entries()].sort(([left], [right]) => left - right)) {
+		chunks.push(text.slice(cursor, start), replacement.value);
+		cursor = replacement.end;
+	}
+	chunks.push(text.slice(cursor));
+	return chunks.join("");
 }
 
 function assertSafeArtifactPath(artifactDir: string): void {
@@ -171,29 +214,12 @@ export function redactContributionPrepText(
 	cwd: string,
 	state: RedactionState = { labels: new Set() },
 ): string {
+	if (text.length > MAX_REDACTION_INPUT_CHARS) {
+		state.labels.add("oversized_content");
+		return "[REDACTED_OVERSIZED_CONTENT]";
+	}
 	let redacted = redactAwsJsonStrings(text, state);
-	redacted = redactAwsAccessKeyIds(redacted, state);
-	redacted = replaceRegex(
-		redacted,
-		/(<((?:[A-Za-z_][\w.-]*:)?(?:SecretAccessKey|SessionToken))>)[^<\r\n]{8,}(<\/\2>)/gi,
-		"$1[REDACTED_SECRET]$3",
-		state,
-		"aws_keys",
-	);
-	redacted = replaceRegex(
-		redacted,
-		/(^|[^A-Za-z0-9_-])(["']?(?:(?:aws[_-]?)?secret[_-]?access[_-]?key|(?:aws[_-]?)?session[_-]?token)["']?\s*[=:]\s*)(\$?)(["'`])([^"'`\r\n]{8,})\4/gi,
-		"$1$2$3$4[REDACTED_SECRET]$4",
-		state,
-		"aws_keys",
-	);
-	redacted = replaceRegex(
-		redacted,
-		/(^|[^A-Za-z0-9_-])(["']?(?:(?:aws[_-]?)?secret[_-]?access[_-]?key|(?:aws[_-]?)?session[_-]?token)["']?\s*[=:]\s*)[^\s"'`,;{}[\]()&<>#]{8,}/gi,
-		"$1$2[REDACTED_SECRET]",
-		state,
-		"aws_keys",
-	);
+	redacted = redactAwsLabeledValues(redacted, state);
 	redacted = replaceRegex(
 		redacted,
 		/\b(?:sk|pk|rk|xox[baprs])-[-_A-Za-z0-9]{12,}\b/g,
@@ -296,13 +322,21 @@ async function writeArtifact(
 }
 
 export function buildContributionPrepWorkerPrompt(manifestPath: string): string {
+	const manifestName = path.basename(manifestPath);
 	return [
 		"Prepare a maintainer-friendly contribution draft from the redacted context dump.",
-		"Read the manifest and referenced artifact file pointers. Do not assume transcript context was inlined here.",
-		`Manifest: ${manifestPath}`,
+		"Read the manifest beside this worker prompt and its relative artifact file pointers. Do not assume transcript context was inlined here.",
+		`Manifest: ${manifestName}`,
 		"Produce structured markdown with: title, problem summary, reproduction/context, proposed fix or implementation plan, affected files, tests to run, and uncertainty/remaining risks.",
 		"Do not create GitHub issues, open PRs, push branches, or perform remote writes unless the user explicitly confirms that action in this fresh session.",
 	].join("\n");
+}
+
+function safeWorkspaceLabel(cwd: string): string {
+	const resolved = path.resolve(cwd);
+	const home = os.homedir();
+	if (home && (resolved === home || resolved.startsWith(`${home}${path.sep}`))) return shortenPath(resolved);
+	return path.basename(resolved) || ".";
 }
 
 export async function prepareContributionPrep(
@@ -322,6 +356,7 @@ export async function prepareContributionPrep(
 	const recentMessages = context.messages.slice(-MAX_TRANSCRIPT_MESSAGES);
 	const artifacts: ContributionPrepArtifact[] = [];
 	const redact = (text: string) => redactContributionPrepText(text, context.cwd, redactions);
+	const workspaceLabel = safeWorkspaceLabel(context.cwd);
 
 	artifacts.push(
 		await writeArtifact(
@@ -340,8 +375,8 @@ export async function prepareContributionPrep(
 				[
 					`# Contribution prep context`,
 					`Source session: ${context.sessionId}`,
-					`Session file: ${context.sessionFile ?? "(none)"}`,
-					`Working directory: ${context.cwd}`,
+					`Session file: ${context.sessionFile ? path.basename(context.sessionFile) : "(none)"}`,
+					`Working directory: ${workspaceLabel}`,
 					options.customInstructions || context.customInstructions
 						? `Custom instructions: ${options.customInstructions ?? context.customInstructions}`
 						: "Custom instructions: (none)",
@@ -370,7 +405,7 @@ export async function prepareContributionPrep(
 			"Redacted environment and reproduction metadata",
 			redact(
 				[
-					`cwd: ${context.cwd}`,
+					`cwd: ${workspaceLabel}`,
 					`git_head: ${gitHead ?? "unknown"}`,
 					`platform: ${process.platform}`,
 					`arch: ${process.arch}`,
@@ -383,15 +418,16 @@ export async function prepareContributionPrep(
 	const manifestPath = path.join(artifactDir, "manifest.json");
 	const workerPromptPath = path.join(artifactDir, "worker-prompt.md");
 	await Bun.write(workerPromptPath, `${buildContributionPrepWorkerPrompt(manifestPath)}\n`);
+	const manifestArtifacts = artifacts.map(artifact => ({ ...artifact, path: path.basename(artifact.path) }));
 
 	const manifest: ContributionPrepManifest = {
 		schema_version: CONTRIBUTION_PREP_SCHEMA_VERSION,
 		source_session_id: redact(context.sessionId),
 		created_at: createdAt,
-		cwd: redact(context.cwd),
+		cwd: redact(workspaceLabel),
 		git_head: gitHead,
 		changed_files: files.map(redact),
-		artifacts,
+		artifacts: manifestArtifacts,
 		redactions: [...redactions.labels].sort(),
 		recommended_output: [
 			"title",
@@ -402,7 +438,7 @@ export async function prepareContributionPrep(
 			"tests to run",
 			"uncertainty / remaining risks",
 		],
-		worker_prompt_path: workerPromptPath,
+		worker_prompt_path: path.basename(workerPromptPath),
 	};
 	await Bun.write(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
 
@@ -427,7 +463,7 @@ export async function prepareContributionPrep(
 		const command = resolveGjcCommand();
 		await spawn(
 			[command.cmd, ...command.args, "--no-skills", "--", `@${workerPromptPath}`],
-			context.cwd,
+			artifactDir,
 			command.shell,
 		);
 		spawned = true;

--- a/packages/coding-agent/src/session/contribution-prep.ts
+++ b/packages/coding-agent/src/session/contribution-prep.ts
@@ -96,17 +96,6 @@ function isAwsSecretField(value: string): boolean {
 	);
 }
 
-function isSerializedJson(value: string): boolean {
-	const first = value.trimStart()[0];
-	if (first !== '"' && first !== "{" && first !== "[") return false;
-	try {
-		JSON.parse(value);
-		return true;
-	} catch {
-		return false;
-	}
-}
-
 function redactAwsLabeledValues(text: string, state: RedactionState): string {
 	let redacted = redactAwsAccessKeyIds(text, state);
 	redacted = replaceRegex(
@@ -178,12 +167,7 @@ function redactAwsJsonStrings(text: string, state: RedactionState, depth = 0): s
 			}
 		}
 
-		const atScanLimit = depth >= 3 || decoded.length > MAX_GIT_OUTPUT_CHARS;
-		const nestedRedacted = atScanLimit
-			? isSerializedJson(decoded)
-				? "[REDACTED_NESTED_JSON]"
-				: decoded
-			: redactAwsJsonStrings(decoded, state, depth + 1);
+		const nestedRedacted = depth >= 3 ? "[REDACTED_NESTED_CONTENT]" : redactAwsJsonStrings(decoded, state, depth + 1);
 		const redacted = redactAwsLabeledValues(nestedRedacted, state);
 		if (redacted !== decoded && !replacements.has(token.start)) {
 			replacements.set(token.start, { end: token.end, value: JSON.stringify(redacted) });

--- a/packages/coding-agent/src/session/contribution-prep.ts
+++ b/packages/coding-agent/src/session/contribution-prep.ts
@@ -92,6 +92,17 @@ function isAwsSecretField(value: string): boolean {
 	);
 }
 
+function isSerializedJson(value: string): boolean {
+	const first = value.trimStart()[0];
+	if (first !== '"' && first !== "{" && first !== "[") return false;
+	try {
+		JSON.parse(value);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
 function redactAwsJsonStrings(text: string, state: RedactionState, depth = 0): string {
 	const tokens = [...text.matchAll(/"(?:\\(?:["\\/bfnrt]|u[0-9A-Fa-f]{4})|[^"\\\r\n])*"/g)].map(match => ({
 		start: match.index,
@@ -123,10 +134,12 @@ function redactAwsJsonStrings(text: string, state: RedactionState, depth = 0): s
 			}
 		}
 
-		const nestedRedacted =
-			depth < 3 && decoded.length <= MAX_GIT_OUTPUT_CHARS
-				? redactAwsJsonStrings(decoded, state, depth + 1)
-				: decoded;
+		const atScanLimit = depth >= 3 || decoded.length > MAX_GIT_OUTPUT_CHARS;
+		const nestedRedacted = atScanLimit
+			? isSerializedJson(decoded)
+				? "[REDACTED_NESTED_JSON]"
+				: decoded
+			: redactAwsJsonStrings(decoded, state, depth + 1);
 		const redacted = nestedRedacted.replace(
 			/(^|[^0-9A-Za-z])(?:AKIA|ASIA)[0-9A-Z]{16}(?![0-9A-Za-z])/g,
 			"$1[REDACTED_AWS_KEY_ID]",
@@ -162,14 +175,14 @@ export function redactContributionPrepText(
 	redacted = redactAwsAccessKeyIds(redacted, state);
 	redacted = replaceRegex(
 		redacted,
-		/(^|[^A-Za-z0-9_])(["']?(?:(?:aws[_-]?)?secret[_-]?access[_-]?key|(?:aws[_-]?)?session[_-]?token)["']?\s*[=:]\s*)(["'])([^"'\r\n]{8,})\3/gi,
+		/(^|[^A-Za-z0-9_-])(["']?(?:(?:aws[_-]?)?secret[_-]?access[_-]?key|(?:aws[_-]?)?session[_-]?token)["']?\s*[=:]\s*)(["'])([^"'\r\n]{8,})\3/gi,
 		"$1$2$3[REDACTED_SECRET]$3",
 		state,
 		"aws_keys",
 	);
 	redacted = replaceRegex(
 		redacted,
-		/(^|[^A-Za-z0-9_])(["']?(?:(?:aws[_-]?)?secret[_-]?access[_-]?key|(?:aws[_-]?)?session[_-]?token)["']?\s*[=:]\s*)[^\s"',;{}[\]()]{8,}/gi,
+		/(^|[^A-Za-z0-9_-])(["']?(?:(?:aws[_-]?)?secret[_-]?access[_-]?key|(?:aws[_-]?)?session[_-]?token)["']?\s*[=:]\s*)[^\s"',;{}[\]()]{8,}/gi,
 		"$1$2[REDACTED_SECRET]",
 		state,
 		"aws_keys",

--- a/packages/coding-agent/src/session/contribution-prep.ts
+++ b/packages/coding-agent/src/session/contribution-prep.ts
@@ -72,12 +72,96 @@ function replaceRegex(text: string, regex: RegExp, replacement: string, state: R
 	return text.replace(regex, replacement);
 }
 
+function redactAwsAccessKeyIds(text: string, state: RedactionState): string {
+	return replaceRegex(
+		text,
+		/(^|[^0-9A-Za-z])(?:AKIA|ASIA)[0-9A-Z]{16}(?![0-9A-Za-z])/g,
+		"$1[REDACTED_AWS_KEY_ID]",
+		state,
+		"aws_keys",
+	);
+}
+
+function isAwsSecretField(value: string): boolean {
+	const normalized = value.toLowerCase().replaceAll(/[_-]/g, "");
+	return (
+		normalized === "secretaccesskey" ||
+		normalized === "sessiontoken" ||
+		normalized === "awssecretaccesskey" ||
+		normalized === "awssessiontoken"
+	);
+}
+
+function redactAwsJsonStrings(text: string, state: RedactionState): string {
+	const tokens = [...text.matchAll(/"(?:\\(?:["\\/bfnrt]|u[0-9A-Fa-f]{4})|[^"\\\r\n])*"/g)].map(match => ({
+		start: match.index,
+		end: match.index + match[0].length,
+		raw: match[0],
+	}));
+	const replacements = new Map<number, { end: number; value: string }>();
+
+	for (const [index, token] of tokens.entries()) {
+		let decoded: string;
+		try {
+			decoded = JSON.parse(token.raw) as string;
+		} catch {
+			continue;
+		}
+
+		if (isAwsSecretField(decoded)) {
+			const separator = /^\s*:\s*/.exec(text.slice(token.end));
+			const valueToken = tokens[index + 1];
+			if (separator && valueToken?.start === token.end + separator[0].length) {
+				let value: string;
+				try {
+					value = JSON.parse(valueToken.raw) as string;
+				} catch {
+					value = "";
+				}
+				if (value.length >= 8)
+					replacements.set(valueToken.start, { end: valueToken.end, value: JSON.stringify("[REDACTED_SECRET]") });
+			}
+		}
+
+		const redacted = decoded.replace(
+			/(^|[^0-9A-Za-z])(?:AKIA|ASIA)[0-9A-Z]{16}(?![0-9A-Za-z])/g,
+			"$1[REDACTED_AWS_KEY_ID]",
+		);
+		if (redacted !== decoded && !replacements.has(token.start)) {
+			replacements.set(token.start, { end: token.end, value: JSON.stringify(redacted) });
+		}
+	}
+
+	if (replacements.size === 0) return text;
+	state.labels.add("aws_keys");
+	let redacted = text;
+	for (const [start, replacement] of [...replacements.entries()].sort(([left], [right]) => right - left)) {
+		redacted = `${redacted.slice(0, start)}${replacement.value}${redacted.slice(replacement.end)}`;
+	}
+	return redacted;
+}
+
 export function redactContributionPrepText(
 	text: string,
 	cwd: string,
 	state: RedactionState = { labels: new Set() },
 ): string {
-	let redacted = text;
+	let redacted = redactAwsJsonStrings(text, state);
+	redacted = redactAwsAccessKeyIds(redacted, state);
+	redacted = replaceRegex(
+		redacted,
+		/(^|[^A-Za-z0-9_])(["']?(?:(?:aws[_-]?)?secret[_-]?access[_-]?key|(?:aws[_-]?)?session[_-]?token)["']?\s*[=:]\s*)(["'])([^"'\r\n]{8,})\3/gi,
+		"$1$2$3[REDACTED_SECRET]$3",
+		state,
+		"aws_keys",
+	);
+	redacted = replaceRegex(
+		redacted,
+		/(^|[^A-Za-z0-9_])(["']?(?:(?:aws[_-]?)?secret[_-]?access[_-]?key|(?:aws[_-]?)?session[_-]?token)["']?\s*[=:]\s*)[^\s"',;{}[\]()]{8,}/gi,
+		"$1$2[REDACTED_SECRET]",
+		state,
+		"aws_keys",
+	);
 	redacted = replaceRegex(
 		redacted,
 		/\b(?:sk|pk|rk|xox[baprs])-[-_A-Za-z0-9]{12,}\b/g,
@@ -91,19 +175,6 @@ export function redactContributionPrepText(
 		"[REDACTED_TOKEN]",
 		state,
 		"tokens",
-	);
-	// AKIA is the long-term access key id, ASIA the temporary/STS one. The id is
-	// not the credential on its own: an STS payload carries `SecretAccessKey` and
-	// `SessionToken` beside it, and neither canonical field name is matched by the
-	// `ENV_*=value` rule below, which only sees shell-style `AWS_SECRET_ACCESS_KEY=`.
-	// The crash-log scrubber already covers both shapes; this is the outbound path.
-	redacted = replaceRegex(redacted, /\b(?:AKIA|ASIA)[0-9A-Z]{16}\b/g, "[REDACTED_AWS_KEY_ID]", state, "aws_keys");
-	redacted = replaceRegex(
-		redacted,
-		/(["']?(?:secret[_-]?access[_-]?key|session[_-]?token)["']?\s*[=:]\s*["']?)[^\s"',;}\]]{8,}/gi,
-		"$1[REDACTED_SECRET]",
-		state,
-		"aws_keys",
 	);
 	redacted = replaceRegex(
 		redacted,

--- a/packages/coding-agent/src/session/contribution-prep.ts
+++ b/packages/coding-agent/src/session/contribution-prep.ts
@@ -113,8 +113,9 @@ function redactAwsLabeledValues(text: string, state: RedactionState): string {
 		redacted,
 		// STS XML responses are commonly pretty-printed, so the value sits on its own
 		// line between the tags. `[^<]` still refuses to cross into another element,
-		// and the length bound keeps an empty or whitespace-only body from matching.
-		/(<((?:[A-Za-z_][\w.-]*:)?(?:SecretAccessKey|SessionToken))>)[^<]{8,4096}(<\/\2>)/gi,
+		// while the call-wide input bound caps work without imposing a credential-size
+		// assumption. The lower bound leaves empty or whitespace-only bodies alone.
+		/(<((?:[A-Za-z_][\w.-]*:)?(?:SecretAccessKey|SessionToken))>)[^<]{8,1000000}(<\/\2>)/gi,
 		"$1[REDACTED_SECRET]$3",
 		state,
 		"aws_keys",

--- a/packages/coding-agent/test/contribution-prep.test.ts
+++ b/packages/coding-agent/test/contribution-prep.test.ts
@@ -74,12 +74,18 @@ describe("contribution prep", () => {
 				AccessKeyId: SYNTHETIC_AWS_TEMPORARY_KEY_ID,
 				SecretAccessKey: SYNTHETIC_AWS_SECRET_ACCESS_KEY,
 				SessionToken: SYNTHETIC_AWS_SESSION_TOKEN,
+				"X-Amz-Security-Token": SYNTHETIC_AWS_SESSION_TOKEN,
 			},
 		});
 
 		const redacted = redactContributionPrepText(text, process.cwd());
 		const parsed = JSON.parse(redacted) as {
-			Credentials: { AccessKeyId: string; SecretAccessKey: string; SessionToken: string };
+			Credentials: {
+				AccessKeyId: string;
+				SecretAccessKey: string;
+				SessionToken: string;
+				"X-Amz-Security-Token": string;
+			};
 		};
 
 		expect(redacted).not.toContain(SYNTHETIC_AWS_TEMPORARY_KEY_ID);
@@ -89,6 +95,7 @@ describe("contribution prep", () => {
 			AccessKeyId: "[REDACTED_AWS_KEY_ID]",
 			SecretAccessKey: "[REDACTED_SECRET]",
 			SessionToken: "[REDACTED_SECRET]",
+			"X-Amz-Security-Token": "[REDACTED_SECRET]",
 		});
 	});
 
@@ -153,9 +160,18 @@ describe("contribution prep", () => {
 			{ length: 10001 },
 			(_, index) => `"field${index}":"${SYNTHETIC_AWS_ACCESS_KEY_ID}"`,
 		).join(",")}}`;
+		const manyReplacements = JSON.stringify(
+			Array.from({ length: 10001 }, (_, index) => `${SYNTHETIC_AWS_ACCESS_KEY_ID}-${index}`),
+		);
+		const ordered = JSON.stringify([SYNTHETIC_AWS_ACCESS_KEY_ID, SYNTHETIC_AWS_TEMPORARY_KEY_ID]);
 
 		expect(redactContributionPrepText("x".repeat(1_000_001), process.cwd())).toBe("[REDACTED_OVERSIZED_CONTENT]");
 		expect(redactContributionPrepText(manyFields, process.cwd())).toBe("[REDACTED_OVERSIZED_CONTENT]");
+		expect(redactContributionPrepText(manyReplacements, process.cwd())).toBe("[REDACTED_OVERSIZED_CONTENT]");
+		expect(JSON.parse(redactContributionPrepText(ordered, process.cwd()))).toEqual([
+			"[REDACTED_AWS_KEY_ID]",
+			"[REDACTED_AWS_KEY_ID]",
+		]);
 	});
 
 	it("handles AWS credential boundaries, label case, separators, and whitespace", () => {
@@ -263,7 +279,10 @@ describe("contribution prep", () => {
 					role: "user",
 					content: JSON.stringify({
 						log: `Failure uses Authorization: Bearer ghp_secretsecretsecret and SessionToken: ${SYNTHETIC_AWS_SESSION_TOKEN}`,
-						payload: JSON.stringify({ SecretAccessKey: SYNTHETIC_AWS_SECRET_ACCESS_KEY }),
+						payload: JSON.stringify({
+							SecretAccessKey: SYNTHETIC_AWS_SECRET_ACCESS_KEY,
+							"X-Amz-Security-Token": SYNTHETIC_AWS_SESSION_TOKEN,
+						}),
 					}),
 					timestamp: 1,
 				},
@@ -426,7 +445,8 @@ describe("contribution prep", () => {
 
 			expect(result.spawned).toBe(true);
 			expect(spawns).toHaveLength(1);
-			expect(spawns[0]?.args).toContain(`@${result.workerPromptPath}`);
+			expect(spawns[0]?.args).toContain("@worker-prompt.md");
+			expect(spawns[0]?.args).not.toContain(`@${result.workerPromptPath}`);
 			expect(spawns[0]?.args).toContain("--no-skills");
 			expect(spawns[0]?.args[0]).toBeTruthy();
 			expect(spawns[0]?.cwd).toBe(result.artifactDir);

--- a/packages/coding-agent/test/contribution-prep.test.ts
+++ b/packages/coding-agent/test/contribution-prep.test.ts
@@ -155,6 +155,10 @@ describe("contribution prep", () => {
 			`'SESSION-TOKEN' = '${SYNTHETIC_AWS_SESSION_TOKEN}'`,
 			`AWS_SECRET_ACCESS_KEY = ${SYNTHETIC_AWS_SECRET_ACCESS_KEY}`,
 			`aws_session_token=${SYNTHETIC_AWS_SESSION_TOKEN}`,
+			`SecretAccessKey=$'${SYNTHETIC_AWS_SECRET_ACCESS_KEY}'`,
+			`SessionToken=$"${SYNTHETIC_AWS_SESSION_TOKEN}"`,
+			`SecretAccessKey=\`${SYNTHETIC_AWS_SECRET_ACCESS_KEY}\``,
+			`?SessionToken=${SYNTHETIC_AWS_SESSION_TOKEN}&status=active`,
 		].join("\n");
 
 		const redacted = redactContributionPrepText(text, process.cwd());
@@ -168,6 +172,20 @@ describe("contribution prep", () => {
 		}
 		expect(redacted).toContain(`"secret_access_key" \t: \t"[REDACTED_SECRET]"`);
 		expect(redacted).toContain(`'SESSION-TOKEN' = '[REDACTED_SECRET]'`);
+		expect(redacted).toContain("SecretAccessKey=$'[REDACTED_SECRET]'");
+		expect(redacted).toContain('SessionToken=$"[REDACTED_SECRET]"');
+		expect(redacted).toContain("SecretAccessKey=`[REDACTED_SECRET]`");
+		expect(redacted).toContain("?SessionToken=[REDACTED_SECRET]&status=active");
+	});
+
+	it("redacts canonical AWS XML fields without changing the document structure", () => {
+		const text = `<Credentials><AccessKeyId>${SYNTHETIC_AWS_TEMPORARY_KEY_ID}</AccessKeyId><SecretAccessKey>${SYNTHETIC_AWS_SECRET_ACCESS_KEY}</SecretAccessKey><sts:SessionToken>${SYNTHETIC_AWS_SESSION_TOKEN}</sts:SessionToken></Credentials>`;
+
+		const redacted = redactContributionPrepText(text, process.cwd());
+
+		expect(redacted).toBe(
+			"<Credentials><AccessKeyId>[REDACTED_AWS_KEY_ID]</AccessKeyId><SecretAccessKey>[REDACTED_SECRET]</SecretAccessKey><sts:SessionToken>[REDACTED_SECRET]</sts:SessionToken></Credentials>",
+		);
 	});
 
 	it("leaves AWS-like prose and key-id near-misses unchanged", () => {
@@ -258,7 +276,7 @@ describe("contribution prep", () => {
 
 			const result = await prepareContributionPrep(
 				{
-					sessionId: "session-123",
+					sessionId: `session-${SYNTHETIC_AWS_ACCESS_KEY_ID}`,
 					cwd: tempDir.path(),
 					messages,
 					sessionFile: path.join(tempDir.path(), "session.jsonl"),
@@ -281,7 +299,7 @@ describe("contribution prep", () => {
 			};
 			const transcriptPath = manifest.artifacts.find(artifact => artifact.path.endsWith("transcript.md"))?.path;
 			expect(manifest.schema_version).toBe(1);
-			expect(manifest.source_session_id).toBe("session-123");
+			expect(manifest.source_session_id).toBe("session-[REDACTED_AWS_KEY_ID]");
 			expect(manifest.worker_prompt_path).toBe(result.workerPromptPath);
 			expect(manifest.recommended_output).toContain("uncertainty / remaining risks");
 			expect(manifest.redactions).toContain("auth_headers");

--- a/packages/coding-agent/test/contribution-prep.test.ts
+++ b/packages/coding-agent/test/contribution-prep.test.ts
@@ -59,6 +59,37 @@ describe("contribution prep", () => {
 		);
 	});
 
+	it("redacts a complete AWS STS credential, not just the key id", () => {
+		// An STS response carries three fields. The key id is the least sensitive of
+		// them; `SecretAccessKey` and `SessionToken` are the credential itself, and
+		// neither canonical field name is matched by the `ENV_*=value` rule, which
+		// only sees the shell spelling `AWS_SECRET_ACCESS_KEY=`.
+		const accessKeyId = "ASIAIOSFODNN7EXAMPLE";
+		const longTermKeyId = "AKIAIOSFODNN7EXAMPLE";
+		const secretAccessKey = "wJalrXUtnFEMI7K7MDENGbPxRfiCYEXAMPLEKEY";
+		const sessionToken = "FwoGZXIvYXdzEBYaDEXAMPLESESSIONTOKENVALUE1234";
+		const text = [
+			`{"AccessKeyId":"${accessKeyId}","SecretAccessKey":"${secretAccessKey}","SessionToken":"${sessionToken}"}`,
+			`long-term ${longTermKeyId}`,
+		].join("\n");
+
+		const redacted = redactContributionPrepText(text, process.cwd());
+
+		expect(redacted).not.toContain(accessKeyId);
+		expect(redacted).not.toContain(longTermKeyId);
+		expect(redacted).not.toContain(secretAccessKey);
+		expect(redacted).not.toContain(sessionToken);
+		// Field names survive so the artifact still says which call was involved.
+		expect(redacted).toContain("SecretAccessKey");
+		expect(redacted).toContain("SessionToken");
+	});
+
+	it("leaves ordinary prose that merely resembles AWS credential names alone", () => {
+		const text = ["ASIAN markets rose", "AKIRA is a film", "the session token expired"].join("\n");
+
+		expect(redactContributionPrepText(text, process.cwd())).toBe(text);
+	});
+
 	it("writes a manifest with redacted file-pointer artifacts", async () => {
 		const tempDir = TempDir.createSync("@gjc-contribution-prep-");
 		try {

--- a/packages/coding-agent/test/contribution-prep.test.ts
+++ b/packages/coding-agent/test/contribution-prep.test.ts
@@ -256,6 +256,26 @@ describe("contribution prep", () => {
 		expect(redacted).toContain("<Region>us-east-1</Region>");
 	});
 
+	it("redacts pretty-printed XML credentials beyond the historical 4096-character boundary", () => {
+		const exactBoundary = `SYNTHETIC_SESSION_TOKEN_${"4".repeat(4072)}`;
+		const overBoundary = `SYNTHETIC_SESSION_TOKEN_${"5".repeat(5000)}`;
+		const text = [
+			"<Credentials>",
+			`<SessionToken>\n${exactBoundary}\n</SessionToken>`,
+			`<sts:SessionToken>\n${overBoundary}\n</sts:SessionToken>`,
+			"<Region>us-east-1</Region>",
+			"</Credentials>",
+		].join("\n");
+
+		const redacted = redactContributionPrepText(text, process.cwd());
+
+		expect(redacted).not.toContain(exactBoundary);
+		expect(redacted).not.toContain(overBoundary);
+		expect(redacted).toContain("<SessionToken>[REDACTED_SECRET]</SessionToken>");
+		expect(redacted).toContain("<sts:SessionToken>[REDACTED_SECRET]</sts:SessionToken>");
+		expect(redacted).toContain("<Region>us-east-1</Region>");
+	});
+
 	it("leaves an empty or whitespace-only XML credential element unchanged", () => {
 		const text = ["<SecretAccessKey></SecretAccessKey>", "<sts:SessionToken>\n\n</sts:SessionToken>"].join("\n");
 

--- a/packages/coding-agent/test/contribution-prep.test.ts
+++ b/packages/coding-agent/test/contribution-prep.test.ts
@@ -148,6 +148,16 @@ describe("contribution prep", () => {
 		expect(redactedOversized).not.toContain(SYNTHETIC_AWS_SECRET_ACCESS_KEY);
 	});
 
+	it("fails closed when redaction input or JSON token counts exceed their budgets", () => {
+		const manyFields = `{${Array.from(
+			{ length: 10001 },
+			(_, index) => `"field${index}":"${SYNTHETIC_AWS_ACCESS_KEY_ID}"`,
+		).join(",")}}`;
+
+		expect(redactContributionPrepText("x".repeat(1_000_001), process.cwd())).toBe("[REDACTED_OVERSIZED_CONTENT]");
+		expect(redactContributionPrepText(manyFields, process.cwd())).toBe("[REDACTED_OVERSIZED_CONTENT]");
+	});
+
 	it("handles AWS credential boundaries, label case, separators, and whitespace", () => {
 		const text = [
 			`long-term (${SYNTHETIC_AWS_ACCESS_KEY_ID})`,
@@ -159,6 +169,7 @@ describe("contribution prep", () => {
 			`SessionToken=$"${SYNTHETIC_AWS_SESSION_TOKEN}"`,
 			`SecretAccessKey=\`${SYNTHETIC_AWS_SECRET_ACCESS_KEY}\``,
 			`?SessionToken=${SYNTHETIC_AWS_SESSION_TOKEN}&status=active`,
+			`?X-Amz-Security-Token=${encodeURIComponent(SYNTHETIC_AWS_SESSION_TOKEN)}&X-Amz-Expires=900`,
 		].join("\n");
 
 		const redacted = redactContributionPrepText(text, process.cwd());
@@ -176,6 +187,7 @@ describe("contribution prep", () => {
 		expect(redacted).toContain('SessionToken=$"[REDACTED_SECRET]"');
 		expect(redacted).toContain("SecretAccessKey=`[REDACTED_SECRET]`");
 		expect(redacted).toContain("?SessionToken=[REDACTED_SECRET]&status=active");
+		expect(redacted).toContain("?X-Amz-Security-Token=[REDACTED_SECRET]&X-Amz-Expires=900");
 	});
 
 	it("redacts canonical AWS XML fields without changing the document structure", () => {
@@ -256,6 +268,19 @@ describe("contribution prep", () => {
 					timestamp: 1,
 				},
 				{
+					role: "toolResult",
+					toolCallId: "synthetic-aws-log",
+					toolName: "read",
+					content: [
+						{
+							type: "text",
+							text: `SecretAccessKey="${SYNTHETIC_AWS_SECRET_ACCESS_KEY}" X-Amz-Security-Token=${SYNTHETIC_AWS_SESSION_TOKEN}`,
+						},
+					],
+					isError: false,
+					timestamp: 3,
+				},
+				{
 					role: "assistant",
 					api: "anthropic-messages",
 					provider: "anthropic",
@@ -296,11 +321,14 @@ describe("contribution prep", () => {
 				recommended_output: string[];
 				worker_prompt_path: string;
 				changed_files: string[];
+				cwd: string;
 			};
 			const transcriptPath = manifest.artifacts.find(artifact => artifact.path.endsWith("transcript.md"))?.path;
 			expect(manifest.schema_version).toBe(1);
 			expect(manifest.source_session_id).toBe("session-[REDACTED_AWS_KEY_ID]");
-			expect(manifest.worker_prompt_path).toBe(result.workerPromptPath);
+			expect(manifest.worker_prompt_path).toBe("worker-prompt.md");
+			expect(manifest.cwd).toBe(path.basename(tempDir.path()));
+			expect(manifest.artifacts.every(artifact => !path.isAbsolute(artifact.path))).toBe(true);
 			expect(manifest.recommended_output).toContain("uncertainty / remaining risks");
 			expect(manifest.redactions).toContain("auth_headers");
 			expect(manifest.redactions).toContain("aws_keys");
@@ -310,19 +338,19 @@ describe("contribution prep", () => {
 			expect(manifest.changed_files).not.toContain(tokenFilename);
 			expect(manifest.changed_files).not.toContain(awsFilename);
 			expect(transcriptPath).toBeTruthy();
-			const transcript = await Bun.file(transcriptPath ?? "").text();
+			const transcript = await Bun.file(path.join(result.artifactDir, transcriptPath ?? "")).text();
 			expect(transcript).toContain("[REDACTED_AUTH_HEADER]");
 			expect(transcript).toContain("[REDACTED_PRIVATE_ENDPOINT]");
 			expect(transcript).not.toContain(transcriptToken);
 			expect(transcript).not.toContain(SYNTHETIC_AWS_SESSION_TOKEN);
 			const summaryPath = manifest.artifacts.find(artifact => artifact.path.endsWith("summary.md"))?.path;
 			expect(summaryPath).toBeTruthy();
-			const summary = await Bun.file(summaryPath ?? "").text();
+			const summary = await Bun.file(path.join(result.artifactDir, summaryPath ?? "")).text();
 			expect(summary).not.toContain(instructionsToken);
 			expect(summary).not.toContain(SYNTHETIC_AWS_SECRET_ACCESS_KEY);
 			const diffPath = manifest.artifacts.find(artifact => artifact.path.endsWith("git-diff.patch"))?.path;
 			expect(diffPath).toBeTruthy();
-			const gitDiff = await Bun.file(diffPath ?? "").text();
+			const gitDiff = await Bun.file(path.join(result.artifactDir, diffPath ?? "")).text();
 			expect(gitDiff).toContain("[REDACTED_TOKEN]");
 			expect(gitDiff).not.toContain("ghs_abcdefghijklmnopqrstuvwxyz123456");
 			expect(gitDiff).not.toContain("github_pat_11ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz1234567890");
@@ -331,7 +359,7 @@ describe("contribution prep", () => {
 			const outboundPaths = [
 				result.manifestPath,
 				result.workerPromptPath,
-				...manifest.artifacts.map(artifact => artifact.path),
+				...manifest.artifacts.map(artifact => path.join(result.artifactDir, artifact.path)),
 			];
 			for (const outboundPath of outboundPaths) {
 				const outboundText = await Bun.file(outboundPath).text();
@@ -343,6 +371,7 @@ describe("contribution prep", () => {
 				]) {
 					expect(outboundText).not.toContain(secret);
 				}
+				expect(outboundText).not.toContain(tempDir.path());
 			}
 		} finally {
 			tempDir.remove();
@@ -373,7 +402,8 @@ describe("contribution prep", () => {
 	it("worker prompt references the manifest instead of inlining transcript", () => {
 		const prompt = buildContributionPrepWorkerPrompt("/tmp/context/manifest.json");
 
-		expect(prompt).toContain("Manifest: /tmp/context/manifest.json");
+		expect(prompt).toContain("Manifest: manifest.json");
+		expect(prompt).not.toContain("/tmp/context");
 		expect(prompt).toContain("file pointers");
 		expect(prompt).toContain("Do not create GitHub issues");
 	});
@@ -399,7 +429,7 @@ describe("contribution prep", () => {
 			expect(spawns[0]?.args).toContain(`@${result.workerPromptPath}`);
 			expect(spawns[0]?.args).toContain("--no-skills");
 			expect(spawns[0]?.args[0]).toBeTruthy();
-			expect(spawns[0]?.cwd).toBe(tempDir.path());
+			expect(spawns[0]?.cwd).toBe(result.artifactDir);
 			expect(manifest.source_session_id).toBe("source-session");
 		} finally {
 			tempDir.remove();

--- a/packages/coding-agent/test/contribution-prep.test.ts
+++ b/packages/coding-agent/test/contribution-prep.test.ts
@@ -10,6 +10,11 @@ import {
 } from "../src/session/contribution-prep";
 import { lookupBuiltinSlashCommand } from "../src/slash-commands/builtin-registry";
 
+const SYNTHETIC_AWS_ACCESS_KEY_ID = `AKIA${"0".repeat(16)}`;
+const SYNTHETIC_AWS_TEMPORARY_KEY_ID = `ASIA${"1".repeat(16)}`;
+const SYNTHETIC_AWS_SECRET_ACCESS_KEY = `SYNTHETIC_SECRET_ACCESS_KEY_${"2".repeat(20)}`;
+const SYNTHETIC_AWS_SESSION_TOKEN = `SYNTHETIC_SESSION_TOKEN_${"3".repeat(20)}+/=`;
+
 describe("contribution prep", () => {
 	it("redacts secrets, private endpoints, cookies, auth headers, and home paths", () => {
 		const text = [
@@ -64,30 +69,106 @@ describe("contribution prep", () => {
 		// them; `SecretAccessKey` and `SessionToken` are the credential itself, and
 		// neither canonical field name is matched by the `ENV_*=value` rule, which
 		// only sees the shell spelling `AWS_SECRET_ACCESS_KEY=`.
-		const accessKeyId = "ASIAIOSFODNN7EXAMPLE";
-		const longTermKeyId = "AKIAIOSFODNN7EXAMPLE";
-		const secretAccessKey = "wJalrXUtnFEMI7K7MDENGbPxRfiCYEXAMPLEKEY";
-		const sessionToken = "FwoGZXIvYXdzEBYaDEXAMPLESESSIONTOKENVALUE1234";
+		const text = JSON.stringify({
+			Credentials: {
+				AccessKeyId: SYNTHETIC_AWS_TEMPORARY_KEY_ID,
+				SecretAccessKey: SYNTHETIC_AWS_SECRET_ACCESS_KEY,
+				SessionToken: SYNTHETIC_AWS_SESSION_TOKEN,
+			},
+		});
+
+		const redacted = redactContributionPrepText(text, process.cwd());
+		const parsed = JSON.parse(redacted) as {
+			Credentials: { AccessKeyId: string; SecretAccessKey: string; SessionToken: string };
+		};
+
+		expect(redacted).not.toContain(SYNTHETIC_AWS_TEMPORARY_KEY_ID);
+		expect(redacted).not.toContain(SYNTHETIC_AWS_SECRET_ACCESS_KEY);
+		expect(redacted).not.toContain(SYNTHETIC_AWS_SESSION_TOKEN);
+		expect(parsed.Credentials).toEqual({
+			AccessKeyId: "[REDACTED_AWS_KEY_ID]",
+			SecretAccessKey: "[REDACTED_SECRET]",
+			SessionToken: "[REDACTED_SECRET]",
+		});
+	});
+
+	it("redacts escaped AWS JSON fields and key ids without invalidating JSON", () => {
+		const text = String.raw`{"\u0053ecretAccessKey":"${SYNTHETIC_AWS_SECRET_ACCESS_KEY}","Session\u0054oken":"${SYNTHETIC_AWS_SESSION_TOKEN}","AccessKeyId":"\u0041${SYNTHETIC_AWS_TEMPORARY_KEY_ID.slice(1)}"}`;
+
+		const redacted = redactContributionPrepText(text, process.cwd());
+		const parsed = JSON.parse(redacted) as {
+			SecretAccessKey: string;
+			SessionToken: string;
+			AccessKeyId: string;
+		};
+
+		expect(parsed).toEqual({
+			SecretAccessKey: "[REDACTED_SECRET]",
+			SessionToken: "[REDACTED_SECRET]",
+			AccessKeyId: "[REDACTED_AWS_KEY_ID]",
+		});
+		expect(redacted).not.toContain(SYNTHETIC_AWS_SECRET_ACCESS_KEY);
+		expect(redacted).not.toContain(SYNTHETIC_AWS_SESSION_TOKEN);
+		expect(redacted).not.toContain(SYNTHETIC_AWS_TEMPORARY_KEY_ID.slice(1));
+	});
+
+	it("handles AWS credential boundaries, label case, separators, and whitespace", () => {
 		const text = [
-			`{"AccessKeyId":"${accessKeyId}","SecretAccessKey":"${secretAccessKey}","SessionToken":"${sessionToken}"}`,
-			`long-term ${longTermKeyId}`,
+			`long-term (${SYNTHETIC_AWS_ACCESS_KEY_ID})`,
+			`"secret_access_key" \t: \t"${SYNTHETIC_AWS_SECRET_ACCESS_KEY}"`,
+			`'SESSION-TOKEN' = '${SYNTHETIC_AWS_SESSION_TOKEN}'`,
+			`AWS_SECRET_ACCESS_KEY = ${SYNTHETIC_AWS_SECRET_ACCESS_KEY}`,
+			`aws_session_token=${SYNTHETIC_AWS_SESSION_TOKEN}`,
 		].join("\n");
 
 		const redacted = redactContributionPrepText(text, process.cwd());
 
-		expect(redacted).not.toContain(accessKeyId);
-		expect(redacted).not.toContain(longTermKeyId);
-		expect(redacted).not.toContain(secretAccessKey);
-		expect(redacted).not.toContain(sessionToken);
-		// Field names survive so the artifact still says which call was involved.
-		expect(redacted).toContain("SecretAccessKey");
-		expect(redacted).toContain("SessionToken");
+		for (const secret of [
+			SYNTHETIC_AWS_ACCESS_KEY_ID,
+			SYNTHETIC_AWS_SECRET_ACCESS_KEY,
+			SYNTHETIC_AWS_SESSION_TOKEN,
+		]) {
+			expect(redacted).not.toContain(secret);
+		}
+		expect(redacted).toContain(`"secret_access_key" \t: \t"[REDACTED_SECRET]"`);
+		expect(redacted).toContain(`'SESSION-TOKEN' = '[REDACTED_SECRET]'`);
 	});
 
-	it("leaves ordinary prose that merely resembles AWS credential names alone", () => {
-		const text = ["ASIAN markets rose", "AKIRA is a film", "the session token expired"].join("\n");
+	it("leaves AWS-like prose and key-id near-misses unchanged", () => {
+		const text = [
+			"ASIAN markets rose",
+			"AKIRA is a film",
+			"the session token expired",
+			"rotate the secret access key tomorrow",
+			`prefix${SYNTHETIC_AWS_ACCESS_KEY_ID}`,
+			`${SYNTHETIC_AWS_ACCESS_KEY_ID}suffix`,
+		].join("\n");
 
 		expect(redactContributionPrepText(text, process.cwd())).toBe(text);
+	});
+
+	it("preserves delimiters and existing token redaction behavior around AWS fields", () => {
+		const githubToken = "ghs_abcdefghijklmnopqrstuvwxyz123456";
+		const slackToken = "xoxb-abcdefghijklmnopqrstuvwxyz123456";
+		const benignAssignment = "notSecretAccessKey=SYNTHETIC_PUBLIC_VALUE";
+		const text = [
+			`trace_${SYNTHETIC_AWS_ACCESS_KEY_ID}_suffix`,
+			`invoke(SessionToken=${SYNTHETIC_AWS_SESSION_TOKEN});`,
+			`SecretAccessKey=${githubToken}`,
+			`SessionToken=${slackToken}`,
+			benignAssignment,
+		].join("\n");
+
+		const redacted = redactContributionPrepText(text, process.cwd());
+
+		expect(redacted).toContain("trace_[REDACTED_AWS_KEY_ID]_suffix");
+		expect(redacted).toContain("invoke(SessionToken=[REDACTED_SECRET]);");
+		expect(redacted).toContain("SecretAccessKey=[REDACTED_SECRET]");
+		expect(redacted).toContain("SessionToken=[REDACTED_SECRET]");
+		expect(redacted).not.toContain("[REDACTED_SECRET]]");
+		expect(redacted).not.toContain(githubToken);
+		expect(redacted).not.toContain(slackToken);
+		expect(redacted).toContain(benignAssignment);
 	});
 
 	it("writes a manifest with redacted file-pointer artifacts", async () => {
@@ -98,15 +179,21 @@ describe("contribution prep", () => {
 			await $`git add tracked.txt`.cwd(tempDir.path()).quiet();
 			await $`git -c user.email=test@example.com -c user.name=Test commit -m initial`.cwd(tempDir.path()).quiet();
 			const tokenFilename = "ghs_abcdefghijklmnopqrstuvwxyz123456.txt";
+			const awsFilename = `aws-${SYNTHETIC_AWS_ACCESS_KEY_ID}.txt`;
 			const transcriptToken = "ghu_abcdefghijklmnopqrstuvwxyz123456";
 			const instructionsToken = "ghr_abcdefghijklmnopqrstuvwxyz123456";
 			await Bun.write(
 				path.join(tempDir.path(), "tracked.txt"),
-				"changed ghs_abcdefghijklmnopqrstuvwxyz123456 github_pat_11ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz1234567890\n",
+				`changed ghs_abcdefghijklmnopqrstuvwxyz123456 github_pat_11ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz1234567890 ${SYNTHETIC_AWS_TEMPORARY_KEY_ID} SecretAccessKey=${SYNTHETIC_AWS_SECRET_ACCESS_KEY}\n`,
 			);
 			await Bun.write(path.join(tempDir.path(), tokenFilename), "untracked");
+			await Bun.write(path.join(tempDir.path(), awsFilename), "untracked");
 			const messages: AgentMessage[] = [
-				{ role: "user", content: "Failure uses Authorization: Bearer ghp_secretsecretsecret", timestamp: 1 },
+				{
+					role: "user",
+					content: `Failure uses Authorization: Bearer ghp_secretsecretsecret and SessionToken: ${SYNTHETIC_AWS_SESSION_TOKEN}`,
+					timestamp: 1,
+				},
 				{
 					role: "assistant",
 					api: "anthropic-messages",
@@ -135,7 +222,7 @@ describe("contribution prep", () => {
 				},
 				{
 					artifactRoot: path.join(tempDir.path(), "artifacts"),
-					customInstructions: `Include ${instructionsToken}`,
+					customInstructions: `Include ${instructionsToken}; AWS_SECRET_ACCESS_KEY=${SYNTHETIC_AWS_SECRET_ACCESS_KEY}`,
 					now: new Date("2026-05-31T00:00:00.000Z"),
 				},
 			);
@@ -155,24 +242,47 @@ describe("contribution prep", () => {
 			expect(manifest.worker_prompt_path).toBe(result.workerPromptPath);
 			expect(manifest.recommended_output).toContain("uncertainty / remaining risks");
 			expect(manifest.redactions).toContain("auth_headers");
+			expect(manifest.redactions).toContain("aws_keys");
 			expect(manifest.redactions).toContain("private_endpoints");
 			expect(manifest.changed_files).toContain("[REDACTED_TOKEN].txt");
+			expect(manifest.changed_files).toContain("aws-[REDACTED_AWS_KEY_ID].txt");
 			expect(manifest.changed_files).not.toContain(tokenFilename);
+			expect(manifest.changed_files).not.toContain(awsFilename);
 			expect(transcriptPath).toBeTruthy();
 			const transcript = await Bun.file(transcriptPath ?? "").text();
 			expect(transcript).toContain("[REDACTED_AUTH_HEADER]");
 			expect(transcript).toContain("[REDACTED_PRIVATE_ENDPOINT]");
 			expect(transcript).not.toContain(transcriptToken);
+			expect(transcript).not.toContain(SYNTHETIC_AWS_SESSION_TOKEN);
 			const summaryPath = manifest.artifacts.find(artifact => artifact.path.endsWith("summary.md"))?.path;
 			expect(summaryPath).toBeTruthy();
 			const summary = await Bun.file(summaryPath ?? "").text();
 			expect(summary).not.toContain(instructionsToken);
+			expect(summary).not.toContain(SYNTHETIC_AWS_SECRET_ACCESS_KEY);
 			const diffPath = manifest.artifacts.find(artifact => artifact.path.endsWith("git-diff.patch"))?.path;
 			expect(diffPath).toBeTruthy();
 			const gitDiff = await Bun.file(diffPath ?? "").text();
 			expect(gitDiff).toContain("[REDACTED_TOKEN]");
 			expect(gitDiff).not.toContain("ghs_abcdefghijklmnopqrstuvwxyz123456");
 			expect(gitDiff).not.toContain("github_pat_11ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz1234567890");
+			expect(gitDiff).not.toContain(SYNTHETIC_AWS_TEMPORARY_KEY_ID);
+			expect(gitDiff).not.toContain(SYNTHETIC_AWS_SECRET_ACCESS_KEY);
+			const outboundPaths = [
+				result.manifestPath,
+				result.workerPromptPath,
+				...manifest.artifacts.map(artifact => artifact.path),
+			];
+			for (const outboundPath of outboundPaths) {
+				const outboundText = await Bun.file(outboundPath).text();
+				for (const secret of [
+					SYNTHETIC_AWS_ACCESS_KEY_ID,
+					SYNTHETIC_AWS_TEMPORARY_KEY_ID,
+					SYNTHETIC_AWS_SECRET_ACCESS_KEY,
+					SYNTHETIC_AWS_SESSION_TOKEN,
+				]) {
+					expect(outboundText).not.toContain(secret);
+				}
+			}
 		} finally {
 			tempDir.remove();
 		}

--- a/packages/coding-agent/test/contribution-prep.test.ts
+++ b/packages/coding-agent/test/contribution-prep.test.ts
@@ -216,6 +216,52 @@ describe("contribution prep", () => {
 		);
 	});
 
+	it("redacts pretty-printed AWS XML whose value sits on its own line", () => {
+		// A real STS response is usually pretty-printed, so the value is separated
+		// from its tags by a newline and indentation. Matching only same-line bodies
+		// let the complete credential through while the compact form was redacted.
+		const text = [
+			"<Credentials>",
+			`  <AccessKeyId>${SYNTHETIC_AWS_TEMPORARY_KEY_ID}</AccessKeyId>`,
+			"  <SecretAccessKey>",
+			`    ${SYNTHETIC_AWS_SECRET_ACCESS_KEY}`,
+			"  </SecretAccessKey>",
+			"  <sts:SessionToken>",
+			`    ${SYNTHETIC_AWS_SESSION_TOKEN}`,
+			"  </sts:SessionToken>",
+			"</Credentials>",
+		].join("\n");
+
+		const redacted = redactContributionPrepText(text, process.cwd());
+
+		expect(redacted).not.toContain(SYNTHETIC_AWS_SECRET_ACCESS_KEY);
+		expect(redacted).not.toContain(SYNTHETIC_AWS_SESSION_TOKEN);
+		expect(redacted).not.toContain(SYNTHETIC_AWS_TEMPORARY_KEY_ID);
+		// The element names survive, so the artifact still records the shape.
+		expect(redacted).toContain("<SecretAccessKey>");
+		expect(redacted).toContain("</sts:SessionToken>");
+	});
+
+	it("does not let a multiline XML match swallow a following element", () => {
+		const text = [
+			"<SecretAccessKey>",
+			`  ${SYNTHETIC_AWS_SECRET_ACCESS_KEY}`,
+			"</SecretAccessKey>",
+			"<Region>us-east-1</Region>",
+		].join("\n");
+
+		const redacted = redactContributionPrepText(text, process.cwd());
+
+		expect(redacted).not.toContain(SYNTHETIC_AWS_SECRET_ACCESS_KEY);
+		expect(redacted).toContain("<Region>us-east-1</Region>");
+	});
+
+	it("leaves an empty or whitespace-only XML credential element unchanged", () => {
+		const text = ["<SecretAccessKey></SecretAccessKey>", "<sts:SessionToken>\n\n</sts:SessionToken>"].join("\n");
+
+		expect(redactContributionPrepText(text, process.cwd())).toBe(text);
+	});
+
 	it("leaves AWS-like prose and key-id near-misses unchanged", () => {
 		const text = [
 			"ASIAN markets rose",

--- a/packages/coding-agent/test/contribution-prep.test.ts
+++ b/packages/coding-agent/test/contribution-prep.test.ts
@@ -147,12 +147,27 @@ describe("contribution prep", () => {
 
 		const redactedDeep = redactContributionPrepText(deeplyNested, process.cwd());
 		const redactedOversized = redactContributionPrepText(oversized, process.cwd());
+		const oversizedPayload = JSON.parse(redactedOversized) as { payload: string };
 
 		expect(JSON.parse(redactedDeep)).toBeDefined();
-		expect(JSON.parse(redactedOversized)).toEqual({ payload: "[REDACTED_NESTED_JSON]" });
-		expect(redactedDeep).toContain("[REDACTED_NESTED_JSON]");
+		expect(JSON.parse(oversizedPayload.payload)).toEqual({
+			padding: "x".repeat(60001),
+			SecretAccessKey: "[REDACTED_SECRET]",
+		});
+		expect(redactedDeep).toContain("[REDACTED_NESTED_CONTENT]");
 		expect(redactedDeep).not.toContain(SYNTHETIC_AWS_SESSION_TOKEN);
 		expect(redactedOversized).not.toContain(SYNTHETIC_AWS_SECRET_ACCESS_KEY);
+	});
+
+	it("redacts escaped AWS fields inside long prefixed and suffixed log strings", () => {
+		const longLog = `${"x".repeat(60001)} prefix ${String.raw`{"\u0053ecretAccessKey":"${SYNTHETIC_AWS_SECRET_ACCESS_KEY}"}`} suffix`;
+		const text = JSON.stringify([{ type: "text", text: longLog }]);
+
+		const redacted = redactContributionPrepText(text, process.cwd());
+
+		expect(JSON.parse(redacted)).toBeDefined();
+		expect(redacted).not.toContain(SYNTHETIC_AWS_SECRET_ACCESS_KEY);
+		expect(redacted).toContain("[REDACTED_SECRET]");
 	});
 
 	it("fails closed when redaction input or JSON token counts exceed their budgets", () => {
@@ -364,6 +379,19 @@ describe("contribution prep", () => {
 					],
 					isError: false,
 					timestamp: 3,
+				},
+				{
+					role: "toolResult",
+					toolCallId: "synthetic-long-aws-log",
+					toolName: "read",
+					content: [
+						{
+							type: "text",
+							text: `${"x".repeat(60001)} prefix ${String.raw`{"\u0053ecretAccessKey":"${SYNTHETIC_AWS_SECRET_ACCESS_KEY}"}`} suffix`,
+						},
+					],
+					isError: false,
+					timestamp: 4,
 				},
 				{
 					role: "assistant",

--- a/packages/coding-agent/test/contribution-prep.test.ts
+++ b/packages/coding-agent/test/contribution-prep.test.ts
@@ -112,6 +112,22 @@ describe("contribution prep", () => {
 		expect(redacted).not.toContain(SYNTHETIC_AWS_TEMPORARY_KEY_ID.slice(1));
 	});
 
+	it("redacts AWS credentials inside nested serialized JSON", () => {
+		const inner = String.raw`{"Session\u0054oken":"${SYNTHETIC_AWS_SESSION_TOKEN}","AccessKeyId":"\u0041${SYNTHETIC_AWS_TEMPORARY_KEY_ID.slice(1)}"}`;
+		const text = JSON.stringify({ payload: inner });
+
+		const redacted = redactContributionPrepText(text, process.cwd());
+		const outer = JSON.parse(redacted) as { payload: string };
+		const payload = JSON.parse(outer.payload) as { SessionToken: string; AccessKeyId: string };
+
+		expect(payload).toEqual({
+			SessionToken: "[REDACTED_SECRET]",
+			AccessKeyId: "[REDACTED_AWS_KEY_ID]",
+		});
+		expect(redacted).not.toContain(SYNTHETIC_AWS_SESSION_TOKEN);
+		expect(redacted).not.toContain(SYNTHETIC_AWS_TEMPORARY_KEY_ID.slice(1));
+	});
+
 	it("handles AWS credential boundaries, label case, separators, and whitespace", () => {
 		const text = [
 			`long-term (${SYNTHETIC_AWS_ACCESS_KEY_ID})`,
@@ -191,7 +207,10 @@ describe("contribution prep", () => {
 			const messages: AgentMessage[] = [
 				{
 					role: "user",
-					content: `Failure uses Authorization: Bearer ghp_secretsecretsecret and SessionToken: ${SYNTHETIC_AWS_SESSION_TOKEN}`,
+					content: JSON.stringify({
+						log: `Failure uses Authorization: Bearer ghp_secretsecretsecret and SessionToken: ${SYNTHETIC_AWS_SESSION_TOKEN}`,
+						payload: JSON.stringify({ SecretAccessKey: SYNTHETIC_AWS_SECRET_ACCESS_KEY }),
+					}),
 					timestamp: 1,
 				},
 				{
@@ -283,6 +302,27 @@ describe("contribution prep", () => {
 					expect(outboundText).not.toContain(secret);
 				}
 			}
+		} finally {
+			tempDir.remove();
+		}
+	});
+
+	it("rejects credential-shaped artifact paths without echoing them", async () => {
+		const tempDir = TempDir.createSync("@gjc-contribution-prep-path-");
+		try {
+			const artifactRoot = path.join(tempDir.path(), `unsafe-${SYNTHETIC_AWS_ACCESS_KEY_ID}`);
+			let error: Error | undefined;
+			try {
+				await prepareContributionPrep(
+					{ sessionId: "source-session", cwd: tempDir.path(), messages: [] },
+					{ artifactRoot, now: new Date("2026-05-31T00:00:00.000Z") },
+				);
+			} catch (caught) {
+				error = caught instanceof Error ? caught : new Error(String(caught));
+			}
+
+			expect(error?.message).toBe("Contribution prep artifact path contains credential-like material.");
+			expect(error?.message).not.toContain(SYNTHETIC_AWS_ACCESS_KEY_ID);
 		} finally {
 			tempDir.remove();
 		}

--- a/packages/coding-agent/test/contribution-prep.test.ts
+++ b/packages/coding-agent/test/contribution-prep.test.ts
@@ -128,6 +128,26 @@ describe("contribution prep", () => {
 		expect(redacted).not.toContain(SYNTHETIC_AWS_TEMPORARY_KEY_ID.slice(1));
 	});
 
+	it("fails closed at nested JSON depth and size limits", () => {
+		let deeplyNested = JSON.stringify({ SessionToken: SYNTHETIC_AWS_SESSION_TOKEN });
+		for (let depth = 0; depth < 5; depth++) deeplyNested = JSON.stringify({ payload: deeplyNested });
+		const oversized = JSON.stringify({
+			payload: JSON.stringify({
+				padding: "x".repeat(60001),
+				SecretAccessKey: SYNTHETIC_AWS_SECRET_ACCESS_KEY,
+			}),
+		});
+
+		const redactedDeep = redactContributionPrepText(deeplyNested, process.cwd());
+		const redactedOversized = redactContributionPrepText(oversized, process.cwd());
+
+		expect(JSON.parse(redactedDeep)).toBeDefined();
+		expect(JSON.parse(redactedOversized)).toEqual({ payload: "[REDACTED_NESTED_JSON]" });
+		expect(redactedDeep).toContain("[REDACTED_NESTED_JSON]");
+		expect(redactedDeep).not.toContain(SYNTHETIC_AWS_SESSION_TOKEN);
+		expect(redactedOversized).not.toContain(SYNTHETIC_AWS_SECRET_ACCESS_KEY);
+	});
+
 	it("handles AWS credential boundaries, label case, separators, and whitespace", () => {
 		const text = [
 			`long-term (${SYNTHETIC_AWS_ACCESS_KEY_ID})`,
@@ -166,13 +186,17 @@ describe("contribution prep", () => {
 	it("preserves delimiters and existing token redaction behavior around AWS fields", () => {
 		const githubToken = "ghs_abcdefghijklmnopqrstuvwxyz123456";
 		const slackToken = "xoxb-abcdefghijklmnopqrstuvwxyz123456";
-		const benignAssignment = "notSecretAccessKey=SYNTHETIC_PUBLIC_VALUE";
+		const benignAssignments = [
+			"notSecretAccessKey=SYNTHETIC_PUBLIC_VALUE",
+			"not-SecretAccessKey=SYNTHETIC_PUBLIC_VALUE",
+			'"not-SecretAccessKey":"SYNTHETIC_PUBLIC_VALUE"',
+		];
 		const text = [
 			`trace_${SYNTHETIC_AWS_ACCESS_KEY_ID}_suffix`,
 			`invoke(SessionToken=${SYNTHETIC_AWS_SESSION_TOKEN});`,
 			`SecretAccessKey=${githubToken}`,
 			`SessionToken=${slackToken}`,
-			benignAssignment,
+			...benignAssignments,
 		].join("\n");
 
 		const redacted = redactContributionPrepText(text, process.cwd());
@@ -184,7 +208,7 @@ describe("contribution prep", () => {
 		expect(redacted).not.toContain("[REDACTED_SECRET]]");
 		expect(redacted).not.toContain(githubToken);
 		expect(redacted).not.toContain(slackToken);
-		expect(redacted).toContain(benignAssignment);
+		for (const benignAssignment of benignAssignments) expect(redacted).toContain(benignAssignment);
 	});
 
 	it("writes a manifest with redacted file-pointer artifacts", async () => {


### PR DESCRIPTION
## What

- Redact AKIA/ASIA access-key IDs and complete AWS `SecretAccessKey` / `SessionToken` / `X-Amz-Security-Token` values from contribution-prep outbound artifacts.
- Preserve direct, escaped, and bounded nested JSON; fail closed on oversized input and at the explicit recursion boundary.
- Continue scanning long decoded JSON-string/log content within the one-million-character call-wide budget so prefixed/suffixed Unicode-escaped credential fragments cannot bypass redaction.
- Preserve shell, JSON, compact/pretty-printed XML, and query-string delimiters across canonical AWS credential forms, including JSON-escaped tool-result logs.
- Redact multiline XML credential bodies without assuming an STS token maximum; child-element delimiters remain hard stops.
- Reject credential-shaped artifact paths with a non-echoing error and redact source-session metadata.
- Export manifest artifact pointers as relative names and launch the delegated worker from the artifact directory using an artifact-relative prompt argument.
- Preserve existing GitHub, Slack, bearer/auth-header, and cookie redaction behavior.
- Add synthetic-only boundary, case, whitespace, JSON, overlap, benign-prose, short/long log and tool-result, nested/oversized payload, workload-bound, shell-quote, compact/multiline/large XML, query/SigV4, unsafe-path, metadata, and all-artifact regression coverage.
- Record the public behavior change in the coding-agent changelog.

## Why

Contribution-prep artifacts leave the local machine. The prior outbound scrubber covered GitHub, Slack, bearer/auth headers, cookies, provider assignments, private endpoints, and paths, but complete AWS STS/SigV4 credentials could survive in structured/tool output. Contributor and maintainer commits closed canonical, escaped/nested JSON, scan-limit, delimiter, overlap, false-positive, shell-quote, XML/query/SigV4, tool-result serialization, workload-bound, metadata, structural-corruption, and artifact-pointer boundaries. Authenticated human reviews 5120079947 and 5120267998 found multiline XML and long decoded log bypasses; both are fixed-forwarded with synthetic end-to-end regressions.

Contributor authorship and unique commits are preserved. The branch is merge-reconciled onto current `dev@4e3b81855e3f9da7888fb74de15f5b54f70637d8`; the changelog conflict retained both independent entries. No real credentials were used or published.

## Testing

Exact base/head: `4e3b81855e3f9da7888fb74de15f5b54f70637d8...6aab7f2fb09656e549aaaf0f8d87a5f48c309c74`

- `bun test packages/coding-agent/test/contribution-prep.test.ts` — 22 pass, 151 assertions
- `bun --cwd=packages/coding-agent run check` — pass
- `bun --cwd=packages/coding-agent run build` — pass
- Hosted exact-head Dev CI: https://github.com/Yeachan-Heo/gajae-code/actions/runs/33952199599 (in progress at contract update)
- Authenticated write-authority security review 5120344183 approved this exact head; advisory review is not used as merge authority.
- Human reviews 5120079947 and 5120267998 are stale `CHANGES_REQUESTED` reviews whose findings were fixed; exact-head review 5120344183 is `APPROVED`.

## Risk classification

- [ ] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [x] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:a6675bd1dcee5b8916b30343066aa7380be0edc67cfb2e4530e4227e353dee6d reviewer:human reviewer-id:probepark evidence:https://github.com/Yeachan-Heo/gajae-code/pull/5299#pullrequestreview-5120344183
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken