### PR TITLE
fix(acp): request a readiness budget for MCP-less session launches

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- An ACP client that declares no MCP servers no longer loses `session/new`, `session/load`, and `session/fork` to the broker's bare readiness default. Only the MCP branch asked for a readiness budget, so an MCP-less launch kept the 10s default while a host cold start measurably crosses it whenever a second host starts alongside the first: the broker then returned `terminal_uncertain` ("Lifecycle startup cleanup could not be proven"), which Paseo recorded as a failed provider snapshot and left the GJC provider reading `error` instead of `available`, so imported terminal sessions attached to nothing and showed no transcript. Every ACP launch now requests the same budget the MCP path already used, independent of whether the client declared servers.
 
 ## [0.16.4] - 2026-09-05
 ### Added

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -101,6 +101,16 @@ const MAX_PROMPT_FRAME_BYTES = 256 * 1024;
  * envelope. A canonical-length UUID keeps the measurement equal to the real frame.
  */
 const PROMPT_FRAME_ID_PLACEHOLDER = "00000000-0000-4000-8000-000000000000";
+/**
+ * Readiness budget every ACP session launch requests, independent of MCP.
+ *
+ * Host cold start costs the same whether or not the client declared MCP servers,
+ * so leaving the MCP-less path on the broker's 10s default made it the only ACP
+ * launch that fails under ordinary concurrency: a second host starting beside the
+ * first measurably crosses that deadline, and the broker then reports the launch
+ * as `terminal_uncertain`, which an external client surfaces as a dead provider.
+ */
+const ACP_SESSION_READINESS_TIMEOUT_MS = ACP_MCP_LIFECYCLE_TIMEOUT_MS;
 
 type JsonObject = Record<string, unknown>;
 interface PromptWaiter {
@@ -1362,7 +1372,8 @@ export class AcpAgent implements Agent {
 				cwd: params.cwd,
 				target: { path: params.cwd },
 				...(this.#startupOptions?.modelPreset ? { modelPreset: this.#startupOptions.modelPreset } : {}),
-				...(mcpServers.length > 0 ? { mcpServers, readinessTimeoutMs: ACP_MCP_LIFECYCLE_TIMEOUT_MS } : {}),
+				readinessTimeoutMs: ACP_SESSION_READINESS_TIMEOUT_MS,
+				...(mcpServers.length > 0 ? { mcpServers } : {}),
 			},
 			randomUUID(),
 			mcpServers,
@@ -1418,7 +1429,8 @@ export class AcpAgent implements Agent {
 				sourceSessionId: params.sessionId,
 				sourceSessionPath: source,
 				target: { path: params.cwd },
-				...(mcpServers.length > 0 ? { mcpServers, readinessTimeoutMs: ACP_MCP_LIFECYCLE_TIMEOUT_MS } : {}),
+				readinessTimeoutMs: ACP_SESSION_READINESS_TIMEOUT_MS,
+				...(mcpServers.length > 0 ? { mcpServers } : {}),
 			},
 			randomUUID(),
 			mcpServers,
@@ -2268,7 +2280,8 @@ export class AcpAgent implements Agent {
 				sessionId: id,
 				sessionPath: saved,
 				target: { path: cwd },
-				...(mcpServers.length > 0 ? { mcpServers, readinessTimeoutMs: ACP_MCP_LIFECYCLE_TIMEOUT_MS } : {}),
+				readinessTimeoutMs: ACP_SESSION_READINESS_TIMEOUT_MS,
+				...(mcpServers.length > 0 ? { mcpServers } : {}),
 			},
 			randomUUID(),
 			mcpServers,

--- a/packages/coding-agent/test/acp/acp-fallback-cancel-completion.test.ts
+++ b/packages/coding-agent/test/acp/acp-fallback-cancel-completion.test.ts
@@ -18,6 +18,7 @@ import { createAcpConnection } from "@gajae-code/coding-agent/modes/acp/acp-mode
 import { TempDir } from "@gajae-code/utils";
 import { AcpSdkAdapterError } from "../../src/sdk/acp";
 import { writeBrokerDiscovery } from "../../src/sdk/broker/discovery";
+import { DEFAULT_READINESS_TIMEOUT_MS, MAX_READINESS_TIMEOUT_MS } from "../../src/sdk/broker/startup-budget";
 import {
 	type ExactSessionAuthorityFixture,
 	type ExactSessionAuthorityOptions,
@@ -75,6 +76,7 @@ describe("ACP production cancellation completion", () => {
 		let promptSocket: TestSocket | undefined;
 		let promptCount = 0;
 		let abortAcknowledged = true;
+		let createInput: Record<string, unknown> | undefined;
 
 		server = Bun.serve({
 			hostname: "127.0.0.1",
@@ -98,6 +100,7 @@ describe("ACP production cancellation completion", () => {
 					}
 					if (frame.type === "broker_request") {
 						if (frame.operation === "session.create") {
+							createInput = frame.input as Record<string, unknown>;
 							socket.send(
 								JSON.stringify({ type: "broker_response", id: frame.id, ok: true, result: authority }),
 							);
@@ -209,6 +212,14 @@ describe("ACP production cancellation completion", () => {
 		} as unknown as AgentSideConnection;
 		const acp = new AcpAgent(connection, { agentDir });
 		const created = await bounded(acp.newSession({ cwd, mcpServers: [] }), "new session");
+		// A launch that declares no MCP servers still pays the host's cold start, so it must
+		// ask for more than the broker's bare default; leaving it there made an MCP-less ACP
+		// client the only caller whose `session/new` died on a concurrent host start.
+		const requestedReadiness = createInput?.readinessTimeoutMs;
+		expect(typeof requestedReadiness).toBe("number");
+		expect(requestedReadiness as number).toBeGreaterThan(DEFAULT_READINESS_TIMEOUT_MS);
+		expect(requestedReadiness as number).toBeLessThanOrEqual(MAX_READINESS_TIMEOUT_MS);
+		expect(createInput).not.toHaveProperty("mcpServers");
 		expect(created.configOptions).toEqual(
 			expect.arrayContaining([
 				expect.objectContaining({

--- a/packages/coding-agent/test/sdk-broker-startup-admission.test.ts
+++ b/packages/coding-agent/test/sdk-broker-startup-admission.test.ts
@@ -719,7 +719,7 @@ test("a default startup admitted late by the production broker stays inside the 
 				return Promise.withResolvers<void>().promise;
 			},
 		});
-		// No `readinessTimeoutMs`: the default request every ACP caller sends.
+		// No `readinessTimeoutMs`: the request shape of a caller that sizes nothing itself.
 		const queued = broker.handleRequest(
 			"session.create",
 			{ cwd: root, stateRoot: path.join(root, ".gjc", "state") },


### PR DESCRIPTION
## Problem

The ACP agent sized a readiness budget **only when the client declared MCP servers**:

```ts
...(mcpServers.length > 0 ? { mcpServers, readinessTimeoutMs: ACP_MCP_LIFECYCLE_TIMEOUT_MS } : {}),
```

Paseo sends `mcpServers: []`, so every `session/new`, `session/load`, and `session/fork` from it fell back to the broker's `DEFAULT_READINESS_TIMEOUT_MS` (10s). Host cold start costs the same with or without MCP and measurably crosses that deadline whenever a second host starts alongside the first.

## Evidence (live machine, 2026-09-05)

`~/.gjc/agent/sdk/lifecycle-ledger.jsonl` — every failed `session.create` today died on the 10s wall, while a concurrently-started one succeeded:

```
22:54:55   3.48s  terminal_ok
22:54:58   9.91s  terminal_uncertain   <- second host, same second
22:18:19   9.91s  terminal_uncertain   <- killed a Paseo import
13:37:40  13.98s  terminal_ok          <- succeeded only because it asked for more
```

Underlying broker error: `spawn_failed: SDK startup did not complete before readiness cutoff.` The reconciliation wrapper then masks it as:

```
terminal_uncertain: Lifecycle startup cleanup could not be proven; retained artifacts require reconciliation.
```

`~/.paseo/daemon.log` records that as `provider-snapshot-manager … Failed to refresh provider snapshot`, so:

```
$ paseo provider ls
gjc            Gajae Code              error     <- docs require `available`
gjc-codex-pro  Gajae Code (codex-pro)  error
```

Downstream user-visible effect: an imported terminal session becomes a dead shell. Agent record frozen at import (`lastStatus: idle`, `lastUserMessageAt: null`), `paseo logs <id>` reports `No activity to display.` — while `gjc sdk session list` shows the same session `live=true` with an in-flight turn.

## Change

Every ACP launch now requests the same budget the MCP path already used, independent of whether the client declared servers. `mcpServers` is still attached only when non-empty.

## Test

`packages/coding-agent/test/acp/acp-fallback-cancel-completion.test.ts` already drives `newSession({ cwd, mcpServers: [] })` against a fake broker; it now captures the `session.create` frame and asserts the launch carries a readiness budget above `DEFAULT_READINESS_TIMEOUT_MS` and within `MAX_READINESS_TIMEOUT_MS`, and that no `mcpServers` key is attached. Before this change the field is absent entirely, so the assertion fails.

Also corrected a comment in `sdk-broker-startup-admission.test.ts` that claimed an omitted `readinessTimeoutMs` is "the default request every ACP caller sends" — no longer true.

## Verification

- `bun test packages/coding-agent/test/acp/ packages/coding-agent/test/sdk-acp-provider-reconnect.test.ts packages/coding-agent/test/sdk-acp-stale-attachment-4356.test.ts packages/coding-agent/test/sdk-acp-two-client-race.test.ts` — 66 pass
- `bun test packages/coding-agent/test/sdk-acp-production-path.test.ts packages/coding-agent/test/sdk-broker-startup-admission.test.ts packages/coding-agent/test/sdk-acp-adapter.test.ts` — 51 pass (MCP path still pins 30_500)
- `bun --cwd=packages/coding-agent run check` — clean

Not verified: a live Paseo provider-snapshot refresh, which needs `dist/gjc` rebuilt; the running binary is currently serving active sessions.

## Rejected alternatives

- **Raise `DEFAULT_READINESS_TIMEOUT_MS`** — widens every non-ACP caller's deadline to solve one client's problem.
- **Retry the launch inside the ACP agent** — duplicates broker idempotency and hides the real budget defect.

## Risk classification

- [ ] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [x] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:b2c60944302d6ec1d7ed3f2a4c618bd2ddce06c11c0a69e3e49bf3e73e2f0369 reviewer:human reviewer-id:snowykr evidence:https://github.com/Yeachan-Heo/gajae-code/pull/5312/checks
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken

<!-- exact-head contract revalidation requested -->
<!-- contract-refresh-1788631071 -->
<!-- final-contract-refresh -->
<!-- digest-corrected -->
<!-- authoritative-review-refresh -->