### PR TITLE
fix(tools): bound the module-global read-URL cache

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 
+- The read-URL cache is now bounded (FIFO, 64 keys), so long-lived TUI and SDK-host processes no longer retain every fetched page's full output and image payload for the process lifetime; an evicted entry simply refetches on the next read.
 - Contribution-prep outbound artifacts now redact complete AWS credentials, including AKIA/ASIA access-key IDs and SecretAccessKey/SessionToken values in shell-style and escaped JSON forms, while preserving structured output and existing GitHub, Slack, authorization-header, and cookie redaction.
 - Model preset registry URL and disable overrides now resolve only from explicitly inherited or user-owned environment sources, so a checkout `.env` cannot suppress updates or redirect signed-registry polling while dependency injection, HTTPS validation, signatures, ETags, cache, and offline behavior remain unchanged (#5300).
 - OpenCode Go's provider conversation identity now remains distinct from generic cache affinity across normal turns and maintenance calls, so the required session header reuses the session manager's opaque lifecycle without accepting auth-gateway prompt-derived cache keys (#5295).

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ### Fixed
 
-- The read-URL cache is now bounded (FIFO, 64 keys), so long-lived TUI and SDK-host processes no longer retain every fetched page's full output and image payload for the process lifetime; an evicted entry simply refetches on the next read.
+- The read-URL cache is now bounded (FIFO, 64 keys), so long-lived TUI and SDK-host processes no longer retain every fetched page's full output and image payload for the process lifetime; an evicted entry simply refetches on the next read, and unpersisted sessions sharing a working directory remain isolated by session identity.
 - Contribution-prep outbound artifacts now redact complete AWS credentials, including AKIA/ASIA access-key IDs and SecretAccessKey/SessionToken values in shell-style and escaped JSON forms, while preserving structured output and existing GitHub, Slack, authorization-header, and cookie redaction.
 - Model preset registry URL and disable overrides now resolve only from explicitly inherited or user-owned environment sources, so a checkout `.env` cannot suppress updates or redirect signed-registry polling while dependency injection, HTTPS validation, signatures, ETags, cache, and offline behavior remain unchanged (#5300).
 - OpenCode Go's provider conversation identity now remains distinct from generic cache affinity across normal turns and maintenance calls, so the required session header reuses the session manager's opaque lifecycle without accepting auth-gateway prompt-derived cache keys (#5295).

--- a/packages/coding-agent/src/tools/fetch.ts
+++ b/packages/coding-agent/src/tools/fetch.ts
@@ -1167,6 +1167,12 @@ interface ReadUrlCacheEntry {
 	wrappedPreambleChars?: number;
 }
 
+// Entries hold whole-page outputs and image payloads, so this map must stay
+// bounded in long-lived hosts (TUI, SDK broker). Each fetch caches one entry
+// under up to two keys (requested + final URL). FIFO eviction is sufficient:
+// a miss simply refetches, so correctness never depends on a hit.
+export const READ_URL_CACHE_MAX_KEYS = 64;
+
 const readUrlCache = new Map<string, ReadUrlCacheEntry>();
 
 function getReadUrlCacheKey(session: ToolSession, requestedUrl: string, raw: boolean): string {
@@ -1224,6 +1230,11 @@ async function ensureReadUrlCacheArtifact(session: ToolSession, entry: ReadUrlCa
 function cacheReadUrlEntry(session: ToolSession, requestedUrl: string, raw: boolean, entry: ReadUrlCacheEntry): void {
 	readUrlCache.set(getReadUrlCacheKey(session, requestedUrl, raw), entry);
 	readUrlCache.set(getReadUrlCacheKey(session, entry.details.finalUrl, raw), entry);
+	while (readUrlCache.size > READ_URL_CACHE_MAX_KEYS) {
+		const oldest = readUrlCache.keys().next().value;
+		if (oldest === undefined) break;
+		readUrlCache.delete(oldest);
+	}
 }
 
 async function buildReadUrlCacheEntry(

--- a/packages/coding-agent/src/tools/fetch.ts
+++ b/packages/coding-agent/src/tools/fetch.ts
@@ -1176,9 +1176,26 @@ export const READ_URL_CACHE_MAX_KEYS = 64;
 const readUrlCache = new Map<string, ReadUrlCacheEntry>();
 
 function getReadUrlCacheKey(session: ToolSession, requestedUrl: string, raw: boolean): string {
-	const scope = session.getSessionFile() ?? session.cwd;
+	const sessionFile = session.getSessionFile();
+	const sessionId = session.getSessionId?.();
+	const scope = sessionFile ? `file:${sessionFile}` : sessionId ? `session:${sessionId}` : `cwd:${session.cwd}`;
 	return `${scope}::${raw ? "raw" : "rendered"}::${normalizeUrl(requestedUrl)}`;
 }
+
+/** Test-only seam for deterministic module-global cache assertions. */
+export const readUrlCacheTestHooks = {
+	get size(): number {
+		return readUrlCache.size;
+	},
+	get retainedOutputChars(): number {
+		let total = 0;
+		for (const entry of new Set(readUrlCache.values())) total += entry.output.length;
+		return total;
+	},
+	reset(): void {
+		readUrlCache.clear();
+	},
+};
 
 async function readArtifactOutput(session: ToolSession, artifactId: string): Promise<string | null> {
 	const artifactsDir = session.getArtifactsDir?.();

--- a/packages/coding-agent/test/tools/fetch-url-cache-bound.test.ts
+++ b/packages/coding-agent/test/tools/fetch-url-cache-bound.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import type { ToolSession } from "@gajae-code/coding-agent/tools";
+import { loadReadUrlCacheEntry, READ_URL_CACHE_MAX_KEYS } from "@gajae-code/coding-agent/tools/fetch";
+import * as scrapers from "@gajae-code/coding-agent/web/scrapers/types";
+import { Snowflake } from "@gajae-code/utils";
+
+describe("read-URL cache bound", () => {
+	let testDir: string;
+
+	beforeEach(() => {
+		testDir = path.join(os.tmpdir(), `fetch-url-cache-bound-${Snowflake.next()}`);
+		fs.mkdirSync(testDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		fs.rmSync(testDir, { recursive: true, force: true });
+	});
+
+	const createSession = (): ToolSession => {
+		const sessionFile = path.join(testDir, "session.jsonl");
+		const artifactsDir = sessionFile.slice(0, -6);
+		let nextArtifactId = 0;
+		return {
+			cwd: testDir,
+			hasUI: false,
+			getSessionFile: () => sessionFile,
+			getArtifactsDir: () => artifactsDir,
+			getSessionSpawns: () => null,
+			allocateOutputArtifact: async toolType => {
+				const id = String(nextArtifactId++);
+				return {
+					id,
+					path: path.join(artifactsDir, `${id}.${toolType}.log`),
+				};
+			},
+			settings: Settings.isolated({
+				"fetch.enabled": true,
+			}),
+		};
+	};
+
+	it("evicts oldest entries past the key cap instead of growing without limit", async () => {
+		const session = createSession();
+		const firstUrl = "https://example.com/first";
+		const loadPageSpy = vi.spyOn(scrapers, "loadPage").mockImplementation(async requestedUrl => ({
+			ok: true,
+			status: 200,
+			contentType: "text/plain",
+			finalUrl: requestedUrl,
+			content: `content for ${requestedUrl}`,
+		}));
+
+		await loadReadUrlCacheEntry(session, { path: firstUrl }, undefined, { preferCached: true });
+		expect(loadPageSpy).toHaveBeenCalledTimes(1);
+
+		// Each fetch caches up to two keys, so filling the cap with distinct URLs
+		// guarantees the first entry's keys are the oldest and get evicted.
+		for (let i = 0; i < READ_URL_CACHE_MAX_KEYS; i++) {
+			await loadReadUrlCacheEntry(session, { path: `https://example.com/fill-${i}` }, undefined, {
+				preferCached: true,
+			});
+		}
+		expect(loadPageSpy).toHaveBeenCalledTimes(1 + READ_URL_CACHE_MAX_KEYS);
+
+		// Evicted entry is served by refetching, not by a stale cache hit.
+		const refetched = await loadReadUrlCacheEntry(session, { path: firstUrl }, undefined, {
+			preferCached: true,
+		});
+		expect(refetched.details.url).toBe(firstUrl);
+		expect(loadPageSpy).toHaveBeenCalledTimes(2 + READ_URL_CACHE_MAX_KEYS);
+
+		// Entries still under the cap keep being served without a refetch.
+		await loadReadUrlCacheEntry(
+			session,
+			{ path: `https://example.com/fill-${READ_URL_CACHE_MAX_KEYS - 1}` },
+			undefined,
+			{
+				preferCached: true,
+			},
+		);
+		expect(loadPageSpy).toHaveBeenCalledTimes(2 + READ_URL_CACHE_MAX_KEYS);
+	});
+});

--- a/packages/coding-agent/test/tools/fetch-url-cache-bound.test.ts
+++ b/packages/coding-agent/test/tools/fetch-url-cache-bound.test.ts
@@ -1,34 +1,42 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
-import * as fs from "node:fs";
+import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { Settings } from "@gajae-code/coding-agent/config/settings";
 import type { ToolSession } from "@gajae-code/coding-agent/tools";
-import { loadReadUrlCacheEntry, READ_URL_CACHE_MAX_KEYS } from "@gajae-code/coding-agent/tools/fetch";
+import {
+	loadReadUrlCacheEntry,
+	READ_URL_CACHE_MAX_KEYS,
+	readUrlCacheTestHooks,
+} from "@gajae-code/coding-agent/tools/fetch";
 import * as scrapers from "@gajae-code/coding-agent/web/scrapers/types";
 import { Snowflake } from "@gajae-code/utils";
 
 describe("read-URL cache bound", () => {
 	let testDir: string;
 
-	beforeEach(() => {
+	beforeEach(async () => {
 		testDir = path.join(os.tmpdir(), `fetch-url-cache-bound-${Snowflake.next()}`);
-		fs.mkdirSync(testDir, { recursive: true });
+		await fs.mkdir(testDir, { recursive: true });
+		readUrlCacheTestHooks.reset();
 	});
 
-	afterEach(() => {
+	afterEach(async () => {
 		vi.restoreAllMocks();
-		fs.rmSync(testDir, { recursive: true, force: true });
+		readUrlCacheTestHooks.reset();
+		await fs.rm(testDir, { recursive: true, force: true });
 	});
 
-	const createSession = (): ToolSession => {
-		const sessionFile = path.join(testDir, "session.jsonl");
-		const artifactsDir = sessionFile.slice(0, -6);
+	const createSession = (options: { id?: string; persisted?: boolean } = {}): ToolSession => {
+		const sessionFile = options.persisted === false ? null : path.join(testDir, `${options.id ?? "session"}.jsonl`);
+		const artifactScope = sessionFile ?? path.join(testDir, options.id ?? "session");
+		const artifactsDir = artifactScope.endsWith(".jsonl") ? artifactScope.slice(0, -6) : artifactScope;
 		let nextArtifactId = 0;
 		return {
 			cwd: testDir,
 			hasUI: false,
 			getSessionFile: () => sessionFile,
+			getSessionId: () => options.id ?? null,
 			getArtifactsDir: () => artifactsDir,
 			getSessionSpawns: () => null,
 			allocateOutputArtifact: async toolType => {
@@ -64,6 +72,7 @@ describe("read-URL cache bound", () => {
 			await loadReadUrlCacheEntry(session, { path: `https://example.com/fill-${i}` }, undefined, {
 				preferCached: true,
 			});
+			expect(readUrlCacheTestHooks.size).toBeLessThanOrEqual(READ_URL_CACHE_MAX_KEYS);
 		}
 		expect(loadPageSpy).toHaveBeenCalledTimes(1 + READ_URL_CACHE_MAX_KEYS);
 
@@ -84,5 +93,47 @@ describe("read-URL cache bound", () => {
 			},
 		);
 		expect(loadPageSpy).toHaveBeenCalledTimes(2 + READ_URL_CACHE_MAX_KEYS);
+	});
+
+	it("bounds retained synthetic page payloads at the key cap", async () => {
+		const session = createSession();
+		const fixture = "x".repeat(128 * 1024);
+		vi.spyOn(scrapers, "loadPage").mockImplementation(async requestedUrl => ({
+			ok: true,
+			status: 200,
+			contentType: "text/plain",
+			finalUrl: requestedUrl,
+			content: `${requestedUrl}\n${fixture}`,
+		}));
+
+		for (let i = 0; i < READ_URL_CACHE_MAX_KEYS * 3; i++) {
+			await loadReadUrlCacheEntry(session, { path: `https://example.com/large-${i}` }, undefined, {
+				preferCached: true,
+			});
+		}
+
+		expect(readUrlCacheTestHooks.size).toBe(READ_URL_CACHE_MAX_KEYS);
+		expect(readUrlCacheTestHooks.retainedOutputChars).toBeLessThanOrEqual(
+			READ_URL_CACHE_MAX_KEYS * (fixture.length + 1024),
+		);
+	});
+
+	it("isolates unpersisted sessions that share a working directory", async () => {
+		const firstSession = createSession({ id: "first", persisted: false });
+		const secondSession = createSession({ id: "second", persisted: false });
+		const url = "https://example.com/shared";
+		const loadPageSpy = vi.spyOn(scrapers, "loadPage").mockImplementation(async requestedUrl => ({
+			ok: true,
+			status: 200,
+			contentType: "text/plain",
+			finalUrl: requestedUrl,
+			content: `response ${String(loadPageSpy.mock.calls.length)}`,
+		}));
+
+		const first = await loadReadUrlCacheEntry(firstSession, { path: url }, undefined, { preferCached: true });
+		const second = await loadReadUrlCacheEntry(secondSession, { path: url }, undefined, { preferCached: true });
+
+		expect(loadPageSpy).toHaveBeenCalledTimes(2);
+		expect(first.output).not.toBe(second.output);
 	});
 });


### PR DESCRIPTION
## What

Bound the module-global read-URL cache in `packages/coding-agent/src/tools/fetch.ts` (`readUrlCache`) with FIFO eviction at `READ_URL_CACHE_MAX_KEYS = 64`, plus a regression test that observes eviction through refetch counts.

## Why

`readUrlCache` had only `set` (twice per fetch: requested + final URL) and `get`, with no delete/clear/TTL/cap. Entries hold the complete page output string (up to `MAX_OUTPUT_CHARS`) and image payloads, so long-lived TUI and SDK-broker host processes accumulated every fetched page for the process lifetime — keyed per session scope, across all sessions the host ever served.

Every sibling module cache is already bounded (cursor conversation F15 LRU+TTL, subagent body cache, blob-store LRU, `FileReadCache`, attempt records); this one was missed.

Deliberately cap-only, no TTL: a miss simply refetches, so correctness never depends on a hit (same rationale as the bounded hash cache in `runtime-adapters.ts`), and freshness semantics for repeated reads of the same URL stay unchanged below the cap. Eviction follows the exact insert-order pattern already used in `subagent-render.ts` and `attempt-record-store.ts`.

## Testing

- `bun test packages/coding-agent/test/tools/fetch-url-cache-bound.test.ts packages/coding-agent/test/tools/fetch-kagi-toggle.test.ts packages/coding-agent/test/tools/fetch-insane-fallback.test.ts packages/coding-agent/test/qa-prompts-redteam.test.ts` — 38 pass; covers FIFO eviction/refetch, retained synthetic 128 KiB fixtures, hot-cache hits, and same-cwd unpersisted session isolation
- `bun --cwd=packages/coding-agent run check` — biome + tsc clean
- `bun --cwd=packages/coding-agent run build` — compiled package build passed
- `bun scripts/verify-gjc-state-writers.ts --fail` — 0 write sites outside the sanctioned writer / allowlist
- Native addon rebuilt locally with `bun --cwd=packages/natives run build` before focused execution

## Risk classification

- [ ] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [x] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:7a51fa8aff9e1bacb6362a8a35d225e6abc72f688d5f01aef20421367311a97d reviewer:human reviewer-id:Yeachan-Heo evidence:exact-head approval 5120643603 + 38 focused tests + coding-agent check + package build + frozen architect and red-team cohort
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken
