### PR TITLE
docs(readme): promote community app CTA

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -22,6 +22,12 @@
 </p>
 
 <p align="center">
+  <a href="https://github.com/devswha/gajae-code-app"><kbd><strong>🖥️ Gajae-Code App を見る → デスクトップ＆セルフホスト Web GUI</strong></kbd></a>
+  <br/>
+  <sub>コミュニティ製の実験的なサードパーティープロジェクトであり、Gajae-Code 公式のファーストパーティーアプリではありません。</sub>
+</p>
+
+<p align="center">
   <a href="#クイックスタート">クイックスタート</a> ·
   <a href="#なぜ-gajae-code-なのか">なぜ</a> ·
   <a href="#手持ちのコーディングプランで">コーディングプラン</a> ·

--- a/README.ko.md
+++ b/README.ko.md
@@ -22,6 +22,12 @@
 </p>
 
 <p align="center">
+  <a href="https://github.com/devswha/gajae-code-app"><kbd><strong>🖥️ Gajae-Code App 살펴보기 → 데스크톱·셀프 호스팅 웹 GUI</strong></kbd></a>
+  <br/>
+  <sub>커뮤니티가 만드는 실험적 서드파티 프로젝트이며, Gajae-Code의 공식 퍼스트파티 앱이 아닙니다.</sub>
+</p>
+
+<p align="center">
   <a href="#빠른-시작">빠른 시작</a> ·
   <a href="#왜-gajae-code인가">왜</a> ·
   <a href="#쓰던-코딩-플랜-그대로">코딩 플랜</a> ·

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/devswha/gajae-code-app"><strong>🖥️ Desktop app (experimental, community-built)</strong></a> — a third-party, community-built desktop interface for Gajae-Code. Not an official first-party app; use at your own discretion.
+  <a href="https://github.com/devswha/gajae-code-app"><kbd><strong>🖥️ Explore Gajae-Code App → Desktop &amp; self-hosted web GUI</strong></kbd></a>
+  <br/>
+  <sub>Experimental, community-built third-party project — not an official first-party Gajae-Code app.</sub>
 </p>
 
 <p align="center">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,6 +22,12 @@
 </p>
 
 <p align="center">
+  <a href="https://github.com/devswha/gajae-code-app"><kbd><strong>🖥️ 探索 Gajae-Code App → 桌面端与自托管 Web GUI</strong></kbd></a>
+  <br/>
+  <sub>这是由社区构建的实验性第三方项目，并非 Gajae-Code 官方第一方应用。</sub>
+</p>
+
+<p align="center">
   <a href="#快速开始">快速开始</a> ·
   <a href="#为什么选-gajae-code">为什么</a> ·
   <a href="#带上你的编程订阅">编程订阅</a> ·


### PR DESCRIPTION
## Summary

- promote Gajae-Code App as a button-like CTA in the top hero area
- add natural Korean, Simplified Chinese, and Japanese CTA copy
- keep the experimental community/third-party and non-official boundary explicit

## Risk classification

- [x] `low-risk`
- [ ] `regression-risk`
- [ ] `high-risk`

## Validation

- GitHub GFM API rendered all four READMEs with the exact clickable app link and `<kbd>` CTA
- `git diff --check`
- `bun test scripts/install-tests/install-docs-contract.test.ts`
- `bun scripts/rebrand-inventory.ts --strict`
- affected CI planner returned no required jobs for the README-only diff
- signed low-risk owner review record is bound to the latest exact base/head/diff digest
- Prettier reports the same four files as unformatted on `origin/dev`; no broad baseline reformat was included

gajae.pr-review-verdict.v1 merge-self-approved sha256:b376adc8f5169ab1349b688c5c7fcc5364b707e504632df0f9b5d82084589fbc reviewer:human reviewer-id:Yeachan-Heo evidence:independent architect review of equivalent rebased diff; GitHub GFM and focused docs validation passed

Fixes #5303

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
