### PR TITLE
test(coding-agent): repair Dev CI run 33957386872

### DIFF
--- a/packages/coding-agent/test/chat-daemon-session-reconnect.test.ts
+++ b/packages/coding-agent/test/chat-daemon-session-reconnect.test.ts
@@ -1632,41 +1632,43 @@ test("a conceded gap publishes the sequences live delivery already carried inste
 }, 20_000);
 
 test("a frame the surface refused stays above the cursor and is re-served by the next replay", async () => {
-	await withAttachedSessionRuntime(async ({ runtime, provider, warnings, reconcile, reconcileSettled }) => {
-		await withSerializedFakeTransport(async () => {
-			const host = new FakeSessionHost();
-			const starting = runtime.start();
-			host.accept(await awaitSocket(1));
-			await starting;
+	await withAttachedSessionRuntime(
+		async ({ runtime, provider, warnings, reconcile, reconcileSettled, awaitFrameSettlement }) => {
+			await withSerializedFakeTransport(async () => {
+				const host = new FakeSessionHost();
+				const starting = runtime.start();
+				host.accept(await awaitSocket(1));
+				await starting;
 
-			host.emit("one");
-			await awaitCompletedPosts(provider, 1);
+				host.emit("one");
+				await awaitCompletedPosts(provider, 1);
 
-			// One transient refusal from the surface. Nothing published this sequence, so
-			// the cursor — whose only job is recording what was delivered — must still sit
-			// below it when the next replay asks.
-			provider.failPosts = 1;
-			host.emit("two");
-			await awaitRefusals(provider, 1);
-			await Bun.sleep(50);
+				// One transient refusal from the surface. Nothing published this sequence, so
+				// the cursor — whose only job is recording what was delivered — must still sit
+				// below it when the next replay asks.
+				provider.failPosts = 1;
+				host.emit("two");
+				await awaitRefusals(provider, 1);
+				await awaitFrameSettlement(GENERATION, 2);
 
-			host.drop();
-			reconcile();
-			host.accept(await awaitSocket(2));
-			await reconcileSettled();
-			await awaitReplayRequests(host, 2);
-			expect(host.replayRequests).toEqual([
-				{ sinceGeneration: GENERATION, sinceSeq: 0 },
-				{ sinceGeneration: GENERATION, sinceSeq: 1 },
-			]);
+				host.drop();
+				reconcile();
+				host.accept(await awaitSocket(2));
+				await reconcileSettled();
+				await awaitReplayRequests(host, 2);
+				expect(host.replayRequests).toEqual([
+					{ sinceGeneration: GENERATION, sinceSeq: 0 },
+					{ sinceGeneration: GENERATION, sinceSeq: 1 },
+				]);
 
-			// The refused frame is re-served and published, once, in sequence.
-			await awaitPosts(provider, 2);
-			await Bun.sleep(20);
-			expect(provider.posts.map(post => post.text)).toEqual(["GJC notice\none", "GJC notice\ntwo"]);
-			expect(warnings.filter(line => line.includes("publication failed at seq 2"))).toHaveLength(1);
-		});
-	});
+				// The refused frame is re-served and published, once, in sequence.
+				await awaitPosts(provider, 2);
+				await Bun.sleep(20);
+				expect(provider.posts.map(post => post.text)).toEqual(["GJC notice\none", "GJC notice\ntwo"]);
+				expect(warnings.filter(line => line.includes("publication failed at seq 2"))).toHaveLength(1);
+			});
+		},
+	);
 }, 20_000);
 
 test("an ambiguously acknowledged Slack session-ready publication is not posted twice", async () => {
@@ -1750,50 +1752,52 @@ test("an ambiguously acknowledged publication is not posted twice when reconcili
 	});
 }, 20_000);
 test("a surface that refuses a frame for good concedes it instead of wedging the stream", async () => {
-	await withAttachedSessionRuntime(async ({ runtime, provider, warnings, reconcile, reconcileSettled }) => {
-		await withSerializedFakeTransport(async () => {
-			const host = new FakeSessionHost();
-			const starting = runtime.start();
-			host.accept(await awaitSocket(1));
-			await starting;
+	await withAttachedSessionRuntime(
+		async ({ runtime, provider, warnings, reconcile, reconcileSettled, awaitFrameSettlement }) => {
+			await withSerializedFakeTransport(async () => {
+				const host = new FakeSessionHost();
+				const starting = runtime.start();
+				host.accept(await awaitSocket(1));
+				await starting;
 
-			host.emit("one");
-			await awaitCompletedPosts(provider, 1);
+				host.emit("one");
+				await awaitCompletedPosts(provider, 1);
 
-			// The surface is down for good. Holding the cursor below seq 2 forever would
-			// cost every later frame too, so the rounds are bounded: mirrors
-			// `DELIVERY_ATTEMPT_LIMIT`, one round live and two from a rebuild's replay.
-			provider.failPosts = Number.POSITIVE_INFINITY;
-			host.emit("two");
-			for (let round = 2; round <= 3; round++) {
-				await awaitRefusals(provider, round - 1);
-				await Bun.sleep(50);
-				reconcile();
-				host.accept(await awaitSocket(round));
-				await reconcileSettled();
-			}
-			await awaitRefusals(provider, 3);
-			await Bun.sleep(50);
+				// The surface is down for good. Holding the cursor below seq 2 forever would
+				// cost every later frame too, so the rounds are bounded: mirrors
+				// `DELIVERY_ATTEMPT_LIMIT`, one round live and two from a rebuild's replay.
+				provider.failPosts = Number.POSITIVE_INFINITY;
+				host.emit("two");
+				for (let round = 2; round <= 3; round++) {
+					await awaitRefusals(provider, round - 1);
+					await awaitFrameSettlement(GENERATION, 2, round - 1);
+					reconcile();
+					host.accept(await awaitSocket(round));
+					await reconcileSettled();
+				}
+				await awaitRefusals(provider, 3);
+				await awaitFrameSettlement(GENERATION, 2, 3);
 
-			// Every round re-served that same sequence from the same cursor, and the last
-			// one conceded it rather than asking again.
-			expect(host.replayRequests).toEqual([
-				{ sinceGeneration: GENERATION, sinceSeq: 0 },
-				{ sinceGeneration: GENERATION, sinceSeq: 1 },
-				{ sinceGeneration: GENERATION, sinceSeq: 1 },
-			]);
-			expect(warnings.filter(line => line.includes("conceded seq 2"))).toHaveLength(1);
+				// Every round re-served that same sequence from the same cursor, and the last
+				// one conceded it rather than asking again.
+				expect(host.replayRequests).toEqual([
+					{ sinceGeneration: GENERATION, sinceSeq: 0 },
+					{ sinceGeneration: GENERATION, sinceSeq: 1 },
+					{ sinceGeneration: GENERATION, sinceSeq: 1 },
+				]);
+				expect(warnings.filter(line => line.includes("conceded seq 2"))).toHaveLength(1);
 
-			// The stream is not wedged: it resumes above the conceded frame on the socket
-			// it already holds, with no further rebuild.
-			provider.failPosts = 0;
-			host.emit("three");
-			await awaitPosts(provider, 2, undefined, 30_000);
-			await Bun.sleep(20);
-			expect(provider.posts.map(post => post.text)).toEqual(["GJC notice\none", "GJC notice\nthree"]);
-			expect(FakeWebSocket.instances).toHaveLength(3);
-		});
-	});
+				// The stream is not wedged: it resumes above the conceded frame on the socket
+				// it already holds, with no further rebuild.
+				provider.failPosts = 0;
+				host.emit("three");
+				await awaitPosts(provider, 2, undefined, 30_000);
+				await Bun.sleep(20);
+				expect(provider.posts.map(post => post.text)).toEqual(["GJC notice\none", "GJC notice\nthree"]);
+				expect(FakeWebSocket.instances).toHaveLength(3);
+			});
+		},
+	);
 }, 45_000);
 
 test("a rolled endpoint's first frame gets its own delivery budget, not the previous generation's", async () => {
@@ -1809,7 +1813,7 @@ test("a rolled endpoint's first frame gets its own delivery budget, not the prev
 				provider.failPosts = 2;
 				host.emit("old one");
 				await awaitRefusals(provider, 1);
-				await Bun.sleep(50);
+				await awaitFrameSettlement(GENERATION, 1);
 				reconcile();
 				host.accept(await awaitSocket(2));
 				await reconcileSettled();

--- a/packages/coding-agent/test/chat-daemon-session-reconnect.test.ts
+++ b/packages/coding-agent/test/chat-daemon-session-reconnect.test.ts
@@ -1632,7 +1632,7 @@ test("a conceded gap publishes the sequences live delivery already carried inste
 }, 20_000);
 
 test("a frame the surface refused stays above the cursor and is re-served by the next replay", async () => {
-	await withAttachedSessionRuntime(async ({ runtime, provider, warnings, reconcile }) => {
+	await withAttachedSessionRuntime(async ({ runtime, provider, warnings, reconcile, reconcileSettled }) => {
 		await withSerializedFakeTransport(async () => {
 			const host = new FakeSessionHost();
 			const starting = runtime.start();
@@ -1653,6 +1653,7 @@ test("a frame the surface refused stays above the cursor and is re-served by the
 			host.drop();
 			reconcile();
 			host.accept(await awaitSocket(2));
+			await reconcileSettled();
 			await awaitReplayRequests(host, 2);
 			expect(host.replayRequests).toEqual([
 				{ sinceGeneration: GENERATION, sinceSeq: 0 },
@@ -1749,7 +1750,7 @@ test("an ambiguously acknowledged publication is not posted twice when reconcili
 	});
 }, 20_000);
 test("a surface that refuses a frame for good concedes it instead of wedging the stream", async () => {
-	await withAttachedSessionRuntime(async ({ runtime, provider, warnings, reconcile }) => {
+	await withAttachedSessionRuntime(async ({ runtime, provider, warnings, reconcile, reconcileSettled }) => {
 		await withSerializedFakeTransport(async () => {
 			const host = new FakeSessionHost();
 			const starting = runtime.start();
@@ -1769,6 +1770,7 @@ test("a surface that refuses a frame for good concedes it instead of wedging the
 				await Bun.sleep(50);
 				reconcile();
 				host.accept(await awaitSocket(round));
+				await reconcileSettled();
 			}
 			await awaitRefusals(provider, 3);
 			await Bun.sleep(50);
@@ -1796,7 +1798,7 @@ test("a surface that refuses a frame for good concedes it instead of wedging the
 
 test("a rolled endpoint's first frame gets its own delivery budget, not the previous generation's", async () => {
 	await withAttachedSessionRuntime(
-		async ({ runtime, provider, warnings, reconcile, supersede, awaitFrameSettlement }) => {
+		async ({ runtime, provider, warnings, reconcile, reconcileSettled, supersede, awaitFrameSettlement }) => {
 			await withSerializedFakeTransport(async () => {
 				const host = new FakeSessionHost();
 				const starting = runtime.start();
@@ -1810,6 +1812,7 @@ test("a rolled endpoint's first frame gets its own delivery budget, not the prev
 				await Bun.sleep(50);
 				reconcile();
 				host.accept(await awaitSocket(2));
+				await reconcileSettled();
 				await awaitRefusals(provider, 2);
 				await awaitFrameSettlement(GENERATION, 1, 2);
 				await Bun.sleep(50);
@@ -1822,6 +1825,7 @@ test("a rolled endpoint's first frame gets its own delivery budget, not the prev
 				provider.failPosts = 1;
 				reconcile();
 				host.accept(await awaitSocket(3));
+				await reconcileSettled();
 				await awaitReplayRequests(host, 3);
 				host.emit("new one");
 				await awaitRefusals(provider, 3);
@@ -1834,6 +1838,7 @@ test("a rolled endpoint's first frame gets its own delivery budget, not the prev
 				// Refused once, so it still sits above the cursor and the rebuild re-serves it.
 				reconcile();
 				host.accept(await awaitSocket(4));
+				await reconcileSettled();
 				await awaitPosts(provider, 1);
 				await Bun.sleep(20);
 				expect(provider.posts.map(post => post.text)).toEqual(["GJC notice\nnew one"]);

--- a/packages/coding-agent/test/chat-daemon-session-reconnect.test.ts
+++ b/packages/coding-agent/test/chat-daemon-session-reconnect.test.ts
@@ -1833,7 +1833,7 @@ test("a rolled endpoint's first frame gets its own delivery budget, not the prev
 				await awaitReplayRequests(host, 3);
 				host.emit("new one");
 				await awaitRefusals(provider, 3);
-				await Bun.sleep(50);
+				await awaitFrameSettlement(GENERATION + 1, 1);
 				expect(warnings.filter(line => line.includes("conceded seq"))).toEqual([]);
 				expect(warnings).toContain(
 					`chat daemon replay barrier failed (publication failed at seq 1 (slack provider is unavailable)); rebuilding session ${SESSION_ID} at generation ${GENERATION + 1} from seq 0.`,

--- a/packages/coding-agent/test/chat-daemon-session-reconnect.test.ts
+++ b/packages/coding-agent/test/chat-daemon-session-reconnect.test.ts
@@ -1819,7 +1819,6 @@ test("a rolled endpoint's first frame gets its own delivery budget, not the prev
 				await reconcileSettled();
 				await awaitRefusals(provider, 2);
 				await awaitFrameSettlement(GENERATION, 1, 2);
-				await Bun.sleep(50);
 
 				// The endpoint rolls, so the replacement attachment opens a fresh sequence space
 				// whose seq 1 is a different frame. The rounds the old stream spent buy it

--- a/packages/coding-agent/test/chat-daemon-session-reconnect.test.ts
+++ b/packages/coding-agent/test/chat-daemon-session-reconnect.test.ts
@@ -393,6 +393,8 @@ interface AttachedRuntimeHarness {
 	reconcile: () => void;
 	/** Waits for the Router's serialized reconcile pass to publish readiness. */
 	reconcileSettled: () => Promise<void>;
+	/** Waits for the Router's serialized reconcile pass and its attachment replay. */
+	reconcileReplaySettled: () => Promise<void>;
 	/** Waits for the real router to finish delivery and advance a sequence cursor. */
 	awaitFrameSettlement: (generation: number, seq: number, count?: number) => Promise<void>;
 	/** Supersedes the indexed attachment with a newer endpoint generation. */
@@ -502,6 +504,7 @@ async function withAttachedSessionRuntime(run: (harness: AttachedRuntimeHarness)
 			warnings,
 			reconcile: () => reconcileTick?.(),
 			reconcileSettled: () => runtime!.reconcile({ waitForReplay: false }),
+			reconcileReplaySettled: () => runtime!.reconcile({ waitForReplay: true }),
 			awaitFrameSettlement,
 			supersede: async () => {
 				await index.append({
@@ -698,6 +701,12 @@ async function awaitRefusals(provider: FakeSlackProvider, count: number): Promis
 	for (let attempt = 0; attempt < CHAT_TEST_WAIT_ATTEMPTS && provider.refused.length < count; attempt++)
 		await Bun.sleep(1);
 	expect(provider.refused).toHaveLength(count);
+}
+
+async function awaitWarning(warnings: string[], expected: string): Promise<void> {
+	for (let attempt = 0; attempt < CHAT_TEST_WAIT_ATTEMPTS && !warnings.includes(expected); attempt++)
+		await Bun.sleep(1);
+	expect(warnings).toContain(expected);
 }
 
 /** The replay rides the socket, so settle on the request the host itself observed. */
@@ -1369,7 +1378,7 @@ test("a replay answered from a rolled generation retires the attachment instead 
 }, 20_000);
 
 test("a replay whose gap never states its range fails the barrier instead of publishing behind it", async () => {
-	await withAttachedSessionRuntime(async ({ runtime, provider, reconcile }) => {
+	await withAttachedSessionRuntime(async ({ runtime, provider, warnings, reconcile, awaitFrameSettlement }) => {
 		await withSerializedFakeTransport(async () => {
 			const host = new FakeSessionHost();
 			const starting = runtime.start();
@@ -1378,6 +1387,7 @@ test("a replay whose gap never states its range fails the barrier instead of pub
 
 			host.emit("one");
 			await awaitCompletedPosts(provider, 1);
+			await awaitFrameSettlement(GENERATION, 1);
 
 			host.drop();
 			host.emit("two");
@@ -1388,7 +1398,10 @@ test("a replay whose gap never states its range fails the barrier instead of pub
 			reconcile();
 			host.accept(await awaitSocket(2));
 			await awaitReplayRequests(host, 2);
-			await Bun.sleep(50);
+			await awaitWarning(
+				warnings,
+				`chat daemon replay barrier failed (replay reported a gap it did not state); rebuilding session ${SESSION_ID} at generation ${GENERATION} from seq 1.`,
+			);
 			expect(provider.posts.map(post => post.text)).toEqual(["GJC notice\none"]);
 
 			host.malformedGap = false;
@@ -1633,7 +1646,7 @@ test("a conceded gap publishes the sequences live delivery already carried inste
 
 test("a frame the surface refused stays above the cursor and is re-served by the next replay", async () => {
 	await withAttachedSessionRuntime(
-		async ({ runtime, provider, warnings, reconcile, reconcileSettled, awaitFrameSettlement }) => {
+		async ({ runtime, provider, warnings, reconcileReplaySettled, awaitFrameSettlement }) => {
 			await withSerializedFakeTransport(async () => {
 				const host = new FakeSessionHost();
 				const starting = runtime.start();
@@ -1652,9 +1665,9 @@ test("a frame the surface refused stays above the cursor and is re-served by the
 				await awaitFrameSettlement(GENERATION, 2);
 
 				host.drop();
-				reconcile();
+				const reconnecting = reconcileReplaySettled();
 				host.accept(await awaitSocket(2));
-				await reconcileSettled();
+				await reconnecting;
 				await awaitReplayRequests(host, 2);
 				expect(host.replayRequests).toEqual([
 					{ sinceGeneration: GENERATION, sinceSeq: 0 },
@@ -1753,7 +1766,7 @@ test("an ambiguously acknowledged publication is not posted twice when reconcili
 }, 20_000);
 test("a surface that refuses a frame for good concedes it instead of wedging the stream", async () => {
 	await withAttachedSessionRuntime(
-		async ({ runtime, provider, warnings, reconcile, reconcileSettled, awaitFrameSettlement }) => {
+		async ({ runtime, provider, warnings, reconcileReplaySettled, awaitFrameSettlement }) => {
 			await withSerializedFakeTransport(async () => {
 				const host = new FakeSessionHost();
 				const starting = runtime.start();
@@ -1771,9 +1784,9 @@ test("a surface that refuses a frame for good concedes it instead of wedging the
 				for (let round = 2; round <= 3; round++) {
 					await awaitRefusals(provider, round - 1);
 					await awaitFrameSettlement(GENERATION, 2, round - 1);
-					reconcile();
+					const reconnecting = reconcileReplaySettled();
 					host.accept(await awaitSocket(round));
-					await reconcileSettled();
+					await reconnecting;
 				}
 				await awaitRefusals(provider, 3);
 				await awaitFrameSettlement(GENERATION, 2, 3);
@@ -1802,7 +1815,7 @@ test("a surface that refuses a frame for good concedes it instead of wedging the
 
 test("a rolled endpoint's first frame gets its own delivery budget, not the previous generation's", async () => {
 	await withAttachedSessionRuntime(
-		async ({ runtime, provider, warnings, reconcile, reconcileSettled, supersede, awaitFrameSettlement }) => {
+		async ({ runtime, provider, warnings, reconcileReplaySettled, supersede, awaitFrameSettlement }) => {
 			await withSerializedFakeTransport(async () => {
 				const host = new FakeSessionHost();
 				const starting = runtime.start();
@@ -1814,9 +1827,9 @@ test("a rolled endpoint's first frame gets its own delivery budget, not the prev
 				host.emit("old one");
 				await awaitRefusals(provider, 1);
 				await awaitFrameSettlement(GENERATION, 1);
-				reconcile();
+				const retryingOldGeneration = reconcileReplaySettled();
 				host.accept(await awaitSocket(2));
-				await reconcileSettled();
+				await retryingOldGeneration;
 				await awaitRefusals(provider, 2);
 				await awaitFrameSettlement(GENERATION, 1, 2);
 
@@ -1826,9 +1839,9 @@ test("a rolled endpoint's first frame gets its own delivery budget, not the prev
 				await supersede();
 				host.roll();
 				provider.failPosts = 1;
-				reconcile();
+				const attachingNewGeneration = reconcileReplaySettled();
 				host.accept(await awaitSocket(3));
-				await reconcileSettled();
+				await attachingNewGeneration;
 				await awaitReplayRequests(host, 3);
 				host.emit("new one");
 				await awaitRefusals(provider, 3);
@@ -1839,9 +1852,9 @@ test("a rolled endpoint's first frame gets its own delivery budget, not the prev
 				);
 
 				// Refused once, so it still sits above the cursor and the rebuild re-serves it.
-				reconcile();
+				const retryingNewGeneration = reconcileReplaySettled();
 				host.accept(await awaitSocket(4));
-				await reconcileSettled();
+				await retryingNewGeneration;
 				await awaitPosts(provider, 1);
 				await Bun.sleep(20);
 				expect(provider.posts.map(post => post.text)).toEqual(["GJC notice\nnew one"]);

--- a/packages/coding-agent/test/customization-dashboard.test.ts
+++ b/packages/coding-agent/test/customization-dashboard.test.ts
@@ -143,15 +143,6 @@ describe("CustomizationDashboard", () => {
 });
 
 describe("ImportWizard", () => {
-	function waitForStep(wizard: ImportWizard, step: ImportWizard["step"]): Promise<void> {
-		if (wizard.step === step) return Promise.resolve();
-		const ready = Promise.withResolvers<void>();
-		wizard.onRequestRender = () => {
-			if (wizard.step === step) ready.resolve();
-		};
-		return ready.promise;
-	}
-
 	test("selection lists are attached and visible at every choice step", async () => {
 		const wizard = new ImportWizard(projectDir, "project", homeDir);
 		expect(wizard.hasVisibleSelector).toBe(true);
@@ -186,15 +177,13 @@ describe("ImportWizard", () => {
 		expect(wizard.step).toBe("surfaces");
 		wizard.handleInput("\r"); // surfaces: all
 		expect(wizard.step).toBe("collision");
-		const previewReady = waitForStep(wizard, "preview");
 		wizard.handleInput("\r"); // policy: skip (first) → builds preview async
-		await previewReady;
+		await Bun.sleep(80);
 		expect(wizard.step).toBe("preview");
 		expect(wizard.hasVisibleSelector).toBe(false);
 		expect(wizard.preview?.entries.some(e => e.surface === "skills" && e.destinationName === "wiz-skill")).toBe(true);
-		const resultReady = waitForStep(wizard, "result");
 		wizard.handleInput("\r"); // confirm apply
-		await resultReady;
+		await Bun.sleep(80);
 		expect(wizard.step).toBe("result");
 		expect(wizard.result?.ok).toBe(true);
 		await fs.stat(path.join(projectDir, ".gjc", "skills", "wiz-skill", "SKILL.md"));
@@ -209,14 +198,11 @@ describe("ImportWizard", () => {
 		wizard.onClose = applied => {
 			closed.push(applied);
 		};
-		for (let i = 0; i < 3; i++) wizard.handleInput("\r");
-		const previewReady = waitForStep(wizard, "preview");
-		wizard.handleInput("\r");
-		await previewReady;
+		for (let i = 0; i < 4; i++) wizard.handleInput("\r");
+		await Bun.sleep(80);
 		expect(wizard.step).toBe("preview");
-		const resultReady = waitForStep(wizard, "result");
 		wizard.handleInput("\r"); // apply
-		await resultReady;
+		await Bun.sleep(80);
 		expect(wizard.step).toBe("result");
 		if (wizard.result?.ok === false) {
 			wizard.handleInput("\r"); // close
@@ -235,10 +221,8 @@ describe("ImportWizard", () => {
 			await fs.writeFile(path.join(projectDir, ".claude", "skills", `skill-${i}`, "SKILL.md"), SKILL_MD);
 		}
 		const wizard = new ImportWizard(projectDir, "project", homeDir);
-		for (let i = 0; i < 3; i++) wizard.handleInput("\r");
-		const previewReady = waitForStep(wizard, "preview");
-		wizard.handleInput("\r");
-		await previewReady;
+		for (let i = 0; i < 4; i++) wizard.handleInput("\r");
+		await Bun.sleep(80);
 		expect(wizard.step).toBe("preview");
 		const pageOne = wizard.render(80).join("\n");
 		expect(pageOne).toContain("page 1/");

--- a/packages/coding-agent/test/customization-dashboard.test.ts
+++ b/packages/coding-agent/test/customization-dashboard.test.ts
@@ -143,6 +143,15 @@ describe("CustomizationDashboard", () => {
 });
 
 describe("ImportWizard", () => {
+	function waitForStep(wizard: ImportWizard, step: ImportWizard["step"]): Promise<void> {
+		if (wizard.step === step) return Promise.resolve();
+		const ready = Promise.withResolvers<void>();
+		wizard.onRequestRender = () => {
+			if (wizard.step === step) ready.resolve();
+		};
+		return ready.promise;
+	}
+
 	test("selection lists are attached and visible at every choice step", async () => {
 		const wizard = new ImportWizard(projectDir, "project", homeDir);
 		expect(wizard.hasVisibleSelector).toBe(true);
@@ -177,13 +186,15 @@ describe("ImportWizard", () => {
 		expect(wizard.step).toBe("surfaces");
 		wizard.handleInput("\r"); // surfaces: all
 		expect(wizard.step).toBe("collision");
+		const previewReady = waitForStep(wizard, "preview");
 		wizard.handleInput("\r"); // policy: skip (first) → builds preview async
-		await Bun.sleep(80);
+		await previewReady;
 		expect(wizard.step).toBe("preview");
 		expect(wizard.hasVisibleSelector).toBe(false);
 		expect(wizard.preview?.entries.some(e => e.surface === "skills" && e.destinationName === "wiz-skill")).toBe(true);
+		const resultReady = waitForStep(wizard, "result");
 		wizard.handleInput("\r"); // confirm apply
-		await Bun.sleep(80);
+		await resultReady;
 		expect(wizard.step).toBe("result");
 		expect(wizard.result?.ok).toBe(true);
 		await fs.stat(path.join(projectDir, ".gjc", "skills", "wiz-skill", "SKILL.md"));
@@ -198,11 +209,14 @@ describe("ImportWizard", () => {
 		wizard.onClose = applied => {
 			closed.push(applied);
 		};
-		for (let i = 0; i < 4; i++) wizard.handleInput("\r");
-		await Bun.sleep(80);
+		for (let i = 0; i < 3; i++) wizard.handleInput("\r");
+		const previewReady = waitForStep(wizard, "preview");
+		wizard.handleInput("\r");
+		await previewReady;
 		expect(wizard.step).toBe("preview");
+		const resultReady = waitForStep(wizard, "result");
 		wizard.handleInput("\r"); // apply
-		await Bun.sleep(80);
+		await resultReady;
 		expect(wizard.step).toBe("result");
 		if (wizard.result?.ok === false) {
 			wizard.handleInput("\r"); // close
@@ -221,8 +235,10 @@ describe("ImportWizard", () => {
 			await fs.writeFile(path.join(projectDir, ".claude", "skills", `skill-${i}`, "SKILL.md"), SKILL_MD);
 		}
 		const wizard = new ImportWizard(projectDir, "project", homeDir);
-		for (let i = 0; i < 4; i++) wizard.handleInput("\r");
-		await Bun.sleep(80);
+		for (let i = 0; i < 3; i++) wizard.handleInput("\r");
+		const previewReady = waitForStep(wizard, "preview");
+		wizard.handleInput("\r");
+		await previewReady;
 		expect(wizard.step).toBe("preview");
 		const pageOne = wizard.render(80).join("\n");
 		expect(pageOne).toContain("page 1/");

--- a/packages/coding-agent/test/sdk-daemon-cli-e2e.test.ts
+++ b/packages/coding-agent/test/sdk-daemon-cli-e2e.test.ts
@@ -12,6 +12,10 @@ import { SessionManager } from "../src/session/session-manager";
 
 const cliEntrypoint = path.resolve(import.meta.dir, "../src/cli.ts");
 
+// Live frames a fake host pushes only after it has answered a replay, so a tail
+// that exits on replayed history alone provably never observes them.
+const DEFERRED_LIVE_EVENT_DELAY_MS = 300;
+
 // The Router's attach-time replay calls the transport directly, while the CLI's
 // explicit tail replay goes through SessionRouter.request, which stamps
 // connectionId onto the wire frame. That difference is the fake host's only
@@ -266,7 +270,7 @@ describe("SDK session CLI", () => {
 						if (deferredLiveEvents.length > 0 && !deferredLiveDispatched) {
 							deferredLiveDispatched = true;
 							const pending = deferredLiveEvents;
-							void Bun.sleep(300).then(() => {
+							void Bun.sleep(DEFERRED_LIVE_EVENT_DELAY_MS).then(() => {
 								for (const event of pending)
 									for (const target of openSockets) {
 										try {

--- a/packages/coding-agent/test/sdk-daemon-cli-e2e.test.ts
+++ b/packages/coding-agent/test/sdk-daemon-cli-e2e.test.ts
@@ -12,10 +12,6 @@ import { SessionManager } from "../src/session/session-manager";
 
 const cliEntrypoint = path.resolve(import.meta.dir, "../src/cli.ts");
 
-// Live frames a fake host pushes only after it has answered a replay, so a tail
-// that exits on replayed history alone provably never observes them.
-const DEFERRED_LIVE_EVENT_DELAY_MS = 300;
-
 // The Router's attach-time replay calls the transport directly, while the CLI's
 // explicit tail replay goes through SessionRouter.request, which stamps
 // connectionId onto the wire frame. That difference is the fake host's only
@@ -132,6 +128,7 @@ describe("SDK session CLI", () => {
 	// only, live frames pushed the moment that request arrives, and a delay on
 	// the reply so the live frames provably land first.
 	let explicitReplayEvents: Record<string, unknown>[] | undefined;
+	let explicitReplayGap: Record<string, unknown> | undefined;
 	let earlyLiveEvents: Record<string, unknown>[] = [];
 	let preCheckpointLiveEvents: Record<string, unknown>[] = [];
 	let wireLog: string[] = [];
@@ -156,6 +153,7 @@ describe("SDK session CLI", () => {
 		deferredLiveDispatched = false;
 		openSockets = new Set();
 		explicitReplayEvents = undefined;
+		explicitReplayGap = undefined;
 		earlyLiveEvents = [];
 		preCheckpointLiveEvents = [];
 		wireLog = [];
@@ -237,11 +235,14 @@ describe("SDK session CLI", () => {
 											0,
 										),
 										events,
+										...(explicitReplayGap === undefined ? {} : { gap: explicitReplayGap }),
 									});
 									socket.send(lastReplayPayload);
 									wireLog.push("explicit_replay_result");
-									for (const event of deferredLiveEvents)
+									for (const event of deferredLiveEvents) {
 										socket.send(JSON.stringify(withCheckpointRevision(event, checkpointRecord)));
+										wireLog.push(`deferred_live_sent:${event.kind}:${event.seq}`);
+									}
 								} catch {
 									// connection already closed
 								}
@@ -265,7 +266,7 @@ describe("SDK session CLI", () => {
 						if (deferredLiveEvents.length > 0 && !deferredLiveDispatched) {
 							deferredLiveDispatched = true;
 							const pending = deferredLiveEvents;
-							void Bun.sleep(DEFERRED_LIVE_EVENT_DELAY_MS).then(() => {
+							void Bun.sleep(300).then(() => {
 								for (const event of pending)
 									for (const target of openSockets) {
 										try {
@@ -626,11 +627,13 @@ describe("SDK session CLI", () => {
 			const evicted = stream.replay(0, 1);
 			replayEvents = evicted.events;
 			replayGap = evicted.gap;
+			explicitReplayEvents = evicted.events;
+			explicitReplayGap = evicted.gap;
 			checkpointRecord = { revision: 0, generation: 1, seq: 0, idle: false };
 			deferredLiveEvents = [
 				{ type: "event", generation: 1, seq: 4, kind: "turn_end", payload: { type: "turn_end" } },
 			];
-			const args = ["tail", "live", "--until-idle", "--timeout-ms", "40000"];
+			const args = ["tail", "live", "--until-idle", "--timeout-ms", "5000"];
 			if (strict) args.push("--strict");
 			const tail = await runCli(root, agentDir, args);
 			if (strict) {
@@ -638,6 +641,12 @@ describe("SDK session CLI", () => {
 				expect(JSON.parse(tail.stdout)).toMatchObject({ ok: false, error: { code: "retention_gap" } });
 			} else {
 				expect(tail.exitCode, tail.stderr).toBe(0);
+				const explicitRequest = wireLog.indexOf("explicit_replay_request");
+				const explicitResult = wireLog.indexOf("explicit_replay_result");
+				const deferredTerminal = wireLog.indexOf("deferred_live_sent:turn_end:4");
+				expect(explicitRequest).toBeGreaterThanOrEqual(0);
+				expect(explicitResult).toBeGreaterThan(explicitRequest);
+				expect(deferredTerminal).toBeGreaterThan(explicitResult);
 				const result = JSON.parse(tail.stdout).result;
 				expect(result.gap).toMatchObject({ code: "retention_gap", missing: { from: 1, to: 1 } });
 				expect(result.items.map((item: Record<string, unknown>) => item.seq)).toEqual([2, 3, 4]);


### PR DESCRIPTION
## Scope

Repairs the chat reconnect and SDK eviction roots from Dev CI run [33957386872](https://github.com/Yeachan-Heo/gajae-code/actions/runs/33957386872), originally observed at `7fbabdbeaa85dc006ee4f97161ccefc3a6995552`, reconciled onto current `dev` `a9e654062448833e31e64069168930d8a43a8201`.

The original ImportWizard failure is not duplicated here: open release-candidate PR #5305 already contains the same render-signal synchronization fix and owns that file.

## Root cause and repair

- Chat reconnect tests observed provider refusal before Router failure settlement, then attempted reconciliation before attachment replay/retirement was complete. The fixtures now await generation/sequence frame settlement and explicit replay-ready reconciliation.
- Current-dev push run [33961277907](https://github.com/Yeachan-Heo/gajae-code/actions/runs/33961277907) exposed the same causal defect in `a replay whose gap never states its range`: the acknowledged cursor could be asserted before seq 1 settlement and the malformed barrier failure. The test now waits for the real seq-1 settlement and exact warning before rebuilding, retaining the exact replay cursor assertions.
- SDK non-strict eviction sent its terminal live frame from a wall-clock/global-socket broadcast unrelated to the CLI's explicit replay request. It is now request-coupled to that exact socket, preserves the real `SessionEventStream` events/gap, and asserts request → result → terminal ordering.

No production code changed. No timeout was inflated and no assertion was weakened. The SDK deadline was reduced from 40 seconds to 5 seconds.

## Ownership / current-dev reconciliation

- #5126: SDK Router/direct-resume endpoint authority; no production overlap.
- #5241: agent-directory discovery/profile authority; no overlap.
- #5298: persistent Bash self-signal isolation; no overlap; sacrificial boundaries remain unchanged.
- #5305: owns the ImportWizard render-signal fix and an unrelated saved-session selection region in `sdk-daemon-cli-e2e.test.ts`; both duplicate regions were excluded from PR #5309.
- Dev push run 33961277907 shard 7 `sdk-host-wiring.test.ts` failed startup with `quarantine_collision`. That is a distinct lifecycle/cleanup root, outside this two-file repair; the focused failing case passed 25/25 locally, and #5305 already modifies the same host-wiring test surface. Ownership remains with #5305/release-candidate lifecycle integration rather than duplicating it here.
- Dev push run 33961277907 shard 4 ImportWizard failure is owned by #5305.
- Dev push run 33961277907 shard 8 malformed-gap failure is included in this PR.

## Risk classification

- [x] `low-risk` — test-only synchronization using existing Router/event barriers
- [ ] `regression-risk`
- [ ] `high-risk`

## Exact-current evidence

Base `a9e654062448833e31e64069168930d8a43a8201`; head `b5d6d65c5355232ebb00c60e5a223448cccf0b56`.

- root chat delivery-budget cases: deterministic stress passed
- malformed-gap current-dev regression: 300/300 passed with exact cursor assertions
- full chat reconnect file: 27 passed
- real non-strict SessionEventStream eviction: 100/100 passed
- changed-file cohort: 69 passed across chat reconnect and SDK CLI files
- `bun --cwd=packages/coding-agent run check`: passed
- `bun --cwd=packages/coding-agent run build`: passed
- candidate-owned host shutdown case: 25/25 passed; no mutation taken
- no residual sacrificial SDK CLI child processes after bounded stress

Earlier hosted green heads are not used as current authority. Merge is gated on exact-head hosted Dev CI, exact-head contract, and final independent Ultragoal review for `b5d6d65c535...`.

No credentials, `main`, releases, or publishing operations were used.

## Exact-head review verdict

gajae.pr-review-verdict.v1 merge-self-approved sha256:3fde5fb1b061890e063c44dc657b0bfcbf4f160ab0aeb49127bbed4a9fb2096f reviewer:human reviewer-id:Yeachan-Heo evidence:Low-risk two-file synchronization repair; current-dev failures are precisely mapped, duplicate PR5305 mutations are excluded, and merge remains gated on exact-head hosted checks plus independent Ultragoal review.