### PR TITLE
perf(tui): coalesce assistant text projection into existing frames

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 - Status-line settings now include a draft-local spatial custom editor with exact-slot keyboard reordering, hidden-segment palette management, command text configuration, persisted Confirm/Exit semantics, live multi-row preview compatibility, narrow/Unicode rendering, and deterministic visual evidence.
 
+### Changed
+
+- Interactive assistant `text_delta` presentation now coalesces eligible updates into the latest message projection before the existing TUI frame while preserving ordered event processing, immediate non-text updates, and authoritative final output. Session/transcript replacement and disposal cancel stale presentation; temporary TUI stop/start rearms current live text before the first restarted frame without invalidating live historical image callbacks.
+
 ### Fixed
 
 - The read-URL cache is now bounded (FIFO, 64 keys), so long-lived TUI and SDK-host processes no longer retain every fetched page's full output and image payload for the process lifetime; an evicted entry simply refetches on the next read, and unpersisted sessions sharing a working directory remain isolated by session identity.

--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -106,16 +106,24 @@ export class AssistantMessageComponent extends Container {
 	#toolImagesRevision = 0;
 	#convertedToolImagesRevision = 0;
 	#disposed = false;
+	// Cached Markdown children can outlive their attachment to this assistant.
+	// Session/live-parent validity belongs to the owner, not the paint lifetime.
+	readonly #requestRepaint?: () => void;
 	constructor(
 		message?: AssistantMessage,
 		private hideThinkingBlock = false,
-		private readonly onImageUpdate?: () => void,
+		onImageUpdate?: () => void,
 		viewportAnchorId?: string,
 		private readonly onVisibleMutation?: () => void,
 		private readonly hintSession?: ProviderSafetyStopHintSession,
 	) {
 		super();
 		this.#viewportAnchorId = viewportAnchorId;
+		if (onImageUpdate) {
+			this.#requestRepaint = () => {
+				if (!this.#disposed) onImageUpdate();
+			};
+		}
 
 		this.#contentContainer = new Container();
 		this.addChild(this.#contentContainer);
@@ -172,6 +180,7 @@ export class AssistantMessageComponent extends Container {
 	}
 
 	#notifyVisibleMutation(): void {
+		if (this.#disposed) return;
 		const after = this.#visibleContentSignature();
 		if (after === this.#visibleSignature) return;
 		this.#visibleSignature = after;
@@ -186,6 +195,7 @@ export class AssistantMessageComponent extends Container {
 	}
 
 	override invalidate(): void {
+		if (this.#disposed) return;
 		super.invalidate();
 		if (this.#lastMessage) {
 			this.updateContent(this.#lastMessage, { streaming: this.#lastStreaming });
@@ -193,13 +203,14 @@ export class AssistantMessageComponent extends Container {
 	}
 
 	setHideThinkingBlock(hide: boolean): void {
+		if (this.#disposed) return;
 		if (this.hideThinkingBlock === hide) return;
 		this.hideThinkingBlock = hide;
 		this.#notifyVisibleMutation();
 	}
 
 	setToolResultImages(toolCallId: string, images: ImageContent[]): void {
-		if (!toolCallId) return;
+		if (this.#disposed || !toolCallId) return;
 		const validImages = images.filter(img => img.type === "image" && img.data && img.mimeType);
 		const previousImages = this.#toolImagesByCallId.get(toolCallId);
 		if (
@@ -268,7 +279,7 @@ export class AssistantMessageComponent extends Container {
 					this.#convertedKittyImages.set(key, { type: "image", data, mimeType: "image/png", source });
 					this.#convertedToolImagesRevision += 1;
 					if (this.#lastMessage) this.updateContent(this.#lastMessage, { streaming: this.#lastStreaming });
-					this.onImageUpdate?.();
+					this.#requestRepaint?.();
 				})
 				.catch(() => {
 					if (
@@ -283,6 +294,7 @@ export class AssistantMessageComponent extends Container {
 	}
 
 	setUsageInfo(usage: Usage): void {
+		if (this.#disposed) return;
 		this.#usageInfo = usage;
 		if (this.#lastMessage) {
 			this.updateContent(this.#lastMessage, { streaming: this.#lastStreaming });
@@ -311,7 +323,7 @@ export class AssistantMessageComponent extends Container {
 		const cached = this.#contentBlocksCache.get(content);
 		if (cached?.source === content.text) {
 			if (cached.component instanceof Markdown) {
-				cached.component.setOnStaleThrottle(this.onImageUpdate);
+				cached.component.setOnStaleThrottle(this.#requestRepaint);
 				cached.component.setStreaming(streaming);
 			}
 			return cached.component;
@@ -322,14 +334,14 @@ export class AssistantMessageComponent extends Container {
 		// instead of constructing a new one each chunk; combined with the markdown
 		// per-code-block highlight cache, appends no longer re-highlight the whole prefix.
 		if (!deepInterview && cached && cached.component instanceof Markdown) {
-			cached.component.setOnStaleThrottle(this.onImageUpdate);
+			cached.component.setOnStaleThrottle(this.#requestRepaint);
 			cached.component.setText(trimmed, { streaming });
 			cached.source = content.text;
 			return cached.component;
 		}
 		const component = deepInterview ?? new Markdown(trimmed, 1, 0, getMarkdownTheme());
 		if (component instanceof Markdown) {
-			component.setOnStaleThrottle(this.onImageUpdate);
+			component.setOnStaleThrottle(this.#requestRepaint);
 			component.setStreaming(streaming);
 		}
 		this.#contentBlocksCache.set(content, { source: content.text, component });
@@ -341,14 +353,14 @@ export class AssistantMessageComponent extends Container {
 		const cached = this.#contentBlocksCache.get(content);
 		if (cached?.source === content.thinking) {
 			if (cached.component instanceof Markdown) {
-				cached.component.setOnStaleThrottle(this.onImageUpdate);
+				cached.component.setOnStaleThrottle(this.#requestRepaint);
 				cached.component.setStreaming(streaming);
 			}
 			return cached.component as Markdown;
 		}
 		const trimmed = elideRunawayThinkingRepetition(content.thinking.trim());
 		if (cached?.component instanceof Markdown) {
-			cached.component.setOnStaleThrottle(this.onImageUpdate);
+			cached.component.setOnStaleThrottle(this.#requestRepaint);
 			cached.component.setText(trimmed, { streaming });
 			cached.source = content.thinking;
 			return cached.component;
@@ -357,7 +369,7 @@ export class AssistantMessageComponent extends Container {
 			color: (text: string) => theme.fg("thinkingText", text),
 			italic: true,
 		});
-		component.setOnStaleThrottle(this.onImageUpdate);
+		component.setOnStaleThrottle(this.#requestRepaint);
 		component.setStreaming(streaming);
 		this.#contentBlocksCache.set(content, { source: content.thinking, component });
 		this.#reusableChildren.add(component);
@@ -437,6 +449,7 @@ export class AssistantMessageComponent extends Container {
 	}
 
 	updateContent(message: AssistantMessage, options?: AssistantMessageUpdateOptions): void {
+		if (this.#disposed) return;
 		this.#lastMessage = message;
 		this.#lastStreaming = options?.streaming ?? false;
 

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -1043,6 +1043,7 @@ export class CommandController {
 		this.ctx.ui.requestRender();
 
 		prepareTranscriptRebuild(this.ctx.ui, "replace-identity");
+		this.ctx.resetAssistantTextPresentation();
 		this.ctx.chatContainer.clear();
 		this.ctx.pendingMessagesContainer.clear();
 		this.ctx.compactionQueuedMessages = [];
@@ -1083,6 +1084,7 @@ export class CommandController {
 		this.ctx.ui.requestRender();
 
 		prepareTranscriptRebuild(this.ctx.ui, "replace-identity");
+		this.ctx.resetAssistantTextPresentation();
 		this.ctx.chatContainer.clear();
 		this.ctx.pendingMessagesContainer.clear();
 		this.ctx.compactionQueuedMessages = [];

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -128,6 +128,15 @@ type AgentSessionEventHandlers = {
 	[E in AgentSessionEventKind]: (event: Extract<AgentSessionEvent, { type: E }>) => Promise<void>;
 };
 
+interface AssistantTextPresentation {
+	component: AssistantMessageComponent;
+	latestMessage: AssistantMessage;
+	sessionIdentity: InteractiveModeContext["session"];
+	sessionEpoch: number;
+	paintEpoch: number;
+	cancel: () => void;
+}
+
 export class EventController {
 	#lastReadGroup: ReadToolGroupComponent | undefined = undefined;
 	#lastThinkingCount = 0;
@@ -146,6 +155,16 @@ export class EventController {
 	#visibleTranscriptChanged = false;
 	#handlingEvent = false;
 	#eventQueue: Promise<void> = Promise.resolve();
+	#disposed = false;
+	#assistantTextSuspended = false;
+	#sessionPresentationEpoch = 0;
+	#paintEpoch = 0;
+	#pendingAssistantText: AssistantTextPresentation | undefined;
+	#assistantTextMutationScope: AssistantTextPresentation | undefined;
+	#assistantLifetimes = new WeakMap<
+		AssistantMessageComponent,
+		{ sessionIdentity: InteractiveModeContext["session"]; sessionEpoch: number }
+	>();
 
 	constructor(private ctx: InteractiveModeContext) {
 		this.#handlers = {
@@ -177,6 +196,8 @@ export class EventController {
 	}
 
 	dispose(): void {
+		this.#disposed = true;
+		this.resetAssistantTextPresentation();
 		this.#cancelIdleCompaction();
 		this.#clearRetryCountdown();
 		if (this.ctx.retryEscapeHandler) {
@@ -197,6 +218,104 @@ export class EventController {
 			this.ctx.retryLoader = undefined;
 		}
 		this.clearIrcExpiryTimers();
+	}
+
+	#cancelAssistantTextPresentation(): void {
+		const pending = this.#pendingAssistantText;
+		this.#pendingAssistantText = undefined;
+		pending?.cancel();
+	}
+
+	/** Temporary TUI stop discards scheduling, not historical assistant callback lifetimes. */
+	suspendAssistantTextPresentation(): void {
+		this.#assistantTextSuspended = true;
+		this.#paintEpoch += 1;
+		this.#cancelAssistantTextPresentation();
+	}
+
+	/** Rearm before the first restarted frame, even without a new provider event. */
+	resumeAssistantTextPresentation(): void {
+		this.#cancelAssistantTextPresentation();
+		this.#assistantTextSuspended = false;
+		const component = this.ctx.streamingComponent;
+		const message = this.ctx.streamingMessage;
+		if (component && message && this.#isLiveAssistant(component)) {
+			this.#queueAssistantText(component, message);
+		}
+	}
+
+	/** Session/transcript replacement invalidates callbacks before removing old children. */
+	resetAssistantTextPresentation(): void {
+		this.#sessionPresentationEpoch += 1;
+		this.#cancelAssistantTextPresentation();
+	}
+
+	#isLiveAssistant(component: AssistantMessageComponent): boolean {
+		const lifetime = this.#assistantLifetimes.get(component);
+		return (
+			!this.#disposed &&
+			!this.ctx.isStopped?.() &&
+			lifetime !== undefined &&
+			lifetime.sessionIdentity === this.ctx.session &&
+			lifetime.sessionEpoch === this.#sessionPresentationEpoch &&
+			this.ctx.chatContainer.hasLiveChild(component)
+		);
+	}
+
+	#isValidAssistantText(record: AssistantTextPresentation): boolean {
+		return (
+			!this.#assistantTextSuspended &&
+			this.#isLiveAssistant(record.component) &&
+			record.sessionIdentity === this.ctx.session &&
+			record.sessionEpoch === this.#sessionPresentationEpoch &&
+			record.paintEpoch === this.#paintEpoch &&
+			record.component === this.ctx.streamingComponent
+		);
+	}
+
+	#queueAssistantText(component: AssistantMessageComponent, latestMessage: AssistantMessage): void {
+		if (this.#assistantTextSuspended || !this.#isLiveAssistant(component)) return;
+		const pending = this.#pendingAssistantText;
+		if (pending && this.#isValidAssistantText(pending)) {
+			pending.latestMessage = latestMessage;
+			return;
+		}
+		this.#cancelAssistantTextPresentation();
+		const record: AssistantTextPresentation = {
+			component,
+			latestMessage,
+			sessionIdentity: this.ctx.session,
+			sessionEpoch: this.#sessionPresentationEpoch,
+			paintEpoch: this.#paintEpoch,
+			cancel: () => {},
+		};
+		this.#pendingAssistantText = record;
+		record.cancel = this.ctx.ui.enqueueBeforeRender(() => this.#flushAssistantText(record));
+	}
+
+	#flushAssistantText(record = this.#pendingAssistantText): void {
+		if (!record || this.#pendingAssistantText !== record) return;
+		this.#cancelAssistantTextPresentation();
+		if (!this.#isValidAssistantText(record)) return;
+		const previousScope = this.#assistantTextMutationScope;
+		this.#assistantTextMutationScope = record;
+		try {
+			record.component.updateContent(record.latestMessage, { streaming: true });
+		} finally {
+			this.#assistantTextMutationScope = previousScope;
+		}
+	}
+
+	#observeAssistantMutation(component: AssistantMessageComponent): void {
+		if (!this.#isLiveAssistant(component)) return;
+		const scope = this.#assistantTextMutationScope;
+		if (scope?.component === component && this.#isValidAssistantText(scope)) {
+			// Only this synchronous projection publishes before frame source selection.
+			// An unrelated awaited event retains its own dirty flag and settlement semantics.
+			this.ctx.recordVisibleTranscriptMutation?.();
+			return;
+		}
+		this.#observeVisibleTranscriptMutation();
 	}
 
 	#recordVisibleTranscriptMutation(): void {
@@ -292,9 +411,10 @@ export class EventController {
 	}
 
 	async #dispatchEvent(event: AgentSessionEvent): Promise<void> {
+		if (this.#disposed) return;
 		if (this.ctx.isStopped?.()) return;
 		if (!this.ctx.isInitialized) await this.ctx.init();
-		if (this.ctx.isStopped?.()) return;
+		if (this.#disposed || this.ctx.isStopped?.()) return;
 		this.#visibleTranscriptChanged = false;
 		this.#handlingEvent = true;
 		try {
@@ -462,18 +582,26 @@ export class EventController {
 			this.ctx.ui.requestRender();
 			this.#recordVisibleTranscriptMutation();
 		} else if (event.message.role === "assistant") {
+			this.#cancelAssistantTextPresentation();
 			this.#lastThinkingCount = 0;
 			this.#resetReadGroup();
 			this.#toolIntentCache.clear();
 			this.#thinkingContentIndices.clear();
-			this.ctx.streamingComponent = new AssistantMessageComponent(
+			const component: AssistantMessageComponent = new AssistantMessageComponent(
 				undefined,
 				this.ctx.hideThinkingBlock,
-				() => this.ctx.ui.requestRender(),
+				() => {
+					if (this.#isLiveAssistant(component)) this.ctx.ui.requestRender();
+				},
 				this.ctx.getAssistantViewportAnchorId?.(event.message),
-				() => this.#observeVisibleTranscriptMutation(),
+				() => this.#observeAssistantMutation(component),
 				this.ctx.session,
 			);
+			this.#assistantLifetimes.set(component, {
+				sessionIdentity: this.ctx.session,
+				sessionEpoch: this.#sessionPresentationEpoch,
+			});
+			this.ctx.streamingComponent = component;
 			this.ctx.streamingMessage = event.message;
 			addChatChild(this.ctx, this.ctx.streamingComponent);
 			this.ctx.streamingComponent.updateContent(this.ctx.streamingMessage, { streaming: true });
@@ -605,8 +733,20 @@ export class EventController {
 				transferSessionMessageIdentity([this.ctx.streamingMessage], [event.message]);
 			}
 			this.ctx.streamingMessage = event.message;
-			this.ctx.streamingComponent.updateContent(this.ctx.streamingMessage, { streaming: true });
 			const contentIndex = event.assistantMessageEvent?.contentIndex;
+			if (
+				event.assistantMessageEvent?.type === "text_delta" &&
+				typeof contentIndex === "number" &&
+				Number.isInteger(contentIndex) &&
+				contentIndex >= 0 &&
+				contentIndex < event.message.content.length &&
+				event.message.content[contentIndex]?.type === "text"
+			) {
+				this.#queueAssistantText(this.ctx.streamingComponent, event.message);
+			} else {
+				this.#cancelAssistantTextPresentation();
+				this.ctx.streamingComponent.updateContent(this.ctx.streamingMessage, { streaming: true });
+			}
 			const changedContent =
 				typeof contentIndex === "number" && contentIndex >= 0
 					? this.ctx.streamingMessage.content[contentIndex]
@@ -714,6 +854,7 @@ export class EventController {
 
 	async #handleMessageEnd(event: Extract<AgentSessionEvent, { type: "message_end" }>): Promise<void> {
 		if (event.message.role === "user") return;
+		if (event.message.role === "assistant") this.#cancelAssistantTextPresentation();
 		if (this.ctx.streamingComponent && event.message.role === "assistant") {
 			if (this.ctx.streamingMessage?.role === "assistant") {
 				transferSessionMessageIdentity([this.ctx.streamingMessage], [event.message]);
@@ -916,6 +1057,8 @@ export class EventController {
 	}
 
 	async #handleAgentEnd(event: Extract<AgentSessionEvent, { type: "agent_end" }>): Promise<void> {
+		this.#flushAssistantText();
+		this.#cancelAssistantTextPresentation();
 		this.ctx.setWorkingMessage(undefined);
 		stopInteractiveActivityIndicator(this.ctx, { foregroundSettled: true });
 		if (this.ctx.streamingComponent) {

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -3265,6 +3265,7 @@ export class SelectorController {
 	}
 
 	#clearTransientSessionUi(options?: { restoreBackground?: boolean; clearSpecializedLoaders?: boolean }): void {
+		this.ctx.resetAssistantTextPresentation();
 		if (options?.clearSpecializedLoaders) clearInteractiveActivityLoaders(this.ctx);
 		stopInteractiveActivityIndicator(this.ctx, {
 			restoreBackground: options?.restoreBackground,

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -780,6 +780,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#btwController = new BtwController(this);
 		this.#extensionUiController = new ExtensionUiController(this);
 		this.#eventController = new EventController(this);
+		this.ui.setRenderPreparationLifecycleCallbacks({
+			invalidate: () => this.#eventController.suspendAssistantTextPresentation(),
+			beforeStart: () => this.#eventController.resumeAssistantTextPresentation(),
+		});
 		this.#commandController = new CommandController(this);
 		this.#todoCommandController = new TodoCommandController(this);
 		this.#selectorController = new SelectorController(this);
@@ -1521,6 +1525,7 @@ export class InteractiveMode implements InteractiveModeContext {
 
 	rebuildChatFromMessages(policy: TranscriptRebuildPolicy): void {
 		prepareTranscriptRebuild(this.ui, policy);
+		this.resetAssistantTextPresentation();
 		this.chatContainer.clear();
 		const context = this.session.buildDisplaySessionContext();
 		this.renderSessionContext(context);
@@ -1653,6 +1658,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	stop(): void {
 		const wasInitialized = this.isInitialized;
 		this.#stopped = true;
+		this.ui.setRenderPreparationLifecycleCallbacks(undefined);
 		this.#inputController.discardDeferredSubmission();
 		for (const listener of this.#stopListeners) {
 			try {
@@ -2079,6 +2085,10 @@ export class InteractiveMode implements InteractiveModeContext {
 
 	isKnownSlashCommand(text: string): boolean {
 		return this.#uiHelpers.isKnownSlashCommand(text);
+	}
+
+	resetAssistantTextPresentation(): void {
+		this.#eventController.resetAssistantTextPresentation();
 	}
 
 	/** Advances the sticky-viewport source only for semantic transcript output. */

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -355,6 +355,7 @@ export interface InteractiveModeContext {
 	extractAssistantText(message: AssistantMessage): string;
 	/** Records one semantic visible-transcript mutation for the sticky viewport. */
 	recordVisibleTranscriptMutation?(): void;
+	resetAssistantTextPresentation(): void;
 	updateEditorTopBorder(): void;
 	updateEditorBorderColor(): void;
 	rebuildChatFromMessages(policy: TranscriptRebuildPolicy): void;

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -944,6 +944,7 @@ export class UiHelpers {
 		this.ctx.pendingPythonComponents = this.ctx.pendingPythonComponents.filter(component =>
 			runningExecutionComponents.includes(component),
 		);
+		this.ctx.resetAssistantTextPresentation();
 		this.ctx.chatContainer.clear();
 
 		// Reuse a pre-built context when available (e.g. from navigateTree) to avoid a second O(N) walk.

--- a/packages/coding-agent/test/event-controller-abort-render.test.ts
+++ b/packages/coding-agent/test/event-controller-abort-render.test.ts
@@ -14,12 +14,25 @@
  *       → `updateContent` receives a message with `stopReason: "stop"`;
  *         `errorMessage` is NOT set (TTSR existing behavior unchanged).
  */
-import { describe, expect, it, vi } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import type { AssistantMessage } from "@gajae-code/ai";
+import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
 import { EventController } from "@gajae-code/coding-agent/modes/controllers/event-controller";
+import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
 import type { InteractiveModeContext } from "@gajae-code/coding-agent/modes/types";
 import type { AgentSessionEvent } from "@gajae-code/coding-agent/session/agent-session";
 import { SILENT_ABORT_MARKER } from "@gajae-code/coding-agent/session/messages";
+import { Container } from "@gajae-code/tui";
+
+beforeEach(async () => {
+	resetSettingsForTest();
+	await Settings.init({ inMemory: true });
+	await initTheme(false);
+});
+afterEach(() => {
+	vi.restoreAllMocks();
+	resetSettingsForTest();
+});
 
 function makeAssistantMessage(overrides: Partial<AssistantMessage> = {}): AssistantMessage {
 	return {
@@ -51,11 +64,23 @@ function createFixture(opts: {
 	const setUsageInfo = vi.fn();
 	const streamingComponent = { updateContent, setUsageInfo };
 	const requestRender = vi.fn();
+	const preparations = new Set<() => void>();
+	const captured: Array<() => void> = [];
 
 	const ctx = {
 		isInitialized: true,
 		init: vi.fn(async () => {}),
-		ui: { requestRender },
+		ui: {
+			requestRender,
+			enqueueBeforeRender: (callback: () => void) => {
+				preparations.add(callback);
+				captured.push(callback);
+				return () => {
+					preparations.delete(callback);
+				};
+			},
+		},
+		chatContainer: new Container(),
 		statusLine: { invalidate: vi.fn() },
 		updateEditorTopBorder: vi.fn(),
 		streamingComponent,
@@ -68,10 +93,68 @@ function createFixture(opts: {
 	} as unknown as InteractiveModeContext;
 
 	const controller = new EventController(ctx);
-	return { controller, ctx, streamingComponent, requestRender };
+	return { controller, ctx, streamingComponent, requestRender, preparations, captured };
 }
 
 describe("EventController #handleMessageEnd abort labeling", () => {
+	for (const ending of ["success", "error", "visible", "silent", "ttsr"] as const) {
+		it(`queued text cannot supersede authoritative ${ending} finalization`, async () => {
+			const initial = makeAssistantMessage({ stopReason: "stop", content: [] });
+			const f = createFixture({ streamingMessage: initial, isTtsrAbortPending: ending === "ttsr" });
+			await f.controller.handleEvent({ type: "message_start", message: initial });
+			const component = f.ctx.streamingComponent!;
+			const projection = vi.spyOn(component, "updateContent");
+			const setUsageInfo = component.setUsageInfo.bind(component);
+			const usage = vi.spyOn(component, "setUsageInfo").mockImplementation(value => {
+				// The controller's authoritative final projection precedes usage.
+				expect(projection).toHaveBeenCalledTimes(1);
+				setUsageInfo(value);
+				// Real usage presentation reprojects the saved final message, not a queued delta.
+				expect(projection).toHaveBeenCalledTimes(2);
+			});
+			const draft = makeAssistantMessage({ stopReason: "stop" });
+			await f.controller.handleEvent({
+				type: "message_update",
+				message: draft,
+				assistantMessageEvent: { type: "text_delta", contentIndex: 0 },
+			} as never);
+			expect(projection).not.toHaveBeenCalled();
+			expect(f.preparations.size).toBe(1);
+			const final = makeAssistantMessage({
+				content: [{ type: "text", text: "authoritative final differs from draft" }],
+				stopReason: ending === "success" ? "stop" : ending === "error" ? "error" : "aborted",
+				errorMessage:
+					ending === "silent" ? SILENT_ABORT_MARKER : ending === "error" ? "provider failed" : undefined,
+			});
+			await f.controller.handleEvent({ type: "message_end", message: final });
+			expect(f.preparations.size).toBe(0);
+			expect(usage).toHaveBeenCalledTimes(1);
+			const finalProjectionCount = projection.mock.calls.length;
+			const finalRendered = component.render(80);
+			f.captured[0]!();
+			expect(projection).toHaveBeenCalledTimes(finalProjectionCount);
+			expect(component.render(80)).toEqual(finalRendered);
+			const [display, options] = projection.mock.calls[0]!;
+			for (const [projectedMessage, projectedOptions] of projection.mock.calls) {
+				expect(projectedMessage).toBe(display);
+				expect(projectedOptions).toEqual({ streaming: false });
+			}
+			expect(options).toEqual({ streaming: false });
+			expect(display.content).toEqual(final.content);
+			expect(display.stopReason).toBe(ending === "silent" || ending === "ttsr" ? "stop" : final.stopReason);
+			if (ending === "visible") expect(display.errorMessage).toBe("Operation aborted");
+			if (ending === "silent") expect(final.errorMessage).toBe(SILENT_ABORT_MARKER);
+			if (ending === "ttsr") expect(final.errorMessage).toBeUndefined();
+			if (ending === "error") expect(display.errorMessage).toBe("provider failed");
+			expect(usage).toHaveBeenCalledWith(final.usage);
+			expect(f.ctx.streamingComponent).toBeUndefined();
+			expect(f.ctx.streamingMessage).toBeUndefined();
+			f.controller.resumeAssistantTextPresentation();
+			expect(f.preparations.size).toBe(0);
+			expect(projection).toHaveBeenCalledTimes(finalProjectionCount);
+		});
+	}
+
 	it("C1: SILENT_ABORT_MARKER + aborted -> updateContent stopReason='stop', errorMessage NOT overwritten", async () => {
 		const message = makeAssistantMessage({
 			stopReason: "aborted",

--- a/packages/coding-agent/test/modes/components/assistant-message-streaming.test.ts
+++ b/packages/coding-agent/test/modes/components/assistant-message-streaming.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeEach, describe, expect, it, vi } from "bun:test";
 import type { AssistantMessage } from "@gajae-code/ai";
-import { Container, Spacer, Text } from "@gajae-code/tui";
+import { Container, Image, ImageProtocol, Spacer, setTerminalImageProtocol, TERMINAL, Text } from "@gajae-code/tui";
 import {
 	__markdownPerfCounters,
 	__setMarkdownNowForTest,
@@ -54,6 +54,31 @@ function countChildren(
 	return contentChildren(component).filter(child => child instanceof type).length;
 }
 
+async function withDeferredImages(run: (conversions: PromiseWithResolvers<string>[]) => Promise<void>): Promise<void> {
+	const originalImage = Bun.Image;
+	const originalProtocol = TERMINAL.imageProtocol;
+	const conversions: PromiseWithResolvers<string>[] = [];
+	class DeferredImage {
+		png(): { toBase64(): Promise<string> } {
+			return {
+				toBase64: () => {
+					const conversion = Promise.withResolvers<string>();
+					conversions.push(conversion);
+					return conversion.promise;
+				},
+			};
+		}
+	}
+	(Bun as unknown as { Image: typeof Bun.Image }).Image = DeferredImage as never;
+	setTerminalImageProtocol(ImageProtocol.Kitty);
+	try {
+		await run(conversions);
+	} finally {
+		(Bun as unknown as { Image: typeof Bun.Image }).Image = originalImage;
+		setTerminalImageProtocol(originalProtocol);
+	}
+}
+
 describe("AssistantMessageComponent streaming markdown", () => {
 	beforeEach(async () => {
 		clearRenderCache();
@@ -66,6 +91,143 @@ describe("AssistantMessageComponent streaming markdown", () => {
 	});
 	afterAll(() => {
 		__setMarkdownNowForTest(undefined);
+	});
+
+	it("does not enable stale-throttle repaint scheduling without an owner callback", () => {
+		const staleThrottle = vi.spyOn(Markdown.prototype, "setOnStaleThrottle");
+		let component: AssistantMessageComponent | undefined;
+		try {
+			const content = [
+				{ type: "text" as const, text: "text" },
+				{ type: "thinking" as const, thinking: "thinking" },
+			];
+			component = new AssistantMessageComponent(message(content));
+			component.updateContent(message(content), { streaming: true });
+			expect(staleThrottle.mock.calls.length).toBeGreaterThanOrEqual(4);
+			expect(staleThrottle.mock.calls.every(([callback]) => callback === undefined)).toBe(true);
+		} finally {
+			component?.dispose();
+			staleThrottle.mockRestore();
+		}
+	});
+
+	it.each([
+		"text",
+		"thinking",
+	] as const)("guards captured %s repaint callbacks without expiring finalized assistants", kind => {
+		const repaint = vi.fn();
+		const visibleMutation = vi.fn();
+		const staleThrottle = vi.spyOn(Markdown.prototype, "setOnStaleThrottle");
+		const block =
+			kind === "text"
+				? { type: "text" as const, text: "initial" }
+				: { type: "thinking" as const, thinking: "initial" };
+		let component: AssistantMessageComponent | undefined;
+		try {
+			component = new AssistantMessageComponent(message([block]), false, repaint, undefined, visibleMutation);
+			const markdown = contentChildren(component).find(child => child instanceof Markdown);
+			expect(markdown).toBeDefined();
+			if (!markdown) return;
+			component.updateContent(message([block]), { streaming: true });
+			if (block.type === "text") block.text = "updated";
+			else block.thinking = "updated";
+			component.updateContent(message([block]), { streaming: true });
+			component.updateContent(message([block]), { streaming: false });
+			expect(contentChildren(component)).toContain(markdown);
+			const callbacks = staleThrottle.mock.calls.map(([callback]) => callback);
+			expect(callbacks.length).toBeGreaterThanOrEqual(4);
+			expect(callbacks[0]).toBeTypeOf("function");
+			expect(new Set(callbacks).size).toBe(1);
+			repaint.mockClear();
+			callbacks[0]?.();
+			expect(repaint).toHaveBeenCalledTimes(1);
+			// Detach the cached child before disposal: its captured callback still belongs to the assistant.
+			component.updateContent(message([{ type: "text", text: "replacement" }]), { streaming: false });
+			component.dispose();
+			const disposedChildren = [...component.children];
+			repaint.mockClear();
+			visibleMutation.mockClear();
+			for (const callback of callbacks) callback?.();
+			component.setHideThinkingBlock(true);
+			component.setUsageInfo(message([]).usage);
+			component.setToolResultImages("read-1", [{ type: "image", data: "source", mimeType: "image/png" }]);
+			component.updateContent(message([{ type: "text", text: "must not resurrect" }]));
+			component.invalidate();
+			expect(component.children).toEqual(disposedChildren);
+			expect(repaint).not.toHaveBeenCalled();
+			expect(visibleMutation).not.toHaveBeenCalled();
+		} finally {
+			component?.dispose();
+			staleThrottle.mockRestore();
+		}
+	});
+
+	it.each(["success", "failure"] as const)("ignores late image %s after disposal", async outcome => {
+		await withDeferredImages(async conversions => {
+			const repaint = vi.fn();
+			const visibleMutation = vi.fn();
+			const component = new AssistantMessageComponent(
+				message([{ type: "text", text: "final" }]),
+				false,
+				repaint,
+				undefined,
+				visibleMutation,
+			);
+			component.setToolResultImages("read-1", [{ type: "image", data: "source", mimeType: "image/webp" }]);
+			expect(conversions).toHaveLength(1);
+			component.dispose();
+			repaint.mockClear();
+			visibleMutation.mockClear();
+			if (outcome === "success") conversions[0].resolve("converted");
+			else conversions[0].reject(new Error("conversion failed"));
+			await Promise.resolve();
+			await Promise.resolve();
+			expect(repaint).not.toHaveBeenCalled();
+			expect(visibleMutation).not.toHaveBeenCalled();
+		});
+	});
+
+	it.each([
+		"success",
+		"failure",
+	] as const)("ignores stale generation %s while completing a live finalized image", async outcome => {
+		await withDeferredImages(async conversions => {
+			const repaint = vi.fn();
+			const visibleMutation = vi.fn();
+			const block = { type: "text" as const, text: "streaming" };
+			const component = new AssistantMessageComponent(message([block]), false, repaint, undefined, visibleMutation);
+			try {
+				component.updateContent(message([block]), { streaming: true });
+				const images = [{ type: "image" as const, data: "source", mimeType: "image/webp" }];
+				component.setToolResultImages("read-1", images);
+				component.setToolResultImages("read-1", []);
+				component.setToolResultImages("read-1", images);
+				expect(conversions).toHaveLength(2);
+				block.text = "authoritative final";
+				component.updateContent(message([block]), { streaming: false });
+				const finalChildren = [...contentChildren(component)];
+				repaint.mockClear();
+				visibleMutation.mockClear();
+				if (outcome === "success") conversions[0].resolve("obsolete");
+				else conversions[0].reject(new Error("obsolete conversion"));
+				await Promise.resolve();
+				await Promise.resolve();
+				expect(contentChildren(component)).toEqual(finalChildren);
+				expect(repaint).not.toHaveBeenCalled();
+				expect(visibleMutation).not.toHaveBeenCalled();
+				conversions[1].resolve("fresh");
+				await Promise.resolve();
+				await Promise.resolve();
+				expect(contentChildren(component).some(child => child instanceof Image)).toBe(true);
+				expect(repaint).toHaveBeenCalledTimes(1);
+				expect(visibleMutation).toHaveBeenCalledTimes(1);
+				visibleMutation.mockClear();
+				component.updateContent(message([block]), { streaming: false });
+				expect(visibleMutation).not.toHaveBeenCalled();
+			} finally {
+				component.dispose();
+			}
+		});
 	});
 
 	it("only re-lexes the active block while earlier blocks are unchanged", () => {

--- a/packages/coding-agent/test/modes/controllers/event-controller-text-coalescing.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-text-coalescing.test.ts
@@ -1,0 +1,596 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import type { AssistantMessage } from "@gajae-code/ai";
+import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
+import {
+	__eventControllerPerfCounters,
+	EventController,
+} from "@gajae-code/coding-agent/modes/controllers/event-controller";
+import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
+import type { InteractiveModeContext } from "@gajae-code/coding-agent/modes/types";
+import {
+	associateSessionMessageEntryId,
+	getSessionMessageEntryId,
+} from "@gajae-code/coding-agent/session/session-manager";
+import {
+	Container,
+	Editor,
+	Image,
+	ImageProtocol,
+	setTerminalImageProtocol,
+	TERMINAL,
+	Text,
+	TUI,
+} from "@gajae-code/tui";
+import { __setMarkdownNowForTest } from "@gajae-code/tui/components/markdown";
+import { defaultEditorTheme } from "../../../../tui/test/test-themes";
+import { VirtualTerminal } from "../../../../tui/test/virtual-terminal";
+
+function message(text: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "mock",
+		stopReason: "stop",
+		timestamp: 1,
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+	};
+}
+
+async function withDeferredImages(run: (conversions: PromiseWithResolvers<string>[]) => Promise<void>): Promise<void> {
+	const originalImage = Bun.Image;
+	const originalProtocol = TERMINAL.imageProtocol;
+	const conversions: PromiseWithResolvers<string>[] = [];
+	class DeferredImage {
+		png(): { toBase64(): Promise<string> } {
+			return {
+				toBase64: () => {
+					const conversion = Promise.withResolvers<string>();
+					conversions.push(conversion);
+					return conversion.promise;
+				},
+			};
+		}
+	}
+	(Bun as unknown as { Image: typeof Bun.Image }).Image = DeferredImage as never;
+	setTerminalImageProtocol(ImageProtocol.Kitty);
+	try {
+		await run(conversions);
+	} finally {
+		(Bun as unknown as { Image: typeof Bun.Image }).Image = originalImage;
+		setTerminalImageProtocol(originalProtocol);
+	}
+}
+
+function fixture(real = false) {
+	const queued = new Set<() => void>();
+	const captured: Array<() => void> = [];
+	const terminal = new VirtualTerminal(80, 20);
+	const tui = new TUI(terminal);
+	const enqueueBeforeRender = vi.fn((callback: () => void) => {
+		queued.add(callback);
+		captured.push(callback);
+		return () => {
+			queued.delete(callback);
+		};
+	});
+	const chatContainer = new Container();
+	const ctx = {
+		isInitialized: true,
+		statusLine: { invalidate: vi.fn() },
+		updateEditorTopBorder: vi.fn(),
+		ui: real ? tui : { requestRender: vi.fn(), enqueueBeforeRender },
+		chatContainer,
+		pendingTools: new Map(),
+		settings: { get: () => true },
+		session: {},
+		recordVisibleTranscriptMutation: vi.fn(),
+	} as unknown as InteractiveModeContext;
+	const controller = new EventController(ctx);
+	if (real) {
+		let revision = 0n;
+		tui.setViewportOutputSource({ identity: "test-session", revision });
+		vi.spyOn(ctx, "recordVisibleTranscriptMutation").mockImplementation(() => {
+			tui.setViewportOutputSource({ identity: "test-session", revision: ++revision });
+		});
+		tui.addChild(chatContainer);
+		tui.setRenderPreparationLifecycleCallbacks({
+			invalidate: () => controller.suspendAssistantTextPresentation(),
+			beforeStart: () => controller.resumeAssistantTextPresentation(),
+		});
+	}
+	const drain = () => {
+		for (const callback of [...queued]) {
+			queued.delete(callback);
+			callback();
+		}
+	};
+	const update = (value: AssistantMessage, metadata: unknown = { type: "text_delta", contentIndex: 0 }) =>
+		controller.handleEvent({ type: "message_update", message: value, assistantMessageEvent: metadata } as never);
+	return { ctx, controller, queued, captured, drain, update, enqueueBeforeRender, tui, terminal };
+}
+
+beforeEach(async () => {
+	resetSettingsForTest();
+	await Settings.init({ inMemory: true });
+	await initTheme(false);
+});
+afterEach(() => {
+	__eventControllerPerfCounters.disable();
+	__eventControllerPerfCounters.reset();
+	vi.restoreAllMocks();
+	resetSettingsForTest();
+});
+
+describe("assistant text frame preparation", () => {
+	it("prepares latest text with a real Bun.Image WebP-to-PNG conversion", async () => {
+		// Native decoding is real here; only frame scheduling uses the controlled fixture.
+		const seed = Buffer.from(
+			"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC",
+			"base64",
+		);
+		const webp = await new Bun.Image(seed).webp({ quality: 90 }).toBase64();
+		const originalProtocol = TERMINAL.imageProtocol;
+		const f = fixture();
+		setTerminalImageProtocol(ImageProtocol.Kitty);
+		try {
+			await f.controller.handleEvent({ type: "message_start", message: message("old text") });
+			const component = f.ctx.streamingComponent!;
+			const converted = Promise.withResolvers<Image>();
+			vi.spyOn(f.ctx.ui, "requestRender").mockImplementation(() => {
+				const image = (component.children[0] as Container).children.find(child => child instanceof Image);
+				if (image instanceof Image) converted.resolve(image);
+			});
+			component.setToolResultImages("read-1", [{ type: "image", data: webp, mimeType: "image/webp" }]);
+			const latest = message("latest text with native converted image");
+			await f.update(latest);
+			const image = await converted.promise;
+			const png = Buffer.from(image.retainedBase64DataForTest!, "base64");
+			expect([...png.subarray(0, 8)]).toEqual([137, 80, 78, 71, 13, 10, 26, 10]);
+			const metadata = await new Bun.Image(png).metadata();
+			expect(metadata.width).toBe(1);
+			expect(metadata.height).toBe(1);
+			const projection = vi.spyOn(component, "updateContent");
+			expect(f.queued.size).toBe(1);
+			f.drain();
+			expect(projection).toHaveBeenCalledTimes(1);
+			expect(projection).toHaveBeenLastCalledWith(latest, { streaming: true });
+			expect(Bun.stripANSI(component.render(80).join("\n"))).toContain("latest text with native converted image");
+			expect((component.children[0] as Container).children).toContain(image);
+		} finally {
+			f.controller.dispose();
+			setTerminalImageProtocol(originalProtocol);
+		}
+	});
+
+	for (const mode of ["normal", "forced", "input"] as const) {
+		it(`prepares replacement text and deferred image double together in the first ${mode} frame`, async () => {
+			await withDeferredImages(async conversions => {
+				const f = fixture(true);
+				let markdownNow = 1_000_000;
+				__setMarkdownNowForTest(() => markdownNow);
+				const editor = new Editor(defaultEditorTheme);
+				f.tui.addChild(editor);
+				f.tui.setFocus(editor);
+				try {
+					f.tui.start();
+					await f.terminal.waitForRender();
+					await f.controller.handleEvent({ type: "message_start", message: message("old text") });
+					const component = f.ctx.streamingComponent!;
+					component.setToolResultImages("read-1", [{ type: "image", data: "source", mimeType: "image/webp" }]);
+					expect(conversions).toHaveLength(1);
+					await f.tui.waitForRenderCommit(f.tui.requestRenderWithGeneration(true));
+					const latest = message("replacement text wins over image replay");
+					await f.update(latest);
+					conversions[0]!.resolve("converted");
+					await Promise.resolve();
+					await Promise.resolve();
+					markdownNow += 100;
+					const frames: Array<{ text: string; image: boolean }> = [];
+					const render = component.render.bind(component);
+					vi.spyOn(component, "render").mockImplementation(width => {
+						const image = (component.children[0] as Container).children.some(
+							child => child instanceof Image && child.retainedBase64DataForTest === "converted",
+						);
+						const lines = render(width);
+						frames.push({ text: Bun.stripANSI(lines.join("\n")), image });
+						return lines;
+					});
+					const generation = f.tui.requestRenderWithGeneration(mode === "forced");
+					if (mode === "input") f.terminal.sendInput("x");
+					expect(await f.tui.waitForRenderCommit(generation)).toBe(true);
+					expect(frames.length).toBeGreaterThan(0);
+					expect(frames[0]!.text).toContain("replacement text wins over image replay");
+					expect(frames[0]!.image).toBe(true);
+					expect(f.ctx.streamingMessage).toBe(latest);
+				} finally {
+					f.tui.setRenderPreparationLifecycleCallbacks(undefined);
+					f.controller.dispose();
+					f.tui.stop();
+					__setMarkdownNowForTest(undefined);
+				}
+			});
+		});
+	}
+
+	for (const lifetime of ["historical", "restart", "reset", "dispose"] as const) {
+		it(`deferred image double completion obeys ${lifetime} lifetime after a new assistant starts`, async () => {
+			await withDeferredImages(async conversions => {
+				const f = fixture(true);
+				try {
+					f.tui.start();
+					await f.terminal.waitForRender();
+					await f.controller.handleEvent({ type: "message_start", message: message("historical final") });
+					const historical = f.ctx.streamingComponent!;
+					historical.setToolResultImages("read-1", [{ type: "image", data: "source", mimeType: "image/webp" }]);
+					await f.controller.handleEvent({ type: "message_end", message: message("historical final") });
+					await f.controller.handleEvent({ type: "message_start", message: message("new live assistant") });
+					await f.tui.waitForRenderCommit(f.tui.requestRenderWithGeneration(true));
+					if (lifetime === "restart") {
+						f.tui.stop();
+						f.tui.start();
+						await f.tui.waitForRenderCommit(f.tui.requestRenderWithGeneration(true));
+					}
+					if (lifetime === "reset") f.controller.resetAssistantTextPresentation();
+					if (lifetime === "dispose") f.controller.dispose();
+					const revision = vi.spyOn(f.ctx, "recordVisibleTranscriptMutation");
+					// Publication requests a render itself; keep that origin separate from
+					// the assistant image-completion repaint without suppressing either.
+					let publishing = false;
+					const publish = f.tui.setViewportOutputSource.bind(f.tui);
+					vi.spyOn(f.tui, "setViewportOutputSource").mockImplementation(source => {
+						publishing = true;
+						try {
+							publish(source);
+						} finally {
+							publishing = false;
+						}
+					});
+					const repaintOrigins: string[] = [];
+					const requestRender = f.tui.requestRender.bind(f.tui);
+					const repaint = vi.spyOn(f.tui, "requestRender").mockImplementation((...args) => {
+						repaintOrigins.push(publishing ? "publication" : "image");
+						requestRender(...args);
+					});
+					revision.mockClear();
+					repaint.mockClear();
+					expect(conversions).toHaveLength(1);
+					conversions[0]!.resolve("converted");
+					await Promise.resolve();
+					await Promise.resolve();
+					if (lifetime === "reset" || lifetime === "dispose") {
+						expect(revision).not.toHaveBeenCalled();
+						expect(repaint).not.toHaveBeenCalled();
+					} else {
+						expect(revision).toHaveBeenCalledTimes(1);
+						expect(repaintOrigins).toEqual(["publication", "image"]);
+						expect((historical.children[0] as Container).children.some(child => child instanceof Image)).toBe(
+							true,
+						);
+						await f.tui.waitForRenderCommit(f.tui.requestRenderWithGeneration(true));
+					}
+				} finally {
+					f.tui.setRenderPreparationLifecycleCallbacks(undefined);
+					f.controller.dispose();
+					f.tui.stop();
+				}
+			});
+		});
+	}
+
+	it("retains a manually scrolled viewport through pending text and resize", async () => {
+		const f = fixture(true);
+		try {
+			for (let i = 0; i < 80; i++) f.ctx.chatContainer.addChild(new Text(`history-row-${i}`, 0, 0));
+			f.tui.start();
+			await f.terminal.waitForRender();
+			await f.controller.handleEvent({ type: "message_start", message: message("") });
+			await f.tui.waitForRenderCommit(f.tui.requestRenderWithGeneration(true));
+			expect(f.tui.scrollViewportBy(-30, { pin: "stable" })).toBe(true);
+			await f.tui.waitForRenderCommit(f.tui.requestRenderWithGeneration(true));
+			await f.terminal.flush();
+			const before = f.terminal.getViewport().map(line => Bun.stripANSI(line).trim());
+			const retained = before.find(line => line.startsWith("history-row-"));
+			expect(retained).toBeDefined();
+			const publication = vi.spyOn(f.tui, "setViewportOutputSource");
+			const component = f.ctx.streamingComponent!;
+			// Resize invalidation reprojects cached content with the same streaming
+			// option as deferred text, so distinguish the synchronous call origin.
+			let invalidating = false;
+			const invalidate = component.invalidate.bind(component);
+			vi.spyOn(component, "invalidate").mockImplementation(() => {
+				invalidating = true;
+				try {
+					invalidate();
+				} finally {
+					invalidating = false;
+				}
+			});
+			const deferredProjection = vi.fn();
+			const updateContent = component.updateContent.bind(component);
+			vi.spyOn(component, "updateContent").mockImplementation((value, options) => {
+				if (!invalidating) deferredProjection(value, options);
+				updateContent(value, options);
+			});
+			const latest = message("new assistant output below manual viewport");
+			await f.update(latest);
+			expect(deferredProjection).not.toHaveBeenCalled();
+			expect(publication).not.toHaveBeenCalled();
+			f.terminal.resize(60, 20);
+			await f.tui.waitForRenderCommit(f.tui.requestRenderWithGeneration(true));
+			await f.terminal.flush();
+			expect(publication).toHaveBeenCalledTimes(1);
+			expect(deferredProjection).toHaveBeenCalledTimes(1);
+			expect(deferredProjection).toHaveBeenCalledWith(latest, { streaming: true });
+			const after = f.terminal.getViewport().map(line => Bun.stripANSI(line).trim());
+			expect(f.tui.manualViewportActive).toBe(true);
+			expect(after).toContain(retained!);
+			expect(after.join("\n")).not.toContain("new assistant output below manual viewport");
+			expect(Bun.stripANSI(f.ctx.streamingComponent!.render(60).join("\n"))).toContain(
+				"new assistant output below manual viewport",
+			);
+		} finally {
+			f.tui.setRenderPreparationLifecycleCallbacks(undefined);
+			f.controller.dispose();
+			f.tui.stop();
+		}
+	});
+
+	for (const role of ["custom", "toolResult"] as const) {
+		it(`preserves pending latest text across ${role} message_end until its frame`, async () => {
+			const f = fixture();
+			try {
+				await f.controller.handleEvent({ type: "message_start", message: message("") });
+				const component = f.ctx.streamingComponent!;
+				const projection = vi.spyOn(component, "updateContent");
+				const latest = message("latest");
+				await f.update(latest);
+				await f.controller.handleEvent({
+					type: "message_end",
+					message:
+						role === "custom"
+							? { role, customType: "hook", content: "hook output", display: true, timestamp: 2 }
+							: { role, toolCallId: "read-1", toolName: "read", content: [], isError: false, timestamp: 2 },
+				} as never);
+				expect(f.ctx.streamingMessage).toBe(latest);
+				expect(f.ctx.streamingComponent).toBe(component);
+				expect(projection).not.toHaveBeenCalled();
+				expect(f.queued.size).toBe(1);
+				f.drain();
+				expect(projection).toHaveBeenCalledTimes(1);
+				expect(projection).toHaveBeenLastCalledWith(latest, { streaming: true });
+				expect(Bun.stripANSI(component.render(80).join("\n"))).toContain("latest");
+				f.captured[0]!();
+				f.drain();
+				expect(projection).toHaveBeenCalledTimes(1);
+			} finally {
+				f.controller.dispose();
+			}
+		});
+	}
+
+	for (const mutable of [false, true]) {
+		it(`keeps 100 semantic visits but one latest projection (${mutable ? "mutable" : "replacement"})`, async () => {
+			const f = fixture();
+			let current = message("");
+			associateSessionMessageEntryId(current, "stream-identity");
+			await f.controller.handleEvent({ type: "message_start", message: current });
+			const component = f.ctx.streamingComponent!;
+			const projection = vi.spyOn(component, "updateContent");
+			__eventControllerPerfCounters.enable();
+			for (let burst = 0; burst < 2; burst++) {
+				for (let i = 1; i <= 100; i++) {
+					const text = `burst ${burst}: ${i}`;
+					if (mutable) current.content = [{ type: "text", text }];
+					else current = message(text);
+					await f.update(current);
+					expect(f.ctx.streamingMessage).toBe(current);
+					expect(getSessionMessageEntryId(current)).toBe("stream-identity");
+				}
+				expect(projection).toHaveBeenCalledTimes(burst);
+				expect(f.queued.size).toBe(1);
+				f.drain();
+				expect(projection).toHaveBeenLastCalledWith(current, { streaming: true });
+				expect(__eventControllerPerfCounters.messageUpdateContentVisits).toBe((burst + 1) * 100);
+			}
+			expect(projection).toHaveBeenCalledTimes(2);
+		});
+	}
+
+	for (const metadata of [
+		undefined,
+		{},
+		{ type: "unknown", contentIndex: 0 },
+		{ type: "text_start", contentIndex: 0 },
+		{ type: "text_end", contentIndex: 0 },
+		...[undefined, -1, 0.5, 1, NaN, Infinity, "0"].map(contentIndex => ({ type: "text_delta", contentIndex })),
+		{ type: "thinking_delta", contentIndex: 0 },
+		{ type: "toolcall_delta", contentIndex: 0 },
+	]) {
+		it(`supersedes pending projection immediately for ${JSON.stringify(metadata)}`, async () => {
+			const f = fixture();
+			await f.controller.handleEvent({ type: "message_start", message: message("") });
+			const projection = vi.spyOn(f.ctx.streamingComponent!, "updateContent");
+			await f.update(message("queued"));
+			const boundary = message("boundary");
+			await f.controller.handleEvent({
+				type: "message_update",
+				message: boundary,
+				assistantMessageEvent: metadata,
+			} as never);
+			expect(projection).toHaveBeenCalledTimes(1);
+			expect(projection).toHaveBeenLastCalledWith(boundary, { streaming: true });
+			f.captured[0]!();
+			expect(projection).toHaveBeenCalledTimes(1);
+		});
+	}
+
+	it("rejects indexed thinking content even when metadata says text_delta", async () => {
+		const f = fixture();
+		await f.controller.handleEvent({ type: "message_start", message: message("") });
+		const projection = vi.spyOn(f.ctx.streamingComponent!, "updateContent");
+		const thinking = message("");
+		thinking.content = [{ type: "thinking", thinking: "reasoning" }];
+		await f.update(thinking);
+		expect(projection).toHaveBeenCalledTimes(1);
+		expect(f.queued.size).toBe(0);
+	});
+
+	it("flushes valid orphan text before agent_end removes the live component", async () => {
+		const f = fixture();
+		await f.controller.handleEvent({ type: "message_start", message: message("") });
+		const component = f.ctx.streamingComponent!;
+		const order: string[] = [];
+		const update = component.updateContent.bind(component);
+		vi.spyOn(component, "updateContent").mockImplementation((value, options) => {
+			expect(f.ctx.chatContainer.hasLiveChild(component)).toBe(true);
+			order.push("project");
+			update(value, options);
+		});
+		const dispose = component.dispose.bind(component);
+		vi.spyOn(component, "dispose").mockImplementation(() => {
+			order.push("remove");
+			dispose();
+		});
+		f.ctx.setWorkingMessage = vi.fn();
+		const gate = Promise.withResolvers<void>();
+		const entered = Promise.withResolvers<void>();
+		f.ctx.planModeController = {
+			flushPendingModelSwitch: () => {
+				entered.resolve();
+				return gate.promise;
+			},
+		} as never;
+		let stopped = false;
+		f.ctx.isStopped = () => stopped;
+		await f.update(message("orphan latest"));
+		const pending = f.controller.handleEvent({ type: "agent_end", messages: [] } as never);
+		await entered.promise;
+		expect(order).toEqual(["project", "remove"]);
+		expect(f.ctx.streamingMessage).toBeUndefined();
+		expect(f.ctx.streamingComponent).toBeUndefined();
+		f.captured[0]!();
+		expect(order).toEqual(["project", "remove"]);
+		stopped = true;
+		gate.resolve();
+		await pending;
+	});
+
+	it("processes interleaved read arguments immediately and never replays superseded text", async () => {
+		const f = fixture();
+		await f.controller.handleEvent({ type: "message_start", message: message("") });
+		const projection = vi.spyOn(f.ctx.streamingComponent!, "updateContent");
+		const argsSeen: unknown[] = [];
+		f.ctx.pendingTools.set("read-1", {
+			updateArgs: args => {
+				argsSeen.push(args);
+			},
+			updateResult: vi.fn(),
+			setArgsComplete: vi.fn(),
+			setExpanded: vi.fn(),
+			consumeVisibleTranscriptChange: () => true,
+		});
+		await f.update(message("queued text"));
+		const read = message("text at read boundary");
+		const args = { path: "/tmp/source.ts" };
+		read.content.push({ type: "toolCall", id: "read-1", name: "read", arguments: args });
+		await f.update(read, { type: "toolcall_delta", contentIndex: 1 });
+		expect(argsSeen).toEqual([args]);
+		expect(projection).toHaveBeenCalledTimes(1);
+		expect(f.queued.size).toBe(0);
+		const latest = message("latest after read");
+		latest.content.push(read.content[1]!);
+		await f.update(latest);
+		expect(argsSeen).toEqual([args]);
+		f.drain();
+		expect(projection).toHaveBeenCalledTimes(2);
+		expect(projection).toHaveBeenLastCalledWith(latest, { streaming: true });
+	});
+
+	it("a stale captured callback cannot consume newly rearmed work", async () => {
+		const f = fixture();
+		await f.controller.handleEvent({ type: "message_start", message: message("") });
+		const projection = vi.spyOn(f.ctx.streamingComponent!, "updateContent");
+		await f.update(message("old"));
+		const stale = f.captured[0]!;
+		f.controller.suspendAssistantTextPresentation();
+		expect(f.queued.size).toBe(0);
+		await f.update(message("stopped latest"));
+		expect(f.queued.size).toBe(0);
+		f.controller.resumeAssistantTextPresentation();
+		const latest = message("newest");
+		await f.update(latest);
+		expect(f.queued.size).toBe(1);
+		stale();
+		expect(f.queued.size).toBe(1);
+		f.drain();
+		expect(projection).toHaveBeenCalledTimes(1);
+		expect(projection).toHaveBeenLastCalledWith(latest, { streaming: true });
+	});
+
+	for (const invalidation of ["reset", "dispose", "session", "remove"] as const) {
+		it(`rejects stale captured work after ${invalidation}`, async () => {
+			const f = fixture();
+			await f.controller.handleEvent({ type: "message_start", message: message("") });
+			const component = f.ctx.streamingComponent!;
+			const projection = vi.spyOn(component, "updateContent");
+			await f.update(message("stale"));
+			if (invalidation === "reset") f.controller.resetAssistantTextPresentation();
+			if (invalidation === "dispose") f.controller.dispose();
+			if (invalidation === "session") f.ctx.session = {} as never;
+			if (invalidation === "remove") f.ctx.chatContainer.removeChild(component);
+			f.captured[0]!();
+			f.controller.resumeAssistantTextPresentation();
+			f.drain();
+			expect(projection).not.toHaveBeenCalled();
+			if (invalidation !== "dispose") {
+				await f.controller.handleEvent({ type: "message_start", message: message("") });
+				const fresh = vi.spyOn(f.ctx.streamingComponent!, "updateContent");
+				await f.update(message("fresh"));
+				f.drain();
+				expect(fresh).toHaveBeenCalledTimes(1);
+			}
+		});
+	}
+
+	for (const duringStop of ["none", "delta", "final", "reset", "dispose"] as const) {
+		it(`real TUI restart reconstructs current text: ${duringStop}`, async () => {
+			const f = fixture(true);
+			try {
+				f.tui.start();
+				await f.terminal.waitForRender();
+				await f.controller.handleEvent({ type: "message_start", message: message("") });
+				const projection = vi.spyOn(f.ctx.streamingComponent!, "updateContent");
+				await f.update(message("queued before stop"));
+				f.tui.stop();
+				expect(projection).not.toHaveBeenCalled();
+				if (duringStop === "delta") await f.update(message("latest during stop"));
+				if (duringStop === "final")
+					await f.controller.handleEvent({ type: "message_end", message: message("authoritative final") });
+				if (duringStop === "reset") f.controller.resetAssistantTextPresentation();
+				if (duringStop === "dispose") f.controller.dispose();
+				projection.mockClear();
+				f.tui.start();
+				await f.tui.waitForRenderCommit(f.tui.requestRenderWithGeneration(true));
+				if (duringStop === "none" || duringStop === "delta") {
+					expect(projection).toHaveBeenCalledTimes(1);
+					expect(f.terminal.getWriteLog().join("")).toContain(
+						duringStop === "none" ? "queued before stop" : "latest during stop",
+					);
+				} else expect(projection).not.toHaveBeenCalled();
+			} finally {
+				f.tui.setRenderPreparationLifecycleCallbacks(undefined);
+				f.controller.dispose();
+				f.tui.stop();
+			}
+		});
+	}
+});

--- a/packages/coding-agent/test/modes/controllers/event-controller-viewport-output-revision.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-viewport-output-revision.test.ts
@@ -10,20 +10,33 @@ import type {
 import { EventController } from "@gajae-code/coding-agent/modes/controllers/event-controller";
 import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
 import type { InteractiveModeContext } from "@gajae-code/coding-agent/modes/types";
-import { type Component, Container, Text } from "@gajae-code/tui";
+import { type Component, Container, Editor, Text, TUI } from "@gajae-code/tui";
+import { renderMetrics } from "../../../../tui/src/metrics";
+import { defaultEditorTheme } from "../../../../tui/test/test-themes";
+import { VirtualTerminal } from "../../../../tui/test/virtual-terminal";
 
 function createContext(handle: ToolExecutionHandle): {
 	ctx: InteractiveModeContext;
 	addMessageToChat: Mock<() => Component[]>;
 	recordVisibleTranscriptMutation: Mock<() => void>;
+	drain: () => void;
 } {
 	const addMessageToChat = vi.fn<() => Component[]>(() => []);
 	const recordVisibleTranscriptMutation = vi.fn();
+	const preparations = new Set<() => void>();
 	const ctx = {
 		isInitialized: true,
 		statusLine: { invalidate: vi.fn() },
 		updateEditorTopBorder: vi.fn(),
-		ui: { requestRender: vi.fn() },
+		ui: {
+			requestRender: vi.fn(),
+			enqueueBeforeRender: (callback: () => void) => {
+				preparations.add(callback);
+				return () => {
+					preparations.delete(callback);
+				};
+			},
+		},
 		pendingTools: new Map([["tool-1", handle]]),
 		addMessageToChat,
 		recordVisibleTranscriptMutation,
@@ -33,7 +46,17 @@ function createContext(handle: ToolExecutionHandle): {
 		session: { getToolByName: vi.fn() },
 		sessionManager: { getCwd: vi.fn(() => process.cwd()) },
 	} as unknown as InteractiveModeContext;
-	return { ctx, addMessageToChat, recordVisibleTranscriptMutation };
+	return {
+		ctx,
+		addMessageToChat,
+		recordVisibleTranscriptMutation,
+		drain: () => {
+			for (const callback of [...preparations]) {
+				preparations.delete(callback);
+				callback();
+			}
+		},
+	};
 }
 
 async function waitFor(condition: () => boolean): Promise<void> {
@@ -64,7 +87,251 @@ describe("EventController viewport output revision", () => {
 	});
 
 	afterEach(() => {
+		vi.restoreAllMocks();
 		resetSettingsForTest();
+	});
+
+	for (const mode of ["normal", "forced", "input"] as const) {
+		for (const reject of [false, true]) {
+			for (const independentDirty of [false, true]) {
+				it(`publishes text before ${mode} frame during ${reject ? "rejected" : "resolved"} reload, independent dirty=${independentDirty}`, async () => {
+					await Settings.init({ inMemory: true });
+					const handle: ToolExecutionHandle = {
+						updateArgs: vi.fn(),
+						updateResult: vi.fn(),
+						setArgsComplete: vi.fn(),
+						setExpanded: vi.fn(),
+					};
+					const { ctx, recordVisibleTranscriptMutation } = createContext(handle);
+					const terminal = new VirtualTerminal(80, 20);
+					const tui = new TUI(terminal);
+					const metricsEnabled = renderMetrics.enabled;
+					renderMetrics.enable();
+					const commits = vi.spyOn(renderMetrics, "recordRender");
+					ctx.ui = tui;
+					let revision = 0n;
+					tui.setViewportOutputSource({ identity: "test-session", revision });
+					recordVisibleTranscriptMutation.mockImplementation(() => {
+						tui.setViewportOutputSource({ identity: "test-session", revision: ++revision });
+					});
+					tui.addChild(ctx.chatContainer);
+					const editor = new Editor(defaultEditorTheme);
+					tui.addChild(editor);
+					tui.setFocus(editor);
+					const controller = new EventController(ctx);
+					tui.setRenderPreparationLifecycleCallbacks({
+						invalidate: () => controller.suspendAssistantTextPresentation(),
+						beforeStart: () => controller.resumeAssistantTextPresentation(),
+					});
+					const gate = Promise.withResolvers<void>();
+					const entered = Promise.withResolvers<void>();
+					ctx.reloadTodos = vi.fn(() => {
+						entered.resolve();
+						return gate.promise;
+					});
+					try {
+						tui.start();
+						await terminal.waitForRender();
+						await controller.handleEvent({ type: "message_start", message: assistantMessage("historical") });
+						const historical = ctx.streamingComponent!;
+						await controller.handleEvent({ type: "message_end", message: assistantMessage("historical") });
+						await controller.handleEvent({ type: "message_start", message: assistantMessage("") });
+						await tui.waitForRenderCommit(tui.requestRenderWithGeneration(true));
+						const drainScheduler = async () => {
+							// Probe for forbidden follow-up work only after a real commit barrier.
+							// Do not use this fake-clock probe to establish a required commit.
+							for (let turn = 0; turn < 3; turn++) {
+								await Promise.resolve();
+								await new Promise<void>(resolve => process.nextTick(resolve));
+								vi.advanceTimersByTime(100);
+								await Promise.resolve();
+							}
+						};
+						recordVisibleTranscriptMutation.mockClear();
+						const component = ctx.streamingComponent!;
+						const projection = vi.spyOn(component, "updateContent");
+						const latest = assistantMessage("prepared while reload waits");
+						const commitsBeforeQueue = commits.mock.calls.length;
+						await controller.handleEvent({
+							type: "message_update",
+							message: latest,
+							assistantMessageEvent: { type: "text_delta", contentIndex: 0 },
+						} as never);
+						const pending = controller.handleEvent({ type: "todo_auto_clear" } as never);
+						// Attach the rejection observer before rejecting, without changing dispatch semantics.
+						const settled = pending.then(
+							() => undefined,
+							error => error,
+						);
+						await entered.promise;
+						if (independentDirty)
+							historical.updateContent(assistantMessage("independent historical image equivalent"), {
+								streaming: false,
+							});
+						expect(recordVisibleTranscriptMutation).not.toHaveBeenCalled();
+						const seen: number[] = [];
+						const originalRender = component.render.bind(component);
+						vi.spyOn(component, "render").mockImplementation(width => {
+							seen.push(recordVisibleTranscriptMutation.mock.calls.length);
+							return originalRender(width);
+						});
+						const generation = tui.requestRenderWithGeneration(mode === "forced");
+						if (mode === "input") terminal.sendInput("x");
+						expect(await tui.waitForRenderCommit(generation)).toBe(true);
+						expect(commits).toHaveBeenCalledTimes(commitsBeforeQueue + 1);
+						expect(projection).toHaveBeenCalledTimes(1);
+						expect(seen.length).toBeGreaterThan(0);
+						expect(seen.every(count => count === 1)).toBe(true);
+						expect(terminal.getWriteLog().join("")).toContain("prepared while reload waits");
+						const renderedBeforeSettlement = seen.length;
+						const commitsBeforeSettlement = commits.mock.calls.length;
+						const writesBeforeSettlement = [...terminal.getWriteLog()];
+						// No-dirty settlements must not request any frame. Install the controlled
+						// clock before settlement to detect such work without creating a barrier.
+						if (!independentDirty || reject) vi.useFakeTimers();
+						if (reject) gate.reject(new Error("reload failed"));
+						else gate.resolve();
+						const result = await settled;
+						if (reject) expect(result).toBeInstanceOf(Error);
+						else expect(result).toBeUndefined();
+						expect(recordVisibleTranscriptMutation).toHaveBeenCalledTimes(independentDirty && !reject ? 2 : 1);
+						expect(projection).toHaveBeenCalledTimes(1);
+						if (!independentDirty || reject) {
+							await drainScheduler();
+							expect(seen).toHaveLength(renderedBeforeSettlement);
+							expect(commits).toHaveBeenCalledTimes(commitsBeforeSettlement);
+							expect(terminal.getWriteLog()).toEqual(writesBeforeSettlement);
+						} else {
+							// Publication is asserted above. Drain its legitimate render request via
+							// a real generation barrier, not fake elapsed time: TUI's frame budget
+							// uses performance.now(), which need not share the fake timer clock.
+							const settledGeneration = tui.requestRenderWithGeneration(true);
+							expect(await tui.waitForRenderCommit(settledGeneration)).toBe(true);
+							expect(projection).toHaveBeenCalledTimes(1);
+							vi.useFakeTimers();
+						}
+						const quiescentReads = seen.length;
+						const quiescentCommits = commits.mock.calls.length;
+						const quiescentWrites = [...terminal.getWriteLog()];
+						await drainScheduler();
+						expect(seen).toHaveLength(quiescentReads);
+						expect(commits).toHaveBeenCalledTimes(quiescentCommits);
+						expect(terminal.getWriteLog()).toEqual(quiescentWrites);
+						expect(projection).toHaveBeenCalledTimes(1);
+					} finally {
+						gate.resolve();
+						tui.setRenderPreparationLifecycleCallbacks(undefined);
+						controller.dispose();
+						tui.stop();
+						vi.useRealTimers();
+						commits.mockRestore();
+						if (!metricsEnabled) renderMetrics.disable();
+					}
+				});
+			}
+		}
+	}
+
+	it("restores the exact-component publication scope after a throwing projection", async () => {
+		await Settings.init({ inMemory: true });
+		const handle: ToolExecutionHandle = {
+			updateArgs: vi.fn(),
+			updateResult: vi.fn(),
+			setArgsComplete: vi.fn(),
+			setExpanded: vi.fn(),
+		};
+		const { ctx, drain, recordVisibleTranscriptMutation } = createContext(handle);
+		const controller = new EventController(ctx);
+		await controller.handleEvent({ type: "message_start", message: assistantMessage("") });
+		const component = ctx.streamingComponent!;
+		const originalUpdate = component.updateContent.bind(component);
+		const projection = vi.spyOn(component, "updateContent").mockImplementationOnce(() => {
+			throw new Error("projection failed");
+		});
+		await controller.handleEvent({
+			type: "message_update",
+			message: assistantMessage("queued"),
+			assistantMessageEvent: { type: "text_delta", contentIndex: 0 },
+		} as never);
+		const gate = Promise.withResolvers<void>();
+		const entered = Promise.withResolvers<void>();
+		ctx.reloadTodos = vi.fn(() => {
+			entered.resolve();
+			return gate.promise;
+		});
+		const pending = controller.handleEvent({ type: "todo_auto_clear" } as never);
+		await entered.promise;
+		expect(() => drain()).toThrow("projection failed");
+		projection.mockRestore();
+		originalUpdate(assistantMessage("event owned after exception"), { streaming: true });
+		expect(recordVisibleTranscriptMutation).not.toHaveBeenCalled();
+		gate.resolve();
+		await pending;
+		expect(recordVisibleTranscriptMutation).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not classify another component's synchronous callback as prepared text", async () => {
+		await Settings.init({ inMemory: true });
+		const handle: ToolExecutionHandle = {
+			updateArgs: vi.fn(),
+			updateResult: vi.fn(),
+			setArgsComplete: vi.fn(),
+			setExpanded: vi.fn(),
+		};
+		const { ctx, drain, recordVisibleTranscriptMutation } = createContext(handle);
+		ctx.pendingTools.clear();
+		const controller = new EventController(ctx);
+		await controller.handleEvent({ type: "message_start", message: assistantMessage("history") });
+		const historical = ctx.streamingComponent!;
+		await controller.handleEvent({ type: "message_end", message: assistantMessage("history") });
+		await controller.handleEvent({ type: "message_start", message: assistantMessage("") });
+		const current = ctx.streamingComponent!;
+		const update = current.updateContent.bind(current);
+		vi.spyOn(current, "updateContent").mockImplementation((message, options) => {
+			historical.updateContent(assistantMessage("unrelated synchronous output"), { streaming: false });
+			update(message, options);
+		});
+		recordVisibleTranscriptMutation.mockClear();
+		await controller.handleEvent({
+			type: "message_update",
+			message: assistantMessage("latest"),
+			assistantMessageEvent: { type: "text_delta", contentIndex: 0 },
+		} as never);
+		const gate = Promise.withResolvers<void>();
+		const entered = Promise.withResolvers<void>();
+		ctx.reloadTodos = vi.fn(() => {
+			entered.resolve();
+			return gate.promise;
+		});
+		const pending = controller.handleEvent({ type: "todo_auto_clear" } as never);
+		await entered.promise;
+		drain();
+		expect(recordVisibleTranscriptMutation).toHaveBeenCalledTimes(1);
+		gate.resolve();
+		await pending;
+		expect(recordVisibleTranscriptMutation).toHaveBeenCalledTimes(2);
+	});
+
+	it("does not publish a revision for an unchanged deferred text signature", async () => {
+		await Settings.init({ inMemory: true });
+		const handle: ToolExecutionHandle = {
+			updateArgs: vi.fn(),
+			updateResult: vi.fn(),
+			setArgsComplete: vi.fn(),
+			setExpanded: vi.fn(),
+		};
+		const { ctx, drain, recordVisibleTranscriptMutation } = createContext(handle);
+		const controller = new EventController(ctx);
+		const message = assistantMessage("same source");
+		await controller.handleEvent({ type: "message_start", message });
+		recordVisibleTranscriptMutation.mockClear();
+		await controller.handleEvent({
+			type: "message_update",
+			message,
+			assistantMessageEvent: { type: "text_delta", contentIndex: 0 },
+		} as never);
+		drain();
+		expect(recordVisibleTranscriptMutation).not.toHaveBeenCalled();
 	});
 
 	it("does not record a controller revision when an observed apply_patch preview resolves absent", async () => {

--- a/packages/coding-agent/test/perf-baselines-advisory.test.ts
+++ b/packages/coding-agent/test/perf-baselines-advisory.test.ts
@@ -98,6 +98,262 @@ function largeDiff(repetitions: number): string {
 }
 
 describe("advisory performance baselines", () => {
+	it("records real assistant projection and terminal commits across text workloads", async () => {
+		const { Container, Editor, TUI } = await import("@gajae-code/tui");
+		const { renderMetrics } = await import("../../tui/src/metrics");
+		const { VirtualTerminal } = await import("../../tui/test/virtual-terminal");
+		const { defaultEditorTheme } = await import("../../tui/test/test-themes");
+		const { AssistantMessageComponent } = await import("../src/modes/components/assistant-message");
+		type AssistantMessage = import("@gajae-code/ai").AssistantMessage;
+		type Event = Parameters<InstanceType<typeof EventController>["handleEvent"]>[0];
+		const distribution = (samples: number[]) => {
+			const sorted = [...samples].sort((a, b) => a - b);
+			return {
+				count: samples.length,
+				totalMs: samples.reduce((sum, value) => sum + value, 0),
+				p50Ms: sorted[Math.floor((sorted.length - 1) * 0.5)] ?? null,
+				p95Ms: sorted[Math.ceil((sorted.length - 1) * 0.95)] ?? null,
+			};
+		};
+		const metricsWereEnabled = renderMetrics.enabled;
+		renderMetrics.enable();
+		try {
+			await withEventControllerPerfCounters(async () => {
+				// 24 cells, each with one discarded warmup and five recorded repetitions.
+				// Two bursts separated by a real commit exercise a pause without a streaming timer.
+				for (const size of ["short", "long"] as const) {
+					for (const deltas of [1, 10, 100]) {
+						for (const identity of ["mutable", "replacement"] as const) {
+							for (const mixed of [false, true]) {
+								let expectedFinal: string[] | undefined;
+								for (let repetition = -1; repetition < 5; repetition++) {
+									const term = new VirtualTerminal(100, 32);
+									const ui = new TUI(term);
+									const chatContainer = new Container();
+									const editor = new Editor(defaultEditorTheme);
+									ui.addChild(chatContainer);
+									ui.addChild(editor);
+									ui.setFocus(editor);
+									let revision = 0n;
+									let semanticPasses = 0;
+									const ctx = {
+										isInitialized: true,
+										init: async () => {},
+										ui,
+										chatContainer,
+										editor,
+										statusLine: { invalidate: () => {} },
+										updateEditorTopBorder: () => {
+											semanticPasses++;
+										},
+										pendingTools: new Map(),
+										session: { getToolByName: () => undefined, retryAttempt: 0 },
+										sessionManager: { getCwd: () => os.tmpdir() },
+										settings: { get: () => false },
+										hideThinkingBlock: false,
+										toolOutputExpanded: false,
+										setWorkingMessage: () => {},
+										getAssistantViewportAnchorId: () => "perf-assistant",
+										recordVisibleTranscriptMutation: () => {
+											ui.setViewportOutputSource({ identity: "perf-session", revision: ++revision });
+										},
+									} as any;
+									const controller = new EventController(ctx);
+									const projections: Array<{ streaming: boolean; ms: number }> = [];
+									const realUpdate = AssistantMessageComponent.prototype.updateContent;
+									const projectionSpy = spyOn(
+										AssistantMessageComponent.prototype,
+										"updateContent",
+									).mockImplementation(function (
+										this: InstanceType<typeof AssistantMessageComponent>,
+										message,
+										options,
+									) {
+										const started = performance.now();
+										try {
+											return realUpdate.call(this, message, options);
+										} finally {
+											projections.push({
+												streaming: options?.streaming ?? false,
+												ms: performance.now() - started,
+											});
+										}
+									});
+									const controllerMs: number[] = [];
+									const eventToCommitMs: number[] = [];
+									const inputToCommitMs: number[] = [];
+									const commits: Array<{ generation: number; writes: number; bytes: number }> = [];
+									const submitted: Record<string, number> = {};
+									const dispatch = async (event: Event) => {
+										const started = performance.now();
+										submitted[event.type] = (submitted[event.type] ?? 0) + 1;
+										await controller.handleEvent(event);
+										controllerMs.push(performance.now() - started);
+									};
+									const commit = async () => {
+										const generation = ui.requestRenderWithGeneration(false, "perf.assistant.commit");
+										expect(await ui.waitForRenderCommit(generation, 2_000)).toBe(true);
+										const committedAt = performance.now();
+										await term.flush();
+										const writes = term.getWriteLog();
+										commits.push({
+											generation,
+											writes: writes.length,
+											bytes: writes.reduce((sum, text) => sum + Buffer.byteLength(text), 0),
+										});
+										term.clearWriteLog();
+										return committedAt;
+									};
+									let message: AssistantMessage = {
+										role: "assistant",
+										api: "anthropic-messages",
+										provider: "anthropic",
+										model: "perf-fixture",
+										timestamp: 1,
+										stopReason: "stop",
+										usage: {
+											input: 0,
+											output: 0,
+											cacheRead: 0,
+											cacheWrite: 0,
+											totalTokens: 0,
+											cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+										},
+										content: [{ type: "text", text: "## Projection baseline\n\n" }],
+									};
+									const update = async (type: string, contentIndex: number, delta: string) => {
+										await dispatch({
+											type: "message_update",
+											message,
+											assistantMessageEvent: { type, contentIndex, delta, partial: message },
+										} as Event);
+										expect(ctx.streamingMessage).toBe(message);
+									};
+									try {
+										ui.start();
+										await commit();
+										commits.length = 0;
+										renderMetrics.reset();
+										eventControllerPerfCounters.reset();
+										await dispatch({ type: "message_start", message } as Event);
+										const assistant = ctx.streamingComponent as InstanceType<
+											typeof AssistantMessageComponent
+										>;
+										await commit();
+										for (let burst = 0; burst < 2; burst++) {
+											const eventStarts: number[] = [];
+											for (let delta = 0; delta < deltas; delta++) {
+												if (identity === "replacement")
+													message = { ...message, content: message.content.map(block => ({ ...block })) };
+												const text = message.content[0];
+												if (text.type !== "text") throw new Error("fixture lost text block");
+												const chunk =
+													size === "short"
+														? `word${burst}_${delta} `
+														: `\n- **item ${burst}_${delta}**: ${"growing Markdown content ".repeat(12)}\n`;
+												text.text += chunk;
+												eventStarts.push(performance.now());
+												await update("text_delta", 0, chunk);
+											}
+											let inputStarted: number | undefined;
+											if (mixed) {
+												message.content[1] = { type: "thinking", thinking: `Thinking boundary ${burst}` };
+												await update("thinking_delta", 1, `Thinking boundary ${burst}`);
+												message.content[2] = {
+													type: "toolCall",
+													id: "perf-tool",
+													name: "bash",
+													arguments: { command: `echo boundary${burst}` },
+												};
+												await update("toolcall_delta", 2, `boundary${burst}`);
+												inputStarted = performance.now();
+												term.sendInput(burst === 0 ? "Q" : "X");
+											}
+											const committedAt = await commit();
+											for (const started of eventStarts) eventToCommitMs.push(committedAt - started);
+											if (inputStarted !== undefined) {
+												inputToCommitMs.push(committedAt - inputStarted);
+												expect(term.getViewport().join("\n")).toContain(burst === 0 ? "Q" : "QX");
+											}
+										}
+										message = {
+											...message,
+											content: [...message.content, { type: "text", text: "\n\nFINAL-ANCHOR\n" }],
+										};
+										await dispatch({ type: "message_end", message } as Event);
+										await commit();
+										const metrics = renderMetrics.snapshot();
+										const finalOutput = assistant.render(100);
+										expect(finalOutput.join("\n")).toContain("FINAL-ANCHOR");
+										expect(term.getViewport().join("\n")).toContain("FINAL-ANCHOR");
+										expect(ctx.streamingMessage).toBeUndefined();
+										expect(ctx.streamingComponent).toBeUndefined();
+										expect(editor.getText()).toBe(mixed ? "QX" : "");
+										expect(eventControllerPerfCounters.messageUpdateContentVisits).toBe(
+											2 * deltas + (mixed ? 4 : 0),
+										);
+										expect(semanticPasses).toBe(controllerMs.length + 1); // message_end also refreshes the border.
+										expect(revision > 0n).toBe(true);
+										expect(projections.length).toBeGreaterThanOrEqual(2);
+										if (expectedFinal) expect(finalOutput).toEqual(expectedFinal);
+										else expectedFinal = finalOutput;
+										if (repetition >= 0)
+											logBaseline("assistant.real-text-frame", {
+												size,
+												deltasPerBurst: deltas,
+												bursts: 2,
+												identity,
+												mixed,
+												repetition,
+												warmups: 1,
+												repetitions: 5,
+												width: 100,
+												rows: 32,
+												bun: Bun.version,
+												platform: process.platform,
+												arch: process.arch,
+												semantic: {
+													submitted,
+													borderPasses: semanticPasses,
+													contentVisits: eventControllerPerfCounters.messageUpdateContentVisits,
+													visibleRevisions: String(revision),
+												},
+												projection: {
+													...distribution(projections.map(sample => sample.ms)),
+													streamingCalls: projections.filter(sample => sample.streaming).length,
+												},
+												controller: distribution(controllerMs),
+												eventToObservedCommit: distribution(eventToCommitMs),
+												inputToObservedCommit: distribution(inputToCommitMs),
+												commits,
+												render: metrics,
+												finalOutput,
+												preparationCount: {
+													available: false,
+													reason: "No cross-revision public preparation metric",
+												},
+												lexerCount: { available: false, reason: "No lexer instrumentation installed" },
+												latencyScope:
+													"Generation waiter observation, not exact first-write timestamp; includes controller completion and mixed boundaries",
+											});
+									} finally {
+										controller.dispose();
+										ui.stop();
+										ui.dispose();
+										projectionSpy.mockRestore();
+									}
+								}
+							}
+						}
+					}
+				}
+			});
+		} finally {
+			renderMetrics.reset();
+			if (!metricsWereEnabled) renderMetrics.disable();
+		}
+	}, 120_000);
+
 	it("records status-line branch resolver calls across simulated renders", () => {
 		const renders = 12;
 		setProjectDir(os.tmpdir());

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added cancellable, one-shot `enqueueBeforeRender` preparation on the existing frame scheduler and a single-owner `setRenderPreparationLifecycleCallbacks` seam for invalidation and restart preparation. Stop, terminal loss, and disposal cancel stale work; restart preparation runs before the first forced frame without adding another streaming timer.
+
 ## [0.16.3] - 2026-09-04
 
 ## [0.16.2] - 2026-09-04

--- a/packages/tui/README.md
+++ b/packages/tui/README.md
@@ -44,6 +44,60 @@ tui.start();
 
 Main container that manages components and rendering.
 
+#### Frame preparation
+
+`tui.enqueueBeforeRender(callback: () => void): () => void` registers one synchronous,
+one-shot preparation and returns an idempotent cancellation function. It requests a
+normal full-mutation render on the existing 16 ms frame clock; it adds no timer and
+does not force or expedite a frame. Normal, forced, and input-priority frames drain
+the same snapshot before capturing render generations or reading layout, components,
+viewport sources, or caches. Ordinary render requests made by preparation join that
+frame without a request-only follow-up paint. Registrations made while draining run
+in a later frame; their generations cannot commit before that preparation executes,
+even when a newer ordinary request commits first or terminal output is queued.
+
+Cancellation removes callback references, including entries already captured but
+not yet invoked. Retained cancellation handles release their reference to the TUI
+and callback on cancellation, invocation (including failure), or lifecycle
+invalidation. Later cancellation calls are no-ops; an executing callback remains
+live until its synchronous invocation returns. Preparation exceptions are logged, unrelated callbacks continue,
+and the failed preparation's generation is not reported as successfully committed.
+Throwing or lifecycle-invalidated preparations immediately resolve their existing
+commit waiters `false`; late waiters for those generations also resolve `false`,
+even after a newer successful frame. Retired generations are stored as merged,
+sorted failure ranges, separate from live pending-frame exclusions. Contiguous
+failures compact into one range; separated failures retain distinct ranges to
+preserve exact outcomes. Historical failure ranges are not copied or scanned on
+each frame (waiter lookup uses binary search).
+History has no arbitrary expiry: its numeric storage is O(disjoint failed ranges),
+not bounded over an indefinitely alternating failure/success session. Empty active
+pending and hole sets do not imply bounded historical storage or prove leak freedom.
+Callbacks must be synchronous (do not pass async functions).
+
+The cancellation lifetime regression inspects Bun's heap snapshot for outgoing
+local closure/entry paths to the owner, callback and payload, while all targets
+remain deliberately rooted. Pending handles and an intentionally retaining arrow
+are positive controls; retired handles must lose those paths. This checks reference
+release without assuming when GC collects an object. It does not prove global leak
+freedom or exclude unrelated module, runtime or test-runner roots.
+
+`tui.setRenderPreparationLifecycleCallbacks(callbacks: { invalidate: () => void;
+beforeStart: () => void } | undefined): void` installs a **single** preparation owner.
+Replacing or clearing the owner invalidates its old queued and captured work and
+calls its `invalidate` synchronously. Stop, terminal loss, and disposal do the same;
+exceptions are logged without preventing cancellation. Disposal also clears the
+owner. Enqueue while stopped, unavailable, invalidating, or disposed retains no work.
+Disposal cancels pending render/width-settle timers and render requests; later normal,
+forced, input-priority, and resize requests cannot rearm the disposed renderer.
+
+After successful terminal setup, each `start()` calls `beforeStart` synchronously
+before its first forced render request. The owner can enqueue fresh preparation
+from its current authoritative state there, so restarting does not require another
+provider event. Failed setup does not rearm work; a throwing `beforeStart` is logged
+and its queued work is invalidated. Stop/start during a drain cannot revive that
+drain's old snapshot. This API is only a presentation-preparation lifecycle seam,
+not a general lifecycle event bus.
+
 ```typescript
 const tui = new TUI(terminal);
 tui.addChild(component);

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -960,6 +960,20 @@ function hasDistinctPostContractionRows(
 	return false;
 }
 
+interface RenderPreparation {
+	callback?: () => void;
+	generation: number;
+	cancel?: () => void;
+}
+
+// Keep the public handle outside the enqueue scope: it must capture only the entry,
+// not the TUI or the original callback after the entry has been released.
+function createPreparationCancellation(entry: RenderPreparation): () => void {
+	return () => entry.cancel?.();
+}
+
+function cancelNoPreparation(): void {}
+
 /**
  * TUI - Main class for managing terminal UI with differential rendering
  */
@@ -1009,6 +1023,21 @@ export class TUI extends Container {
 	#nextRenderGeneration = 0;
 	#renderRequestedGeneration = 0;
 	#committedRenderGeneration = 0;
+	#preparations = new Set<RenderPreparation>();
+	#preparationSnapshot: Set<RenderPreparation> | undefined;
+	#preparationEpoch = 0;
+	#preparationDrainEpoch = -1;
+	#preparationDisposed = false;
+	#preparationInvalidating = false;
+	#preparationLifecycle: { invalidate: () => void; beforeStart: () => void } | undefined;
+	// A newer ordinary request may commit while an older nested preparation is still pending.
+	// Keep holes in the high-water mark, including for waiters registered after that commit.
+	#preparationBlocked = new Set<number>();
+	#commitHoles = new Set<number>();
+	// Terminal failures are sorted, disjoint inclusive ranges, not per-frame exclusions.
+	#failedPreparationRanges: Array<[number, number]> = [];
+	// Captured by queued terminal writes; never consult the mutable queue at write settlement.
+	#frameCommitExclusions = new Set<number>();
 	#renderCommitWaiters = new Map<number, Set<RenderCommitWaiter>>();
 	#lastRenderWriteSucceeded = false;
 	/** Generation whose render path is currently capturing terminal output. */
@@ -1161,6 +1190,14 @@ export class TUI extends Container {
 		return { ...TUI.#renderCounters };
 	}
 
+	getRenderPreparationStateForTest(): { pending: number; holes: number; failedRanges: number } {
+		return {
+			pending: this.#preparationBlocked.size,
+			holes: this.#commitHoles.size,
+			failedRanges: this.#failedPreparationRanges.length,
+		};
+	}
+
 	static #readDebugRedrawFlag(): boolean {
 		TUI.#renderCounters.debugRedrawEnvReads += 1;
 		return $pickflag("GJC_DEBUG_REDRAW", "PI_DEBUG_REDRAW");
@@ -1249,6 +1286,29 @@ export class TUI extends Container {
 	}
 
 	override dispose(): void {
+		if (this.#preparationDisposed) return;
+		this.#preparationDisposed = true;
+		this.#renderRequested = false;
+		this.#renderRequestedGeneration = 0;
+		this.#inputRenderPending = false;
+		this.#resizeRenderQueued = false;
+		this.#resizeRenderMutationQueued = false;
+		this.#renderMutationQueued = false;
+		this.#widthSettleRenderQueued = false;
+		this.#forcedRenderQueued = false;
+		this.#clearSixelProbeState();
+		if (this.#renderTimer) {
+			clearTimeout(this.#renderTimer);
+			this.#renderTimer = undefined;
+			if (renderMetrics.enabled) renderMetrics.setTimerGauge("tui.renderTimer", 0);
+		}
+		if (this.#widthSettleTimer) {
+			clearTimeout(this.#widthSettleTimer);
+			this.#widthSettleTimer = undefined;
+		}
+		this.#invalidatePreparations();
+		this.#preparationLifecycle = undefined;
+		this.#settleRenderCommitWaiters(false);
 		this.#unsubscribeTabWidthChange?.();
 		this.#unsubscribeTabWidthChange = undefined;
 		this.#finalizeRasterLeases("terminal-loss");
@@ -2314,6 +2374,7 @@ export class TUI extends Container {
 		return true;
 	}
 	start(): void {
+		if (this.#preparationDisposed) return;
 		this.#stopped = false;
 		this.#terminalUnavailable = false;
 		this.#clearMouseSelection();
@@ -2321,31 +2382,36 @@ export class TUI extends Container {
 		// Seed the observed width so a spurious post-start resize event (iTerm2 tab
 		// activation, the self-sent SIGWINCH after resume) is not read as a reflow.
 		this.#lastObservedWidth = this.terminal.columns;
-		this.terminal.setMouseEnabled?.(this.options.enableMouse === true);
-		this.terminal.start(
-			data => this.#handleInput(data),
-			() => {
-				const hadRasterLease = this.#rasterLeases.size > 0;
-				this.#revokeRasterLeases("resize");
-				// Only a pet raster lease needs refreshed cell metrics on resize; a
-				// plain resize keeps the historical byte stream (no cell query).
-				if (hadRasterLease) this.#queryCellSize(true);
-				this.invalidate();
-				if (this.#pendingTerminalCleanup.length > 0 || this.#rasterCleanup.size > 0) {
-					// Retained pet/cleanup output must be flushed before the resize
-					// repaint so it cannot interleave behind the new frame.
-					this.notifyTerminalLifecycle({
-						kind: "explicit-cleanup",
-						source: "tui",
-						terminalGeneration: this.#terminalGeneration,
-					}).then(result => {
-						if (result.stillPending === 0) this.requestResizeRender();
-					});
-				} else {
-					this.requestResizeRender();
-				}
-			},
-		);
+		try {
+			this.terminal.setMouseEnabled?.(this.options.enableMouse === true);
+			this.terminal.start(
+				data => this.#handleInput(data),
+				() => {
+					const hadRasterLease = this.#rasterLeases.size > 0;
+					this.#revokeRasterLeases("resize");
+					// Only a pet raster lease needs refreshed cell metrics on resize; a
+					// plain resize keeps the historical byte stream (no cell query).
+					if (hadRasterLease) this.#queryCellSize(true);
+					this.invalidate();
+					if (this.#pendingTerminalCleanup.length > 0 || this.#rasterCleanup.size > 0) {
+						// Retained pet/cleanup output must be flushed before the resize
+						// repaint so it cannot interleave behind the new frame.
+						this.notifyTerminalLifecycle({
+							kind: "explicit-cleanup",
+							source: "tui",
+							terminalGeneration: this.#terminalGeneration,
+						}).then(result => {
+							if (result.stillPending === 0) this.requestResizeRender();
+						});
+					} else {
+						this.requestResizeRender();
+					}
+				},
+			);
+		} catch (error) {
+			this.#markTerminalUnavailable();
+			throw error;
+		}
 		if (this.#pendingTerminalCleanup.length > 0 || this.#rasterCleanup.size > 0) {
 			void this.notifyTerminalLifecycle({
 				kind: "availability-restored",
@@ -2356,6 +2422,14 @@ export class TUI extends Container {
 		this.#hideCursor();
 		this.#querySixelSupport();
 		this.#queryCellSize();
+		if (this.#stopped || !this.terminalAvailable) return;
+		const epoch = this.#preparationEpoch;
+		if (!this.#callPreparation(this.#preparationLifecycle?.beforeStart, "beforeStart")) {
+			this.#invalidatePreparations();
+			if (!this.#stopped && this.terminalAvailable && !this.#preparationDisposed) this.requestRender(true);
+			return;
+		}
+		if (epoch !== this.#preparationEpoch || this.#stopped || !this.terminalAvailable) return;
 		this.requestRender(true);
 	}
 
@@ -2368,8 +2442,10 @@ export class TUI extends Container {
 	 * holding a session operation behind a dead renderer.
 	 */
 	waitForRenderCommit(generation: number, timeoutMs = 250): Promise<boolean> {
-		if (generation <= 0 || generation <= this.#committedRenderGeneration) return Promise.resolve(true);
-		if (this.#stopped || !this.terminalAvailable) return Promise.resolve(false);
+		if (this.#isFailedPreparation(generation)) return Promise.resolve(false);
+		if (generation <= 0 || (generation <= this.#committedRenderGeneration && !this.#commitHoles.has(generation)))
+			return Promise.resolve(true);
+		if (this.#stopped || !this.terminalAvailable || this.#preparationDisposed) return Promise.resolve(false);
 		return new Promise<boolean>(resolve => {
 			const waiter: RenderCommitWaiter = {
 				resolve,
@@ -2392,14 +2468,31 @@ export class TUI extends Container {
 		});
 	}
 
-	#settleRenderCommitWaiters(committed: boolean, generation = Number.POSITIVE_INFINITY): void {
-		if (committed) this.#committedRenderGeneration = Math.max(this.#committedRenderGeneration, generation);
+	#settleRenderCommitWaiters(
+		committed: boolean,
+		generation = Number.POSITIVE_INFINITY,
+		exclusions = this.#frameCommitExclusions,
+	): void {
+		if (committed) {
+			for (const blocked of exclusions) {
+				if (
+					blocked <= generation &&
+					blocked > this.#committedRenderGeneration &&
+					!this.#isFailedPreparation(blocked)
+				)
+					this.#commitHoles.add(blocked);
+			}
+			for (const hole of this.#commitHoles) {
+				if (hole <= generation && !exclusions.has(hole)) this.#commitHoles.delete(hole);
+			}
+			this.#committedRenderGeneration = Math.max(this.#committedRenderGeneration, generation);
+		}
 		for (const [waiterGeneration, waiters] of this.#renderCommitWaiters) {
-			if (committed && waiterGeneration > generation) continue;
+			if (committed && (waiterGeneration > generation || exclusions.has(waiterGeneration))) continue;
 			this.#renderCommitWaiters.delete(waiterGeneration);
 			for (const waiter of waiters) {
 				clearTimeout(waiter.timer);
-				waiter.resolve(committed);
+				waiter.resolve(committed && !this.#isFailedPreparation(waiterGeneration));
 			}
 		}
 	}
@@ -2440,6 +2533,7 @@ export class TUI extends Container {
 		this.#rasterLeases.clear();
 	}
 	#markTerminalUnavailable(settleRenderWaiters = true): void {
+		this.#invalidatePreparations();
 		this.#terminalGeneration++;
 		for (const record of this.#rasterCleanup.values()) record.terminalGeneration = this.#terminalGeneration;
 		this.#revokeRasterLeases("terminal-loss");
@@ -2676,6 +2770,7 @@ export class TUI extends Container {
 	}
 
 	stop(): void {
+		this.#invalidatePreparations();
 		// Invalidate every raster-queue body captured under the running epoch
 		// before any teardown: nothing queued before stop may write after
 		// restoration. Synchronous stop cleanup below writes directly.
@@ -2785,6 +2880,7 @@ export class TUI extends Container {
 	 * the last committed frame.
 	 */
 	requestResizeRender(): void {
+		if (this.#preparationDisposed) return;
 		// Width is tracked against the last OBSERVED terminal width, not against
 		// #previousWidth (the last committed frame). Those diverge whenever resize
 		// events coalesce inside one frame budget: a 100->90->100 burst would leave
@@ -2844,8 +2940,180 @@ export class TUI extends Container {
 		this.requestRenderWithGeneration(force, source);
 	}
 
+	/** Queue one synchronous preparation on the existing frame clock. Cancellation is idempotent. */
+	enqueueBeforeRender(callback: () => void): () => void {
+		if (this.#preparationDisposed || this.#preparationInvalidating || this.#stopped || !this.terminalAvailable)
+			return cancelNoPreparation;
+		const entry: RenderPreparation = { callback, generation: this.#nextRenderGeneration + 1 };
+		entry.cancel = () => {
+			entry.callback = undefined;
+			entry.cancel = undefined;
+			this.#preparations.delete(entry);
+			this.#preparationSnapshot?.delete(entry);
+			this.#preparationBlocked.delete(entry.generation);
+		};
+		this.#preparations.add(entry);
+		this.#preparationBlocked.add(entry.generation);
+		this.requestRenderWithGeneration(false, "preparation");
+		return createPreparationCancellation(entry);
+	}
+
+	/** One owner only: replacing or clearing it invalidates all old preparation work. */
+	setRenderPreparationLifecycleCallbacks(
+		callbacks: { invalidate: () => void; beforeStart: () => void } | undefined,
+	): void {
+		if (this.#preparationLifecycle === callbacks) return;
+		this.#invalidatePreparations();
+		this.#preparationLifecycle = this.#preparationDisposed ? undefined : callbacks;
+	}
+
+	#callPreparation(callback: (() => void) | undefined, where: string): boolean {
+		try {
+			callback?.();
+			return true;
+		} catch (error) {
+			logger.error("Render preparation failed", {
+				where,
+				error: error instanceof Error ? error.message : String(error),
+				stack: error instanceof Error ? error.stack : undefined,
+			});
+			return false;
+		}
+	}
+
+	#invalidatePreparations(): void {
+		this.#preparationEpoch++;
+		for (const generation of this.#preparationBlocked) this.#retirePreparation(generation);
+		for (const entry of this.#preparations) {
+			entry.callback = undefined;
+			entry.cancel = undefined;
+		}
+		for (const entry of this.#preparationSnapshot ?? []) {
+			entry.callback = undefined;
+			entry.cancel = undefined;
+		}
+		this.#preparations.clear();
+		this.#preparationSnapshot?.clear();
+		if (this.#preparationInvalidating) return;
+		this.#preparationInvalidating = true;
+		try {
+			this.#callPreparation(this.#preparationLifecycle?.invalidate, "invalidate");
+		} finally {
+			this.#preparationInvalidating = false;
+		}
+	}
+
+	#isFailedPreparation(generation: number): boolean {
+		let low = 0;
+		let high = this.#failedPreparationRanges.length;
+		while (low < high) {
+			const middle = (low + high) >>> 1;
+			const [start, end] = this.#failedPreparationRanges[middle];
+			if (generation < start) high = middle;
+			else if (generation > end) low = middle + 1;
+			else return true;
+		}
+		return false;
+	}
+
+	#retirePreparation(generation: number): void {
+		this.#preparationBlocked.delete(generation);
+		this.#commitHoles.delete(generation);
+		const ranges = this.#failedPreparationRanges;
+		let low = 0;
+		let high = ranges.length;
+		while (low < high) {
+			const middle = (low + high) >>> 1;
+			if (ranges[middle][1] < generation - 1) low = middle + 1;
+			else high = middle;
+		}
+		let start = generation;
+		let end = generation;
+		let next = low;
+		while (next < ranges.length && ranges[next][0] <= end + 1) {
+			start = Math.min(start, ranges[next][0]);
+			end = Math.max(end, ranges[next][1]);
+			next++;
+		}
+		ranges.splice(low, next - low, [start, end]);
+		const waiters = this.#renderCommitWaiters.get(generation);
+		this.#renderCommitWaiters.delete(generation);
+		for (const waiter of waiters ?? []) {
+			clearTimeout(waiter.timer);
+			waiter.resolve(false);
+		}
+	}
+
+	/** The only preparation boundary, before generation capture and all renderer reads. */
+	#renderPreparedFrame(): void {
+		if (this.#stopped || this.#preparationDisposed) return;
+		if (!this.terminalAvailable) {
+			this.#markTerminalUnavailable();
+			return;
+		}
+		const epoch = this.#preparationEpoch;
+		const snapshot = this.#preparations;
+		this.#preparations = new Set();
+		this.#preparationSnapshot = snapshot;
+		this.#preparationDrainEpoch = epoch;
+		try {
+			for (const entry of snapshot) {
+				if (epoch !== this.#preparationEpoch || this.#stopped || !this.terminalAvailable) break;
+				const callback = entry.callback;
+				entry.callback = undefined;
+				entry.cancel = undefined;
+				if (
+					callback &&
+					this.#callPreparation(callback, "beforeRender") &&
+					epoch === this.#preparationEpoch &&
+					!this.#stopped &&
+					this.terminalAvailable
+				) {
+					this.#preparationBlocked.delete(entry.generation);
+				} else if (callback) {
+					this.#retirePreparation(entry.generation);
+				}
+			}
+		} finally {
+			for (const entry of snapshot) {
+				entry.callback = undefined;
+				entry.cancel = undefined;
+			}
+			snapshot.clear();
+			this.#preparationSnapshot = undefined;
+		}
+		if (!this.terminalAvailable && !this.#stopped) this.#markTerminalUnavailable();
+		if (epoch !== this.#preparationEpoch || this.#stopped || !this.terminalAvailable || this.#preparationDisposed) {
+			if (!this.#stopped && this.terminalAvailable && !this.#preparationDisposed) this.#scheduleRender();
+			return;
+		}
+		const requestedGeneration = this.#renderRequestedGeneration;
+		this.#renderRequestedGeneration = 0;
+		this.#renderRequested = false;
+		this.#lastRenderAt = performance.now();
+		this.#lastRenderWriteSucceeded = false;
+		this.#frameCommitExclusions = new Set(this.#preparationBlocked);
+		const t0 = renderMetrics.now();
+		try {
+			this.#renderGenerationInProgress = requestedGeneration;
+			this.#doRender();
+			this.#commitRenderGeneration(requestedGeneration);
+		} finally {
+			this.#renderGenerationInProgress = 0;
+			this.#frameCommitExclusions = new Set();
+			if (renderMetrics.enabled) renderMetrics.recordRender(renderMetrics.now() - t0);
+			if (this.#preparations.size > 0 && epoch === this.#preparationEpoch) {
+				for (const entry of this.#preparations)
+					this.#renderRequestedGeneration = Math.max(this.#renderRequestedGeneration, entry.generation);
+				this.#renderRequested = true;
+				this.#scheduleRender();
+			}
+		}
+	}
+
 	#requestRenderWithScope(force: boolean, source: string, scope: "full" | "layout"): number {
 		const generation = ++this.#nextRenderGeneration;
+		if (this.#preparationDisposed) return generation;
 		this.#renderRequestedGeneration = Math.max(this.#renderRequestedGeneration, generation);
 		if (scope === "full") this.#renderScope = "full";
 		this.#requestRenderCore(force, source, generation);
@@ -2863,6 +3131,7 @@ export class TUI extends Container {
 	}
 
 	#requestRenderCore(force: boolean, source: string, generation: number): void {
+		if (this.#preparationDisposed) return;
 		if (!this.terminalAvailable) {
 			this.#markTerminalUnavailable();
 			return;
@@ -2905,6 +3174,7 @@ export class TUI extends Container {
 				this.#viewportTopRow = 0;
 				this.#maxLinesRendered = 0;
 			}
+			if (this.#preparationSnapshot && this.#preparationDrainEpoch === this.#preparationEpoch) return;
 			if (this.#renderTimer) {
 				clearTimeout(this.#renderTimer);
 				this.#renderTimer = undefined;
@@ -2916,20 +3186,12 @@ export class TUI extends Container {
 					this.#settleRenderCommitWaiters(false, generation);
 					return;
 				}
-				const requestedGeneration = this.#renderRequestedGeneration;
-				this.#renderRequestedGeneration = 0;
-				this.#renderRequested = false;
-				this.#lastRenderAt = performance.now();
-				this.#lastRenderWriteSucceeded = false;
-				const t0 = renderMetrics.now();
-				this.#renderGenerationInProgress = requestedGeneration;
-				this.#doRender();
-				this.#renderGenerationInProgress = 0;
-				this.#commitRenderGeneration(requestedGeneration);
-				if (renderMetrics.enabled) renderMetrics.recordRender(renderMetrics.now() - t0);
+				this.#renderPreparedFrame();
 			});
 			return;
 		}
+		// Preparation mutations join this frame; nested registrations get the next normal frame.
+		if (this.#preparationSnapshot && this.#preparationDrainEpoch === this.#preparationEpoch) return;
 		// Input-priority path: expedite so the keystroke echoes within the next tick
 		// instead of waiting for (or behind) the frame-budget timer. Re-entrant input
 		// requests in the same turn coalesce via #inputRenderPending, so at most one
@@ -2950,7 +3212,7 @@ export class TUI extends Container {
 	}
 
 	#scheduleRender(): void {
-		if (this.#stopped || this.#renderTimer || !this.#renderRequested) {
+		if (this.#preparationDisposed || this.#stopped || this.#renderTimer || !this.#renderRequested) {
 			return;
 		}
 		const elapsed = performance.now() - this.#lastRenderAt;
@@ -2961,17 +3223,7 @@ export class TUI extends Container {
 			if (this.#stopped || !this.#renderRequested) {
 				return;
 			}
-			const requestedGeneration = this.#renderRequestedGeneration;
-			this.#renderRequestedGeneration = 0;
-			this.#renderRequested = false;
-			this.#lastRenderAt = performance.now();
-			this.#lastRenderWriteSucceeded = false;
-			const t0 = renderMetrics.now();
-			this.#renderGenerationInProgress = requestedGeneration;
-			this.#doRender();
-			this.#renderGenerationInProgress = 0;
-			this.#commitRenderGeneration(requestedGeneration);
-			if (renderMetrics.enabled) renderMetrics.recordRender(renderMetrics.now() - t0);
+			this.#renderPreparedFrame();
 			if (this.#renderRequested) {
 				this.#scheduleRender();
 			}
@@ -2993,17 +3245,7 @@ export class TUI extends Container {
 			this.#renderTimer = undefined;
 			if (renderMetrics.enabled) renderMetrics.setTimerGauge("tui.renderTimer", 0);
 		}
-		const requestedGeneration = this.#renderRequestedGeneration;
-		this.#renderRequestedGeneration = 0;
-		this.#renderRequested = false;
-		this.#lastRenderAt = performance.now();
-		this.#lastRenderWriteSucceeded = false;
-		const t0 = renderMetrics.now();
-		this.#renderGenerationInProgress = requestedGeneration;
-		this.#doRender();
-		this.#renderGenerationInProgress = 0;
-		this.#commitRenderGeneration(requestedGeneration);
-		if (renderMetrics.enabled) renderMetrics.recordRender(renderMetrics.now() - t0);
+		this.#renderPreparedFrame();
 	}
 
 	#handleInput(data: string): void {
@@ -5607,11 +5849,12 @@ export class TUI extends Container {
 			? (bytes: string) => this.#writeRasterPreservingRenderIngress(bytes)
 			: (bytes: string) => this.#writeProtectedRenderIngress(bytes);
 		const renderGeneration = this.#renderGenerationInProgress;
+		const commitExclusions = this.#frameCommitExclusions;
 		const write = () => {
 			if (!writeIngress(buffer)) return false;
 			onBufferWritten?.();
 			this.#lastRenderWriteSucceeded = true;
-			if (renderGeneration > 0) this.#settleRenderCommitWaiters(true, renderGeneration);
+			if (renderGeneration > 0) this.#settleRenderCommitWaiters(true, renderGeneration, commitExclusions);
 			const emission = this.#postRenderEmitter?.();
 			if (emission) {
 				const overlay = typeof emission === "string" ? emission : emission.payload;

--- a/packages/tui/test/input-render-latency.test.ts
+++ b/packages/tui/test/input-render-latency.test.ts
@@ -53,6 +53,32 @@ async function hotRender(h: Harness): Promise<void> {
 }
 
 describe("keyboard input render latency under streaming load", () => {
+	it("prepares pending stream presentation before the input-priority frame reads components", async () => {
+		const h = setup();
+		await h.term.waitForRender();
+		const stream = new Text("old stream", 0, 0);
+		h.tui.addChild(stream);
+		let prepared = 0;
+		let revision = 0;
+		try {
+			h.tui.enqueueBeforeRender(() => {
+				prepared++;
+				stream.setText("latest stream");
+				revision = h.tui.requestRenderWithGeneration(false, "stream.prepared");
+			});
+			h.term.sendInput("ZQX");
+			await nextTick();
+			await h.term.flush();
+			expect(prepared).toBe(1);
+			expect(await h.tui.waitForRenderCommit(revision)).toBe(true);
+			const viewport = h.term.getViewport().join("\n");
+			expect(viewport).toContain("latest stream");
+			expect(viewport).toContain("ZQX");
+		} finally {
+			h.tui.stop();
+		}
+	});
+
 	it("never drops keystrokes during fast typing interleaved with streaming (hard gate)", async () => {
 		const h = setup();
 		await h.term.waitForRender();

--- a/packages/tui/test/render-commit.test.ts
+++ b/packages/tui/test/render-commit.test.ts
@@ -29,7 +29,589 @@ class CursorComponent implements Component {
 	}
 }
 
+function createLifetimePayload(throws: boolean): { callback: () => void; payload: Uint8Array } {
+	const payload = new Uint8Array(1024 * 1024);
+	return {
+		payload,
+		callback: () => {
+			payload[0]++;
+			if (throws) throw new Error("lifetime preparation failure");
+		},
+	};
+}
+
+class LifetimeTUI extends TUI {
+	// Positive control for the original enqueue-scope arrow's retained `this`.
+	// Never invoked: the test checks its outgoing references, not its behavior.
+	createRetainingControl(callback: () => void): () => void {
+		return () => {
+			this.requestRender();
+			callback();
+		};
+	}
+}
+
+interface PreparationLifetimeFixture {
+	mode: "cancel" | "complete" | "throw" | "stop" | "owner" | "dispose";
+	preparationMemoryOwner: LifetimeTUI;
+	preparationMemoryCallback: () => void;
+	preparationMemoryPayload: Uint8Array;
+	preparationMemoryHandle: () => void;
+	preparationMemoryControl: () => void;
+	generation: number;
+	early: Promise<boolean>;
+}
+
+function expectPreparationReferencePaths(count: number, retained: boolean): void {
+	// Bun's typed Inspector snapshot exposes JSC's four-word node/edge records:
+	// WebKit Source/JavaScriptCore/heap/HeapSnapshotBuilder.cpp documents the layout;
+	// runtime/JSLexicalEnvironment.cpp emits the captured-variable edges.
+	// Inspect the local closure -> entry -> callback/cancel graph, NOT reachability
+	// from GC roots. Module/global scopes, prototypes and VM structures are outside
+	// this contract. All targets deliberately stay strongly rooted in the fixtures.
+	const snapshot: Bun.HeapSnapshot = Bun.generateHeapSnapshot();
+	expect(snapshot.type).toBe("Inspector");
+	expect(snapshot.nodes.length % 4).toBe(0);
+	expect(snapshot.edges.length % 4).toBe(0);
+	const classes = new Map<number, string>();
+	for (let index = 0; index < snapshot.nodes.length; index += 4) {
+		classes.set(snapshot.nodes[index], snapshot.nodeClassNames[snapshot.nodes[index + 2]]);
+	}
+	const outgoing = new Map<number, number[]>();
+	const fixtures = new Map<number, Map<string, number>>();
+	for (let index = 0; index < snapshot.edges.length; index += 4) {
+		const from = snapshot.edges[index];
+		const to = snapshot.edges[index + 1];
+		const type = snapshot.edgeTypes[snapshot.edges[index + 2]];
+		const name = snapshot.edgeNames[snapshot.edges[index + 3]];
+		if (type === "Property" && name?.startsWith("preparationMemory")) {
+			let fields = fixtures.get(from);
+			if (!fields) {
+				fields = new Map();
+				fixtures.set(from, fields);
+			}
+			fields.set(name, to);
+		}
+		const fromClass = classes.get(from);
+		if (
+			(fromClass === "Function" && classes.get(to) === "JSLexicalEnvironment") ||
+			fromClass === "JSLexicalEnvironment" ||
+			(fromClass === "Object" && type === "Property" && (name === "callback" || name === "cancel"))
+		) {
+			let targets = outgoing.get(from);
+			if (!targets) {
+				targets = [];
+				outgoing.set(from, targets);
+			}
+			targets.push(to);
+		}
+	}
+	const reachable = (start: number): Set<number> => {
+		const seen = new Set<number>([start]);
+		for (const from of seen) {
+			for (const to of outgoing.get(from) ?? []) seen.add(to);
+		}
+		return seen;
+	};
+	expect(fixtures.size).toBe(count);
+	for (const fields of fixtures.values()) {
+		expect(fields.size).toBe(5);
+		const handle = reachable(fields.get("preparationMemoryHandle")!);
+		const control = reachable(fields.get("preparationMemoryControl")!);
+		for (const name of ["preparationMemoryOwner", "preparationMemoryCallback", "preparationMemoryPayload"]) {
+			const target = fields.get(name)!;
+			// Fail closed if this engine's graph cannot expose a known retaining arrow.
+			expect(control.has(target)).toBe(true);
+			expect(handle.has(target)).toBe(retained);
+		}
+	}
+}
+
 describe("generation-scoped render commits", () => {
+	it("severs retired cancellation paths to callbacks, payloads and owners without relying on collection", async () => {
+		const fixtures: PreparationLifetimeFixture[] = [];
+		try {
+			for (const mode of ["cancel", "complete", "throw", "stop", "owner", "dispose"] as const) {
+				const terminal = new VirtualTerminal(40, 8);
+				const tui = new LifetimeTUI(terminal);
+				const { callback, payload } = createLifetimePayload(mode === "throw");
+				fixtures.push({
+					mode,
+					preparationMemoryOwner: tui,
+					preparationMemoryCallback: callback,
+					preparationMemoryPayload: payload,
+					preparationMemoryHandle: () => {},
+					preparationMemoryControl: tui.createRetainingControl(callback),
+					generation: 0,
+					early: Promise.resolve(false),
+				});
+				tui.start();
+				await terminal.waitForRender();
+			}
+			// No await between enqueue, the pending graph and synchronous retirement:
+			// another fixture's preparation must not run before its chosen lifecycle.
+			for (const fixture of fixtures) {
+				const tui = fixture.preparationMemoryOwner;
+				fixture.generation = tui.requestRenderWithGeneration() + 1;
+				fixture.preparationMemoryHandle = tui.enqueueBeforeRender(fixture.preparationMemoryCallback);
+			}
+			expectPreparationReferencePaths(fixtures.length, true);
+			for (const fixture of fixtures) {
+				const tui = fixture.preparationMemoryOwner;
+				// Snapshot cost must not consume a commit waiter's timeout budget.
+				fixture.early = tui.waitForRenderCommit(fixture.generation);
+				if (fixture.mode === "cancel") fixture.preparationMemoryHandle();
+				else if (fixture.mode === "stop") tui.stop();
+				else if (fixture.mode === "owner") {
+					tui.setRenderPreparationLifecycleCallbacks({ invalidate() {}, beforeStart() {} });
+				} else if (fixture.mode === "dispose") tui.dispose();
+			}
+			for (const fixture of fixtures) {
+				const tui = fixture.preparationMemoryOwner;
+				if (fixture.mode !== "stop" && fixture.mode !== "dispose") {
+					expect(await tui.waitForRenderCommit(tui.requestRenderWithGeneration(true))).toBe(true);
+				}
+				const committed = fixture.mode === "cancel" || fixture.mode === "complete";
+				expect(await fixture.early).toBe(committed);
+				expect(await tui.waitForRenderCommit(fixture.generation)).toBe(committed);
+				expect(fixture.preparationMemoryPayload[0]).toBe(
+					fixture.mode === "complete" || fixture.mode === "throw" ? 1 : 0,
+				);
+			}
+			expectPreparationReferencePaths(fixtures.length, false);
+			for (const fixture of fixtures) {
+				fixture.preparationMemoryHandle();
+				fixture.preparationMemoryHandle();
+				fixture.preparationMemoryOwner.stop();
+				fixture.preparationMemoryOwner.dispose();
+				fixture.preparationMemoryHandle();
+				fixture.preparationMemoryHandle();
+			}
+		} finally {
+			for (const fixture of fixtures) {
+				fixture.preparationMemoryOwner.stop();
+				fixture.preparationMemoryOwner.dispose();
+			}
+		}
+	});
+
+	it("retires 1000 nested lifecycle holes without changing current or historical outcomes", async () => {
+		const terminal = new VirtualTerminal(40, 8);
+		const tui = new TUI(terminal);
+		const history: Array<{ generation: number; committed: boolean }> = [];
+		const retainedHandles: Array<() => void> = [];
+		let failedRanges = 0;
+		tui.start();
+		await terminal.waitForRender();
+		try {
+			for (let cycle = 0; cycle < 1000; cycle++) {
+				let nested = 0;
+				let current = 0;
+				let calls = 0;
+				let cancel = () => {};
+				let early: Promise<boolean> | undefined;
+				tui.enqueueBeforeRender(() => {
+					const preceding = tui.requestRenderWithGeneration();
+					cancel = tui.enqueueBeforeRender(() => {
+						calls++;
+					});
+					nested = preceding + 1;
+					early = tui.waitForRenderCommit(nested);
+					current = tui.requestRenderWithGeneration();
+				});
+				tui.requestRender(true);
+				const { promise, resolve } = Promise.withResolvers<void>();
+				process.nextTick(resolve);
+				await promise;
+				expect(await tui.waitForRenderCommit(current)).toBe(true);
+				expect(calls).toBe(0);
+				expect(tui.getRenderPreparationStateForTest()).toEqual({ pending: 1, holes: 1, failedRanges });
+				const committed = cycle % 4 < 2;
+				if (cycle % 4 === 0) {
+					cancel();
+					cancel();
+				} else if (cycle % 4 === 2) {
+					tui.stop();
+					tui.start();
+					failedRanges++;
+				} else if (cycle % 4 === 3) {
+					tui.setRenderPreparationLifecycleCallbacks({ invalidate() {}, beforeStart() {} });
+					failedRanges++;
+				}
+				const final = tui.requestRenderWithGeneration(true);
+				expect(await tui.waitForRenderCommit(final)).toBe(true);
+				expect(await early).toBe(committed);
+				expect(await tui.waitForRenderCommit(nested)).toBe(committed);
+				expect(calls).toBe(cycle % 4 === 1 ? 1 : 0);
+				retainedHandles.push(cancel);
+				cancel();
+				cancel();
+				history.push({ generation: nested, committed }, { generation: current, committed: true });
+				expect(tui.getRenderPreparationStateForTest()).toEqual({ pending: 0, holes: 0, failedRanges });
+				terminal.clearWriteLog();
+			}
+			for (const cancel of retainedHandles) {
+				cancel();
+				cancel();
+			}
+			for (const { generation, committed } of history) {
+				expect(await tui.waitForRenderCommit(generation)).toBe(committed);
+			}
+			expect(tui.getRenderPreparationStateForTest()).toEqual({ pending: 0, holes: 0, failedRanges: 500 });
+		} finally {
+			tui.stop();
+			tui.dispose();
+		}
+	}, 20_000);
+
+	it("quiesces a pending normal timer on dispose without stop and rejects later scheduling", async () => {
+		const terminal = new VirtualTerminal(40, 8);
+		const tui = new TUI(terminal);
+		tui.addChild(new Text("initial", 0, 0));
+		tui.start();
+		await terminal.waitForRender();
+		vi.useFakeTimers();
+		const timers = vi.spyOn(globalThis, "setTimeout");
+		const stale = vi.fn();
+		try {
+			tui.enqueueBeforeRender(stale);
+			await new Promise<void>(resolve => process.nextTick(resolve));
+			expect(timers).toHaveBeenCalled();
+			tui.dispose();
+			await Promise.resolve();
+			const writes = terminal.getWriteLog();
+			timers.mockClear();
+			vi.advanceTimersByTime(1000);
+			tui.requestRender();
+			tui.requestRender(true);
+			tui.requestRender(false, "input");
+			tui.requestLayoutRender();
+			tui.enqueueBeforeRender(stale);
+			await new Promise<void>(resolve => process.nextTick(resolve));
+			vi.advanceTimersByTime(1000);
+			expect(timers).not.toHaveBeenCalled();
+			expect(stale).not.toHaveBeenCalled();
+			expect(terminal.getWriteLog()).toEqual(writes);
+			expect(await tui.waitForRenderCommit(tui.requestRenderWithGeneration())).toBe(false);
+		} finally {
+			timers.mockRestore();
+			vi.useRealTimers();
+			// Deliberately do not call stop(): disposal must quiesce the scheduler itself.
+		}
+	});
+
+	it("compacts retired batches across failures, owner replacement and restart without losing late outcomes", async () => {
+		const terminal = new VirtualTerminal(40, 8);
+		const tui = new TUI(terminal);
+		tui.addChild(new Text("retirement", 0, 0));
+		tui.start();
+		await terminal.waitForRender();
+		const failed: number[] = [];
+		const successful: number[] = [];
+		try {
+			for (let cycle = 0; cycle < 12; cycle++) {
+				const base = tui.requestRenderWithGeneration();
+				const early: Promise<boolean>[] = [];
+				for (let index = 1; index <= 32; index++) {
+					tui.enqueueBeforeRender(() => {
+						throw new Error("retired batch");
+					});
+					failed.push(base + index);
+					early.push(tui.waitForRenderCommit(base + index));
+				}
+				if (cycle % 3 === 0) {
+					tui.setRenderPreparationLifecycleCallbacks({ invalidate() {}, beforeStart() {} });
+				} else if (cycle % 3 === 1) {
+					tui.stop();
+					tui.start();
+				}
+				const committed = tui.requestRenderWithGeneration(true);
+				expect(await tui.waitForRenderCommit(committed)).toBe(true);
+				successful.push(committed);
+				expect(await Promise.all(early)).toEqual(Array(32).fill(false));
+				// Every contiguous failed batch occupies one range, not 32 exclusions.
+				expect(tui.getRenderPreparationStateForTest()).toEqual({ pending: 0, holes: 0, failedRanges: cycle + 1 });
+			}
+			for (const generation of failed) expect(await tui.waitForRenderCommit(generation)).toBe(false);
+			for (const generation of successful) expect(await tui.waitForRenderCommit(generation)).toBe(true);
+			// Historical failures are not reintroduced into the next frame's pending set.
+			expect(await tui.waitForRenderCommit(tui.requestRenderWithGeneration(true))).toBe(true);
+			expect(tui.getRenderPreparationStateForTest()).toEqual({ pending: 0, holes: 0, failedRanges: 12 });
+		} finally {
+			tui.stop();
+		}
+	});
+
+	it("uses the normal frame clock and reads only the prepared component state", async () => {
+		const terminal = new VirtualTerminal(40, 8);
+		const tui = new TUI(terminal);
+		let value = "old";
+		const reads: string[] = [];
+		tui.addChild({
+			invalidate() {},
+			render() {
+				reads.push(value);
+				return [value];
+			},
+		});
+		tui.start();
+		await terminal.waitForRender();
+		reads.length = 0;
+		try {
+			tui.enqueueBeforeRender(() => {
+				value = "normal prepared";
+				tui.requestRender();
+			});
+			const generation = tui.requestRenderWithGeneration();
+			await new Promise<void>(resolve => process.nextTick(resolve));
+			expect(reads).toEqual([]);
+			expect(await tui.waitForRenderCommit(generation)).toBe(true);
+			expect(reads).toEqual(["normal prepared"]);
+			expect(terminal.getWriteLog().join("")).toContain("normal prepared");
+		} finally {
+			tui.stop();
+		}
+	});
+
+	it("invalidates pending and captured work on terminal loss and rejects enqueue while stopped", async () => {
+		class AvailabilityTerminal extends VirtualTerminal {
+			live = true;
+			override get available(): boolean {
+				return this.live;
+			}
+		}
+		const terminal = new AvailabilityTerminal(40, 8);
+		const tui = new TUI(terminal);
+		const invalidate = vi.fn();
+		const stale = vi.fn();
+		tui.setRenderPreparationLifecycleCallbacks({ invalidate, beforeStart() {} });
+		tui.start();
+		await terminal.waitForRender();
+		tui.enqueueBeforeRender(() => {
+			terminal.live = false;
+		});
+		tui.enqueueBeforeRender(stale);
+		const generation = tui.requestRenderWithGeneration(true);
+		expect(await tui.waitForRenderCommit(generation)).toBe(false);
+		expect(invalidate).toHaveBeenCalledTimes(1);
+		tui.enqueueBeforeRender(stale);
+		terminal.live = true;
+		tui.start();
+		await terminal.waitForRender();
+		expect(stale).not.toHaveBeenCalled();
+		tui.stop();
+	});
+
+	it("does not call beforeStart when terminal setup fails", () => {
+		class FailedStartTerminal extends VirtualTerminal {
+			override start(): void {
+				throw new Error("setup failed");
+			}
+		}
+		const tui = new TUI(new FailedStartTerminal(40, 8));
+		const beforeStart = vi.fn();
+		tui.setRenderPreparationLifecycleCallbacks({ invalidate() {}, beforeStart });
+		expect(() => tui.start()).toThrow("setup failed");
+		expect(beforeStart).not.toHaveBeenCalled();
+		tui.dispose();
+	});
+
+	it("prepares the first start frame and discards work from a throwing beforeStart", async () => {
+		const terminal = new VirtualTerminal(40, 8);
+		const tui = new TUI(terminal);
+		const reads: string[] = [];
+		let value = "old";
+		tui.addChild({
+			invalidate() {},
+			render() {
+				reads.push(value);
+				return [value];
+			},
+		});
+		const stale = vi.fn();
+		tui.setRenderPreparationLifecycleCallbacks({
+			invalidate() {},
+			beforeStart() {
+				expect(tui.terminalAvailable).toBe(true);
+				tui.enqueueBeforeRender(() => {
+					value = "first frame fresh";
+				});
+			},
+		});
+		tui.start();
+		await terminal.waitForRender();
+		expect(reads).toEqual(["first frame fresh"]);
+		tui.stop();
+		tui.setRenderPreparationLifecycleCallbacks({
+			invalidate() {},
+			beforeStart() {
+				tui.enqueueBeforeRender(stale);
+				throw new Error("beforeStart failure");
+			},
+		});
+		tui.start();
+		tui.requestRender(true);
+		await terminal.waitForRender();
+		expect(stale).not.toHaveBeenCalled();
+		tui.stop();
+	});
+
+	for (const queuedWrite of [false, true]) {
+		it(`keeps nested preparation out of the current high-water commit (queued write: ${queuedWrite})`, async () => {
+			const terminal = new VirtualTerminal(40, 8);
+			const tui = new TUI(terminal);
+			const text = new Text("initial", 0, 0);
+			tui.addChild(text);
+			tui.start();
+			await terminal.waitForRender();
+			let nestedGeneration = 0;
+			let currentGeneration = 0;
+			let nestedRan = false;
+			let nestedSettled = false;
+			let nestedWait: Promise<boolean> | undefined;
+			try {
+				tui.enqueueBeforeRender(() => {
+					const preceding = tui.requestRenderWithGeneration();
+					tui.enqueueBeforeRender(() => {
+						nestedRan = true;
+						text.setText("next preparation");
+					});
+					nestedGeneration = preceding + 1;
+					text.setText("current preparation");
+					currentGeneration = tui.requestRenderWithGeneration();
+					nestedWait = tui.waitForRenderCommit(nestedGeneration).then(result => {
+						nestedSettled = true;
+						return result;
+					});
+					if (queuedWrite) void tui.queueTerminalCleanup("");
+				});
+				tui.requestRender(true);
+				await new Promise<void>(resolve => process.nextTick(resolve));
+				expect(await tui.waitForRenderCommit(currentGeneration)).toBe(true);
+				expect(terminal.getWriteLog().join("")).toContain("current preparation");
+				expect(nestedRan).toBe(false);
+				expect(nestedSettled).toBe(false);
+				expect(tui.getRenderPreparationStateForTest()).toEqual({ pending: 1, holes: 1, failedRanges: 0 });
+				let lateSettled = false;
+				const lateWait = tui.waitForRenderCommit(nestedGeneration).then(result => {
+					lateSettled = true;
+					return result;
+				});
+				await Promise.resolve();
+				expect(lateSettled).toBe(false);
+				expect(await nestedWait).toBe(true);
+				expect(await lateWait).toBe(true);
+				expect(nestedRan).toBe(true);
+				expect(terminal.getWriteLog().join("")).toContain("next preparation");
+				expect(tui.getRenderPreparationStateForTest()).toEqual({ pending: 0, holes: 0, failedRanges: 0 });
+			} finally {
+				tui.stop();
+			}
+		});
+	}
+
+	it("cancels captured entries and isolates throwing preparation without an extra request-only frame", async () => {
+		const terminal = new VirtualTerminal(40, 8);
+		const tui = new TUI(terminal);
+		let value = "initial";
+		const renders: string[] = [];
+		tui.addChild({
+			invalidate() {},
+			render() {
+				renders.push(value);
+				return [value];
+			},
+		});
+		tui.start();
+		await terminal.waitForRender();
+		renders.length = 0;
+		const cancelled = vi.fn();
+		let cancel = () => {};
+		let failedGeneration = 0;
+		try {
+			tui.enqueueBeforeRender(() => {
+				cancel();
+				cancel();
+			});
+			cancel = tui.enqueueBeforeRender(cancelled);
+			const preceding = tui.requestRenderWithGeneration();
+			tui.enqueueBeforeRender(() => {
+				throw new Error("preparation test failure");
+			});
+			failedGeneration = preceding + 1;
+			tui.enqueueBeforeRender(() => {
+				value = "prepared";
+				tui.requestRenderWithGeneration();
+			});
+			const generation = tui.requestRenderWithGeneration(true);
+			expect(await tui.waitForRenderCommit(generation)).toBe(true);
+			expect(cancelled).not.toHaveBeenCalled();
+			expect(renders).toEqual(["prepared"]);
+			expect(await tui.waitForRenderCommit(failedGeneration, 25)).toBe(false);
+			expect(renders).toEqual(["prepared"]);
+		} finally {
+			tui.stop();
+		}
+	});
+
+	it("invalidates the captured snapshot across synchronous stop/start and rearms only fresh work", async () => {
+		const terminal = new VirtualTerminal(40, 8);
+		const tui = new TUI(terminal);
+		const text = new Text("initial", 0, 0);
+		tui.addChild(text);
+		const stale = vi.fn();
+		const invalidate = vi.fn();
+		const beforeStart = vi.fn(() => tui.enqueueBeforeRender(() => text.setText("fresh restart")));
+		tui.setRenderPreparationLifecycleCallbacks({ invalidate, beforeStart });
+		tui.start();
+		await terminal.waitForRender();
+		try {
+			tui.enqueueBeforeRender(() => {
+				tui.stop();
+				tui.start();
+			});
+			tui.enqueueBeforeRender(stale);
+			tui.requestRender(true);
+			await new Promise<void>(resolve => process.nextTick(resolve));
+			await terminal.waitForRender();
+			expect(stale).not.toHaveBeenCalled();
+			expect(invalidate).toHaveBeenCalledTimes(1);
+			expect(beforeStart).toHaveBeenCalledTimes(2);
+			expect(terminal.getWriteLog().join("")).toContain("fresh restart");
+		} finally {
+			tui.stop();
+		}
+	});
+
+	it("drops old-owner and disposed work even when invalidation throws", async () => {
+		const terminal = new VirtualTerminal(40, 8);
+		const tui = new TUI(terminal);
+		tui.start();
+		await terminal.waitForRender();
+		const stale = vi.fn();
+		const fresh = vi.fn();
+		const invalidate = vi.fn(() => {
+			throw new Error("invalidation test failure");
+		});
+		tui.setRenderPreparationLifecycleCallbacks({ invalidate, beforeStart() {} });
+		tui.enqueueBeforeRender(stale);
+		tui.setRenderPreparationLifecycleCallbacks({ invalidate() {}, beforeStart() {} });
+		tui.enqueueBeforeRender(fresh);
+		expect(await tui.waitForRenderCommit(tui.requestRenderWithGeneration(true))).toBe(true);
+		expect(stale).not.toHaveBeenCalled();
+		expect(fresh).toHaveBeenCalledTimes(1);
+		expect(invalidate).toHaveBeenCalledTimes(1);
+		tui.enqueueBeforeRender(stale);
+		tui.setRenderPreparationLifecycleCallbacks(undefined);
+		tui.enqueueBeforeRender(stale);
+		tui.dispose();
+		tui.enqueueBeforeRender(stale);
+		tui.start();
+		await new Promise<void>(resolve => process.nextTick(resolve));
+		expect(stale).not.toHaveBeenCalled();
+		tui.stop();
+	});
+
 	it("resolves after the requested generation writes successfully", async () => {
 		const terminal = new VirtualTerminal(40, 8);
 		const tui = new TUI(terminal);


### PR DESCRIPTION
## What

Coalesce admitted assistant text-delta presentation into the existing TUI frame clock, without batching semantic events, thinking updates, or tool updates.

- Add cancellable `enqueueBeforeRender` preparation and a single-owner preparation lifecycle hook shared by normal, forced, and input-priority frames.
- Preserve same-frame source revisions while unrelated event handlers await, without consuming their dirty state.
- Retain authoritative final/error/abort behavior; unrelated custom/tool-result endings no longer cancel pending assistant text.
- Rearm current streaming text on restart and separate paint lifetime from session/historical-image lifetime.
- Quiesce disposed scheduling and release retired cancellation-handle references while preserving truthful late generation-waiter outcomes.
- Add scheduler, controller, viewport, native-image, lifetime and advisory measurement coverage; update TUI API documentation and both package changelogs.

## Why

Previously, each incoming text fragment reconciled presentation even when several fragments arrived before the next visible frame. Preparing only the latest text eliminates work on intermediate states that would never be displayed. The frame interval and immediate non-text boundaries remain unchanged.

### Measurement scope and limitations

Local Darwin arm64/Bun 1.4.0 experiments used the same real EventController/AssistantMessageComponent/TUI/VirtualTerminal harness and matching native binary on unchanged and patched product trees. Across 120 paired workload rows, total projection calls were **9,480 -> 720**, with matching final rendered component output and semantic counts.

A subsequent text-test-only experiment used **10 measured process pairs, balanced 5 AB/5 BA**, plus two discarded outer warmup pairs. All **1,200 measured row pairs** passed output/count checks:

- Mean paired CPU after/before ratio: **0.9063**, bootstrap 95% CI **0.8908–0.9202**.
- Mean paired peak-RSS ratio: **0.8841**, CI **0.8550–0.9162**.

These are local **instrumented focused-test process** measurements, including imports, fixtures, assertions, spies and logging—not application-wide CPU, retained heap, battery, or guaranteed user-visible latency improvements. An earlier, different-scope whole-suite experiment observed CPU median **+8.3%**, peak RSS **-9.6%**, and elapsed **+1.4%**; the focused experiment does not erase or causally explain that observation. Resource runs were performed before the final rebase; focused regression and package checks were rerun after rebase. Local raw measurement/PTY artifacts are not committed.

## Testing

After rebasing onto `dev` at `a9e654062448833e31e64069168930d8a43a8201`:

- **193 passed, 0 failed; 12,874 assertions across 13 focused suites**, covering Markdown streaming, render commits/input latency/resilience/detach/disposal, controller coalescing/source revisions/message start/abort, assistant streaming/reconciliation, and session switching.
- `bun --cwd=packages/tui run check` — passed (Biome + TypeScript).
- `bun --cwd=packages/coding-agent run check` — passed (Biome + TypeScript).
- `bun scripts/verify-gjc-state-writers.ts --fail` — passed, zero unauthorized write sites.
- `git diff --check` and base-ancestor check — passed.
- Prior local actual-source CLI smoke verified streaming output and Ctrl-D shutdown, exit 0 without forced termination. Deterministic integration tests cover the precise frame/lifetime race cases.

**Full aggregate check is not green locally:** `bun run check` was attempted but exceeded the 300-second execution window. Its Rust leg reported a Cargo workspace-resolution error for `crates/brush-builtins-vendored/Cargo.toml` in this nested worktree, resolving the enclosing main checkout's workspace. The TS leg had not completed when the timeout terminated the command. This is disclosed, not marked passed; upstream CI must supply the complete required result. No unrelated workspace/config fix is included in this PR.

## Risk classification

- [ ] `low-risk`
- [ ] `regression-risk`
- [x] `high-risk`

This adds public TUI APIs and changes frame scheduling/lifecycle behavior. Independent domain review is required. Proposed reviewer: **@Yeachan-Heo**, repository owner/maintainer with prior ownership of TUI synchronized-output and resize behavior. GitHub rejected the review-request operation because the contributor account lacks permission; maintainer assignment is still needed. Authenticated exact-head approval was submitted by @Yeachan-Heo at review 5121410369; the reviewer is distinct from contributor @laerad777.

## GJC verdict

Authenticated independent exact-head review is approved. The digest is the exact `git diff --binary --full-index --no-ext-diff origin/dev...HEAD` digest, not an Ultragoal source hash.

```text
gajae.pr-review-verdict.v1 merge-approved sha256:20b9fa3a19eea4a04ee6d06f6d8ccebb68532509dc4da714dfcbffcebffee548 reviewer:human reviewer-id:Yeachan-Heo evidence:https://github.com/Yeachan-Heo/gajae-code/pull/5310#pullrequestreview-5121410369
```

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken

Exact head: `1ebebf42a00ec1dbd1346db80ca13834c1223f2a`.

