### PR TITLE
test(chat): await replay cursor settlement

### DIFF
--- a/packages/coding-agent/test/chat-daemon-session-reconnect.test.ts
+++ b/packages/coding-agent/test/chat-daemon-session-reconnect.test.ts
@@ -826,7 +826,7 @@ test("an unreachable attached chat session exhausts its long-lived reconnect bud
 }, 20_000);
 
 test("an established chat attachment that loses its open socket resumes from its last acknowledged event", async () => {
-	await withAttachedSessionRuntime(async ({ runtime, provider, reconcile }) => {
+	await withAttachedSessionRuntime(async ({ runtime, provider, reconcile, awaitFrameSettlement }) => {
 		await withSerializedFakeTransport(async () => {
 			const host = new FakeSessionHost();
 			const starting = runtime.start();
@@ -834,7 +834,8 @@ test("an established chat attachment that loses its open socket resumes from its
 			await starting;
 
 			host.emit("before the drop");
-			await awaitCompletedPosts(provider, 1);
+			await awaitFrameSettlement(GENERATION, 1);
+			expect(provider.posts).toHaveLength(1);
 
 			// Drop the already-attached, already-active socket, then keep the session
 			// producing: these events exist only in the host's log until delivery resumes.


### PR DESCRIPTION
## What

Synchronize the chat-daemon reconnect regression on the router's acknowledged sequence cursor before forcing a socket drop.

## Why

Authoritative dev CI run 33945756253 failed only in shard-8 job 101253068080 because the test observed fake Slack completion but did not prove `SessionRouter` had advanced to generation 4 sequence 1. Under shard contention, reconnect could therefore legitimately request sequence 0. This is a test synchronization defect, not a product replay race.

Source: `dev@25b460c2b4dcae20a031e9376c5266b2b6f8a5e7`.

PR #5283 overlap was inspected and does not touch this test file. Downstream jobs 101255674569 and 101255722830 are fail-closed aggregates of the same root failure.

## Testing

- exact target test: 200/200 repeated passes
- full reconnect test file: 5/5 serial repeated passes
- `bun --cwd=packages/coding-agent run check`
- `bun --cwd=packages/coding-agent run build`
- independent architecture review: approve, no findings
- independent Ultragoal red-team review: approve, no findings
- signed evidence: https://github.com/Yeachan-Heo/gajae-code/pull/5302#issuecomment-5549743620

A separate existing timeout appeared once only when the full-file stress loop competed with package check/build; it passed in all five serial reruns and is outside this exact ownership item.

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:18405a739e69128b2b9c184e38be33bedaa986a545e152df4528e7f4eba69e0e reviewer:human reviewer-id:Yeachan-Heo evidence:dev CI run 33945756253 root failure repaired with 200 exact repeated passes
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing) — not user-facing; unchanged
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken