### PR TITLE
perf(agent-ai): bound streaming retention and reuse context scans

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 - Failed cooperative context maintenance now terminalizes the active run with its concrete maintenance error instead of advertising a continuation over unchanged context. Only committed prune, compaction, or promotion outcomes remain resumable.
 
+### Performance
+
+- Bound stream abort-race retention to the current read and reuse history hashes when checking append-only context rewrites.
+
 ## [0.16.3] - 2026-09-04
 
 ## [0.16.2] - 2026-09-04

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -8,15 +8,15 @@
 
 - Compaction summary, turn-prefix summary, and handoff generation now clamp their reasoning effort to the model they are about to call instead of hard-coding `high`. A reasoning-capable model on a transport without reasoning control (the registry strips `thinking` when `openai-codex` or `anthropic` is routed through a non-audited proxy `baseUrl`) rejected the raw effort inside the provider mapper with "Model <provider>/<id> does not support thinking"; since the compaction fallback chain then reaches for the same-provider largest-context model, every candidate died on that throw and auto-compaction reported only the last one. The agent turn already clamps through `clampThinkingLevelForModel`; the maintenance calls were the one path still sending an unclamped effort.
 
+### Performance
+
+- Bound stream abort-race retention to the current read and reuse history hashes when checking append-only context rewrites.
+
 ## [0.16.4] - 2026-09-05
 
 - Provider calls now carry the agent-owned opaque provider conversation identity separately from generic session/cache affinity, including compaction, handoff, turn-prefix summary, and branch-summary maintenance calls. This lets provider-specific conversation headers remain stable without treating prompt-derived gateway cache keys as conversation authority (#5295).
 
 - Failed cooperative context maintenance now terminalizes the active run with its concrete maintenance error instead of advertising a continuation over unchanged context. Only committed prune, compaction, or promotion outcomes remain resumable.
-
-### Performance
-
-- Bound stream abort-race retention to the current read and reuse history hashes when checking append-only context rewrites.
 
 ## [0.16.3] - 2026-09-04
 

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -4744,10 +4744,9 @@ async function streamAssistantResponse(
 				return getResponseResult();
 			};
 
-			// Set up a single abort race: register the abort listener once for the whole
-			// stream and reuse the same race promise for every iterator.next() instead of
-			// allocating Promise.withResolvers and add/removeEventListener per event.
-			let abortRacePromise: Promise<typeof ABORTED> | undefined;
+			// Keep one listener, but race a fresh promise per read so pending abort
+			// reactions do not retain every event until the request ends.
+			let resolveReadAbort: ((value: typeof ABORTED) => void) | undefined;
 			let detachAbortListener: (() => void) | undefined;
 			if (requestSignal) {
 				if (requestSignal.aborted) {
@@ -4763,18 +4762,23 @@ async function streamAssistantResponse(
 					await finishChat(aborted);
 					return aborted;
 				}
-				const { promise, resolve } = Promise.withResolvers<typeof ABORTED>();
-				const onAbort = () => resolve(ABORTED);
+				const onAbort = () => resolveReadAbort?.(ABORTED);
 				requestSignal.addEventListener("abort", onAbort, { once: true });
-				abortRacePromise = promise;
 				detachAbortListener = () => requestSignal.removeEventListener("abort", onAbort);
 			}
 
 			try {
 				while (true) {
 					let next: IteratorResult<AssistantMessageEvent>;
-					if (abortRacePromise) {
-						const result = await Promise.race([responseIterator.next(), abortRacePromise]);
+					if (requestSignal) {
+						const { promise, resolve } = Promise.withResolvers<typeof ABORTED>();
+						resolveReadAbort = resolve;
+						let result: IteratorResult<AssistantMessageEvent> | typeof ABORTED;
+						try {
+							result = requestSignal.aborted ? ABORTED : await Promise.race([responseIterator.next(), promise]);
+						} finally {
+							resolveReadAbort = undefined;
+						}
 						if (result === ABORTED) {
 							closeIterator();
 							const aborted = emitAbortedAssistantMessage(

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -4746,7 +4746,7 @@ async function streamAssistantResponse(
 
 			// Keep one listener, but race a fresh promise per read so pending abort
 			// reactions do not retain every event until the request ends.
-			let resolveReadAbort: ((value: typeof ABORTED) => void) | undefined;
+			let settleReadAbort: (() => void) | undefined;
 			let detachAbortListener: (() => void) | undefined;
 			if (requestSignal) {
 				if (requestSignal.aborted) {
@@ -4762,7 +4762,7 @@ async function streamAssistantResponse(
 					await finishChat(aborted);
 					return aborted;
 				}
-				const onAbort = () => resolveReadAbort?.(ABORTED);
+				const onAbort = () => settleReadAbort?.();
 				requestSignal.addEventListener("abort", onAbort, { once: true });
 				detachAbortListener = () => requestSignal.removeEventListener("abort", onAbort);
 			}
@@ -4772,12 +4772,21 @@ async function streamAssistantResponse(
 					let next: IteratorResult<AssistantMessageEvent>;
 					if (requestSignal) {
 						const { promise, resolve } = Promise.withResolvers<typeof ABORTED>();
-						resolveReadAbort = resolve;
+						let settled = false;
+						const settleAbort = (): void => {
+							if (settled) return;
+							settled = true;
+							resolve(ABORTED);
+							config.onAbortRaceReactionChange?.(-1);
+						};
+						config.onAbortRaceReactionChange?.(1);
+						settleReadAbort = settleAbort;
 						let result: IteratorResult<AssistantMessageEvent> | typeof ABORTED;
 						try {
 							result = requestSignal.aborted ? ABORTED : await Promise.race([responseIterator.next(), promise]);
 						} finally {
-							resolveReadAbort = undefined;
+							settleAbort();
+							settleReadAbort = undefined;
 						}
 						if (result === ABORTED) {
 							closeIterator();

--- a/packages/agent/src/append-only-context.ts
+++ b/packages/agent/src/append-only-context.ts
@@ -272,18 +272,19 @@ export class AppendOnlyContextManager {
 			seededPrefixLength > 0 && !includesSeedPrefix
 				? [...this.log.entries().slice(0, seededPrefixLength), ...normalizedMessages]
 				: normalizedMessages;
+		const hashes = this.#hashRange(messagesToSync, 0, messagesToSync.length);
 
 		// Detect in-place rewrites of already-synced messages via per-message content
 		// hashes (no retained full serialized-history string; F5).
 		if (
 			this.#lastSyncCount > 0 &&
 			this.#lastSyncCount <= messagesToSync.length &&
-			this.#prefixChanged(messagesToSync, this.#lastSyncCount)
+			this.#prefixChanged(hashes, this.#lastSyncCount)
 		) {
 			if (this.#seededPrefixCount > 0) {
 				// F9: a seeded fork whose inherited prefix changed (e.g. after compaction)
 				// rebases onto the new provider context instead of throwing.
-				this.#rebaseToBaseline(messagesToSync, seededPrefixLength);
+				this.#rebaseToBaseline(messagesToSync, hashes, seededPrefixLength);
 				return;
 			}
 			this.log.clear();
@@ -296,7 +297,7 @@ export class AppendOnlyContextManager {
 		// while a seed prefix is active; a genuine seeded compaction rebases (F9).
 		if (messagesToSync.length < this.#lastSyncCount) {
 			if (this.#seededPrefixCount > 0) {
-				this.#rebaseToBaseline(messagesToSync, seededPrefixLength);
+				this.#rebaseToBaseline(messagesToSync, hashes, seededPrefixLength);
 				return;
 			}
 			this.log.clear();
@@ -310,7 +311,7 @@ export class AppendOnlyContextManager {
 		}
 
 		this.#lastSyncCount = messagesToSync.length;
-		this.#syncedHashes = this.#hashRange(messagesToSync, 0, messagesToSync.length);
+		this.#syncedHashes = hashes;
 	}
 
 	seedNormalizedMessages(messages: readonly Message[], options?: { reset?: boolean }): void {
@@ -393,21 +394,21 @@ export class AppendOnlyContextManager {
 	}
 
 	/** True when any of the first `count` already-synced messages changed content (in-place rewrite). */
-	#prefixChanged(messages: readonly unknown[], count: number): boolean {
+	#prefixChanged(hashes: readonly (number | bigint)[], count: number): boolean {
 		if (count > this.#syncedHashes.length) return false;
 		for (let i = 0; i < count; i++) {
-			if (this.#hashMessage(messages[i]) !== this.#syncedHashes[i]) return true;
+			if (hashes[i] !== this.#syncedHashes[i]) return true;
 		}
 		return false;
 	}
 
 	/** F9: reset the log to a new provider-visible baseline after seeded compaction/rebase. */
-	#rebaseToBaseline(messages: readonly unknown[], seededPrefixCount = 0): void {
+	#rebaseToBaseline(messages: readonly unknown[], hashes: (number | bigint)[], seededPrefixCount: number): void {
 		this.log.clear();
 		this.log.extend(messages.map(message => cloneJson(message)));
 		this.#lastSyncCount = messages.length;
 		this.#seededPrefixCount = seededPrefixCount;
-		this.#syncedHashes = this.#hashRange(messages, 0, messages.length);
+		this.#syncedHashes = hashes;
 	}
 }
 

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -260,6 +260,8 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
 	 * next tool/turn boundary either way.
 	 */
 	toolInterruptPolicy?: "abort_tools" | "finish_tools";
+	/** Test-only diagnostic for bounding pending per-read abort-race reactions. */
+	onAbortRaceReactionChange?: (delta: 1 | -1) => void;
 
 	/**
 	 * Optional session identifier forwarded to LLM providers.

--- a/packages/agent/test/streaming-perf.test.ts
+++ b/packages/agent/test/streaming-perf.test.ts
@@ -1,0 +1,107 @@
+import { expect, it } from "bun:test";
+import type { AssistantMessageEvent, Message } from "@gajae-code/ai";
+import { createMockModel } from "@gajae-code/ai/providers/mock";
+import { AssistantMessageEventStream } from "@gajae-code/ai/utils/event-stream";
+import { agentLoop } from "../src/agent-loop";
+import { AppendOnlyContextManager } from "../src/append-only-context";
+import { createAssistantMessage, createUserMessage } from "./helpers";
+
+class CountingSignal extends EventTarget {
+	aborted = false;
+	reason: unknown;
+	onabort = null;
+	listeners = new Set<EventListener | EventListenerObject>();
+	addEventListener(
+		type: string,
+		listener: EventListener | EventListenerObject | null,
+		options?: AddEventListenerOptions | boolean,
+	): void {
+		if (type === "abort" && listener) this.listeners.add(listener);
+		if (listener) super.addEventListener(type, listener, options);
+	}
+	removeEventListener(
+		type: string,
+		listener: EventListener | EventListenerObject | null,
+		options?: EventListenerOptions | boolean,
+	): void {
+		if (type === "abort" && listener) this.listeners.delete(listener);
+		if (listener) super.removeEventListener(type, listener, options);
+	}
+	throwIfAborted(): void {
+		if (this.aborted) throw this.reason;
+	}
+	abort(): void {
+		this.aborted = true;
+		this.reason = new Error("cancelled after many events");
+		this.dispatchEvent(new Event("abort"));
+	}
+}
+
+for (const abort of [false, true]) {
+	it(`keeps one stream abort listener across 4096 reads (abort=${abort})`, async () => {
+		const signal = new CountingSignal();
+		const mock = createMockModel();
+		const message = createAssistantMessage([{ type: "text", text: "answer" }]);
+		let reads = 0;
+		let closes = 0;
+		class Response extends AssistantMessageEventStream {
+			[Symbol.asyncIterator](): AsyncIterator<AssistantMessageEvent> {
+				return {
+					next: async () => {
+						expect(signal.listeners.size).toBe(1);
+						if (reads++ < 4096)
+							return {
+								done: false,
+								value: { type: "text_delta", contentIndex: 0, delta: "x", partial: message },
+							};
+						if (abort) {
+							signal.abort();
+							return Promise.withResolvers<IteratorResult<AssistantMessageEvent>>().promise;
+						}
+						return { done: true, value: undefined };
+					},
+					return: async () => {
+						closes++;
+						return { done: true, value: undefined };
+					},
+				};
+			}
+		}
+		const response = new Response();
+		response.end(message);
+		const events = agentLoop(
+			[createUserMessage("hello")],
+			{ systemPrompt: [], messages: [], tools: [] },
+			{
+				model: mock.model,
+				convertToLlm: messages => messages as Message[],
+			},
+			signal as AbortSignal,
+			() => response,
+		);
+		let aborted = false;
+		for await (const event of events) {
+			if (event.type === "message_end" && event.message.role === "assistant")
+				aborted = event.message.stopReason === "aborted";
+		}
+		expect(reads).toBe(4097);
+		expect(aborted).toBe(abort);
+		expect(signal.listeners.size).toBe(0);
+		expect(closes).toBe(abort ? 1 : 0);
+	});
+}
+
+it("appends new history and replaces same-length in-place edits", () => {
+	const manager = new AppendOnlyContextManager();
+	const messages = [createUserMessage("first")];
+	manager.syncMessages(messages);
+	messages.push(createUserMessage("second"));
+	manager.syncMessages(messages);
+	expect(manager.log.toMessages()).toEqual(messages);
+	messages[0].content = "rewritten";
+	manager.syncMessages(messages);
+	expect(manager.log.toMessages()).toEqual(messages);
+	expect(manager.log.length).toBe(2);
+	manager.syncMessages(messages);
+	expect(manager.log.length).toBe(2);
+});

--- a/packages/agent/test/streaming-perf.test.ts
+++ b/packages/agent/test/streaming-perf.test.ts
@@ -40,6 +40,8 @@ class CountingSignal extends EventTarget {
 for (const abort of [false, true]) {
 	it(`keeps one stream abort listener across 4096 reads (abort=${abort})`, async () => {
 		const signal = new CountingSignal();
+		let pendingAbortReactions = 0;
+		let maxPendingAbortReactions = 0;
 		const mock = createMockModel();
 		const message = createAssistantMessage([{ type: "text", text: "answer" }]);
 		let reads = 0;
@@ -75,6 +77,10 @@ for (const abort of [false, true]) {
 			{
 				model: mock.model,
 				convertToLlm: messages => messages as Message[],
+				onAbortRaceReactionChange: delta => {
+					pendingAbortReactions += delta;
+					maxPendingAbortReactions = Math.max(maxPendingAbortReactions, pendingAbortReactions);
+				},
 			},
 			signal as AbortSignal,
 			() => response,
@@ -88,8 +94,43 @@ for (const abort of [false, true]) {
 		expect(aborted).toBe(abort);
 		expect(signal.listeners.size).toBe(0);
 		expect(closes).toBe(abort ? 1 : 0);
+		expect(maxPendingAbortReactions).toBe(1);
+		expect(pendingAbortReactions).toBe(0);
 	});
 }
+
+it("cleans the pending abort race when the provider rejects", async () => {
+	const signal = new CountingSignal();
+	const mock = createMockModel();
+	const failure = new Error("provider failed");
+	let pendingAbortReactions = 0;
+	let maxPendingAbortReactions = 0;
+	const response = new AssistantMessageEventStream();
+	response.fail(failure);
+	const events = agentLoop(
+		[createUserMessage("hello")],
+		{ systemPrompt: [], messages: [], tools: [] },
+		{
+			model: mock.model,
+			convertToLlm: messages => messages as Message[],
+			onAbortRaceReactionChange: delta => {
+				pendingAbortReactions += delta;
+				maxPendingAbortReactions = Math.max(maxPendingAbortReactions, pendingAbortReactions);
+			},
+		},
+		signal as AbortSignal,
+		() => response,
+	);
+	await expect(
+		(async () => {
+			for await (const _event of events) {
+				// Drain the provider failure path.
+			}
+		})(),
+	).rejects.toBe(failure);
+	expect(maxPendingAbortReactions).toBe(1);
+	expect(pendingAbortReactions).toBe(0);
+});
 
 it("appends new history and replaces same-length in-place edits", () => {
 	const manager = new AppendOnlyContextManager();

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Performance
+
+- Drain completion-only stream events instead of retaining them, close idle-iterator sources once on early exit, and avoid repeated suffix scans in escape-dense JSON.
+
 ### Fixed
 
 - ChatGPT Codex Sol credential selection no longer denies `gpt-5.6-sol` from the account's plan label. A Plus-labelled OAuth account was rejected locally before any request, but the provider accepts that account and returns a normal `200`; trial, grandfathered and experiment-enabled accounts all carry an ordinary plan label. Plan tier now only ranks Sol candidates, so a Pro account is still preferred and a Plus account is used when it is the only one connected or the preferred one is exhausted. Spark keeps its existing confirmed-Pro filtering when a Pro account is present. The provider remains the entitlement authority for Sol, and its refusal is still surfaced through the same actionable message (#5270).

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -494,6 +494,9 @@ export async function complete<TApi extends Api>(
 	options?: OptionsForApi<TApi>,
 ): Promise<AssistantMessage> {
 	const s = stream(model, context, options);
+	for await (const _event of s) {
+		// Completion callers only need the terminal message, not buffered events.
+	}
 	return s.result();
 }
 
@@ -818,6 +821,9 @@ export async function completeSimple<TApi extends Api>(
 	options?: SimpleStreamOptions,
 ): Promise<AssistantMessage> {
 	const s = streamSimple(model, context, options);
+	for await (const _event of s) {
+		// Completion callers only need the terminal message, not buffered events.
+	}
 	return s.result();
 }
 

--- a/packages/ai/src/utils/idle-iterator.ts
+++ b/packages/ai/src/utils/idle-iterator.ts
@@ -255,8 +255,12 @@ export async function* iterateWithIdleTimeout<T>(
 	const firstItemTimeoutMs = options.firstItemTimeoutMs ?? options.idleTimeoutMs;
 	const abortSignal = options.abortSignal;
 	const iterator = iterable[Symbol.asyncIterator]();
+	let naturallyExhausted = false;
+	let iteratorClosed = false;
 
 	const closeIterator = (): void => {
+		if (iteratorClosed) return;
+		iteratorClosed = true;
 		const returnPromise = iterator.return?.();
 		if (returnPromise) {
 			void returnPromise.catch(() => {});
@@ -296,109 +300,114 @@ export async function* iterateWithIdleTimeout<T>(
 		(firstItemTimeoutMs === undefined || firstItemTimeoutMs <= 0) &&
 		(options.idleTimeoutMs === undefined || options.idleTimeoutMs <= 0);
 
-	while (true) {
-		let activeTimeoutMs: number | undefined;
-		if (awaitingFirstItem) {
-			activeTimeoutMs =
-				firstItemDeadlineAt === undefined ? undefined : Math.max(0, firstItemDeadlineAt - Date.now());
-		} else if (options.idleTimeoutMs !== undefined && options.idleTimeoutMs > 0) {
-			activeTimeoutMs = options.idleTimeoutMs - (Date.now() - lastProgressAt);
-			// The idle deadline may already have elapsed because the *consumer*
-			// was slow, not because the provider stalled — and the next item may
-			// already be buffered and ready to deliver. Clamp to 0 instead of
-			// throwing eagerly so the next() race below still gets a chance to
-			// win (it settles on a microtask, ahead of the 0ms timer). Only a
-			// genuinely hung iterator loses that race and surfaces as a stall.
-			if (activeTimeoutMs < 0) {
-				activeTimeoutMs = 0;
-			}
-		}
-
-		const racers: Array<
-			Promise<
-				| { kind: "next"; result: IteratorResult<T> }
-				| { kind: "error"; error: unknown }
-				| { kind: "timeout" }
-				| { kind: "abort" }
-			>
-		> = [];
-
-		let timer: NodeJS.Timeout | undefined;
-		let resolveTimeout: ((value: { kind: "timeout" }) => void) | undefined;
-		const enforceTimeout = !noTimeoutEnforced && activeTimeoutMs !== undefined && activeTimeoutMs >= 0;
-		if (enforceTimeout) {
-			const { promise, resolve } = Promise.withResolvers<{ kind: "timeout" }>();
-			resolveTimeout = resolve;
-			timer = setTimeout(() => resolve({ kind: "timeout" }), activeTimeoutMs);
-			racers.push(promise);
-		}
-
-		let abortListener: (() => void) | undefined;
-		let resolveAbort: ((value: { kind: "abort" }) => void) | undefined;
-		if (abortSignal) {
-			const { promise, resolve } = Promise.withResolvers<{ kind: "abort" }>();
-			resolveAbort = resolve;
-			abortListener = () => resolve({ kind: "abort" });
-			abortSignal.addEventListener("abort", abortListener, { once: true });
-			racers.push(promise);
-		}
-
-		// Arm timeout/abort races before asking the source for its next item. A
-		// periodic keepalive iterator commonly registers its own timer inside
-		// `next()`; registering that first lets equal-deadline keepalives win every
-		// race and extend the idle window forever. Already-buffered items still
-		// settle as microtasks before a 0ms watchdog.
-		racers.unshift(withRacy(iterator.next()));
-
-		try {
-			const outcome = await Promise.race(racers);
-			if (outcome.kind === "abort") {
-				closeIterator();
-				throw abortReason(abortSignal!);
-			}
-			if (outcome.kind === "timeout") {
-				if (!awaitingFirstItem) {
-					options.onIdle?.();
-				} else {
-					options.onFirstItemTimeout?.();
+	try {
+		while (true) {
+			let activeTimeoutMs: number | undefined;
+			if (awaitingFirstItem) {
+				activeTimeoutMs =
+					firstItemDeadlineAt === undefined ? undefined : Math.max(0, firstItemDeadlineAt - Date.now());
+			} else if (options.idleTimeoutMs !== undefined && options.idleTimeoutMs > 0) {
+				activeTimeoutMs = options.idleTimeoutMs - (Date.now() - lastProgressAt);
+				// The idle deadline may already have elapsed because the *consumer*
+				// was slow, not because the provider stalled — and the next item may
+				// already be buffered and ready to deliver. Clamp to 0 instead of
+				// throwing eagerly so the next() race below still gets a chance to
+				// win (it settles on a microtask, ahead of the 0ms timer). Only a
+				// genuinely hung iterator loses that race and surfaces as a stall.
+				if (activeTimeoutMs < 0) {
+					activeTimeoutMs = 0;
 				}
-				closeIterator();
-				throw awaitingFirstItem
-					? new FirstEventTimeoutError(options.firstItemErrorMessage ?? options.errorMessage)
-					: new Error(options.errorMessage);
 			}
-			if (outcome.kind === "error") {
-				throw outcome.error;
+
+			const racers: Array<
+				Promise<
+					| { kind: "next"; result: IteratorResult<T> }
+					| { kind: "error"; error: unknown }
+					| { kind: "timeout" }
+					| { kind: "abort" }
+				>
+			> = [];
+
+			let timer: NodeJS.Timeout | undefined;
+			let resolveTimeout: ((value: { kind: "timeout" }) => void) | undefined;
+			const enforceTimeout = !noTimeoutEnforced && activeTimeoutMs !== undefined && activeTimeoutMs >= 0;
+			if (enforceTimeout) {
+				const { promise, resolve } = Promise.withResolvers<{ kind: "timeout" }>();
+				resolveTimeout = resolve;
+				timer = setTimeout(() => resolve({ kind: "timeout" }), activeTimeoutMs);
+				racers.push(promise);
 			}
-			if (awaitingFirstItem && firstItemDeadlineAt !== undefined && Date.now() >= firstItemDeadlineAt) {
-				options.onFirstItemTimeout?.();
-				closeIterator();
-				throw new FirstEventTimeoutError(options.firstItemErrorMessage ?? options.errorMessage);
+
+			let abortListener: (() => void) | undefined;
+			let resolveAbort: ((value: { kind: "abort" }) => void) | undefined;
+			if (abortSignal) {
+				const { promise, resolve } = Promise.withResolvers<{ kind: "abort" }>();
+				resolveAbort = resolve;
+				abortListener = () => resolve({ kind: "abort" });
+				abortSignal.addEventListener("abort", abortListener, { once: true });
+				racers.push(promise);
 			}
-			if (outcome.result.done) {
-				markFirstItemReceived();
-				return;
+
+			// Arm timeout/abort races before asking the source for its next item. A
+			// periodic keepalive iterator commonly registers its own timer inside
+			// `next()`; registering that first lets equal-deadline keepalives win every
+			// race and extend the idle window forever. Already-buffered items still
+			// settle as microtasks before a 0ms watchdog.
+			racers.unshift(withRacy(iterator.next()));
+
+			try {
+				const outcome = await Promise.race(racers);
+				if (outcome.kind === "abort") {
+					closeIterator();
+					throw abortReason(abortSignal!);
+				}
+				if (outcome.kind === "timeout") {
+					if (!awaitingFirstItem) {
+						options.onIdle?.();
+					} else {
+						options.onFirstItemTimeout?.();
+					}
+					closeIterator();
+					throw awaitingFirstItem
+						? new FirstEventTimeoutError(options.firstItemErrorMessage ?? options.errorMessage)
+						: new Error(options.errorMessage);
+				}
+				if (outcome.kind === "error") {
+					throw outcome.error;
+				}
+				if (awaitingFirstItem && firstItemDeadlineAt !== undefined && Date.now() >= firstItemDeadlineAt) {
+					options.onFirstItemTimeout?.();
+					closeIterator();
+					throw new FirstEventTimeoutError(options.firstItemErrorMessage ?? options.errorMessage);
+				}
+				if (outcome.result.done) {
+					naturallyExhausted = true;
+					markFirstItemReceived();
+					return;
+				}
+				const item = outcome.result.value;
+				// Non-progress items (e.g. provider keepalives, synthetic `start` events that
+				// arrive before the model has produced any tokens) MUST NOT flip us out of
+				// `awaitingFirstItem`. Otherwise the next iteration switches from the (longer)
+				// first-item watchdog to the (shorter) idle watchdog while we're still waiting
+				// on the model's first real output.
+				if (isProgressItem(item)) {
+					markFirstItemReceived();
+					lastProgressAt = Date.now();
+				}
+				yield item;
+			} finally {
+				if (timer !== undefined) clearTimeout(timer);
+				// Resolve dangling promises so the racers don't leak (Promise.race is one-shot).
+				resolveTimeout?.({ kind: "timeout" });
+				if (abortListener && abortSignal) {
+					abortSignal.removeEventListener("abort", abortListener);
+				}
+				resolveAbort?.({ kind: "abort" });
 			}
-			const item = outcome.result.value;
-			// Non-progress items (e.g. provider keepalives, synthetic `start` events that
-			// arrive before the model has produced any tokens) MUST NOT flip us out of
-			// `awaitingFirstItem`. Otherwise the next iteration switches from the (longer)
-			// first-item watchdog to the (shorter) idle watchdog while we're still waiting
-			// on the model's first real output.
-			if (isProgressItem(item)) {
-				markFirstItemReceived();
-				lastProgressAt = Date.now();
-			}
-			yield item;
-		} finally {
-			if (timer !== undefined) clearTimeout(timer);
-			// Resolve dangling promises so the racers don't leak (Promise.race is one-shot).
-			resolveTimeout?.({ kind: "timeout" });
-			if (abortListener && abortSignal) {
-				abortSignal.removeEventListener("abort", abortListener);
-			}
-			resolveAbort?.({ kind: "abort" });
 		}
+	} finally {
+		if (!naturallyExhausted) closeIterator();
 	}
 }
 

--- a/packages/ai/src/utils/idle-iterator.ts
+++ b/packages/ai/src/utils/idle-iterator.ts
@@ -261,9 +261,13 @@ export async function* iterateWithIdleTimeout<T>(
 	const closeIterator = (): void => {
 		if (iteratorClosed) return;
 		iteratorClosed = true;
-		const returnPromise = iterator.return?.();
-		if (returnPromise) {
-			void returnPromise.catch(() => {});
+		try {
+			const returnPromise = iterator.return?.();
+			if (returnPromise) {
+				void returnPromise.catch(() => {});
+			}
+		} catch {
+			// Cleanup must not replace the source error or timeout that triggered it.
 		}
 	};
 

--- a/packages/ai/src/utils/json-parse.ts
+++ b/packages/ai/src/utils/json-parse.ts
@@ -249,6 +249,8 @@ export function findUnnecessaryUnicodeEscape(json: string): string | undefined {
 	const len = json.length;
 	let inString = false;
 	let i = 0;
+	let nextQuote = -1;
+	let nextBackslash = -1;
 
 	const hexAt = (start: number): number | undefined => {
 		if (start + 3 >= len) return undefined;
@@ -268,10 +270,16 @@ export function findUnnecessaryUnicodeEscape(json: string): string | undefined {
 		// Jump straight to the next quote or backslash. A per-character walk costs
 		// ~40ms on a 1MB literal-UTF-8 payload (a large `write`), and every byte in
 		// between is by definition uninteresting.
-		const nextQuote = json.indexOf('"', i);
-		const nextBackslash = json.indexOf("\\", i);
-		if (nextQuote === -1 && nextBackslash === -1) return undefined;
-		i = nextBackslash === -1 || (nextQuote !== -1 && nextQuote < nextBackslash) ? nextQuote : nextBackslash;
+		if (nextQuote < i) {
+			const offset = json.indexOf('"', i);
+			nextQuote = offset === -1 ? len : offset;
+		}
+		if (nextBackslash < i) {
+			const offset = json.indexOf("\\", i);
+			nextBackslash = offset === -1 ? len : offset;
+		}
+		i = Math.min(nextQuote, nextBackslash);
+		if (i === len) return undefined;
 
 		if (json.charCodeAt(i) === QUOTE) {
 			inString = false;

--- a/packages/ai/test/streaming-perf.test.ts
+++ b/packages/ai/test/streaming-perf.test.ts
@@ -50,6 +50,30 @@ describe("streaming lifetime regressions", () => {
 		});
 	}
 
+	it("preserves a source error when iterator cleanup throws synchronously", async () => {
+		const sourceFailure = new Error("source failed");
+		const cleanupFailure = new Error("cleanup failed");
+		const source: AsyncIterableIterator<number> = {
+			[Symbol.asyncIterator]() {
+				return this;
+			},
+			async next() {
+				throw sourceFailure;
+			},
+			return() {
+				throw cleanupFailure;
+			},
+		};
+
+		await expect(
+			(async () => {
+				for await (const _value of iterateWithIdleTimeout(source, { errorMessage: "timeout" })) {
+					// The source fails before yielding.
+				}
+			})(),
+		).rejects.toBe(sourceFailure);
+	});
+
 	for (const finish of [complete, completeSimple]) {
 		for (const outcome of ["done", "error", "throw"] as const) {
 			it(`${finish.name} drains events and preserves ${outcome} result semantics`, async () => {

--- a/packages/ai/test/streaming-perf.test.ts
+++ b/packages/ai/test/streaming-perf.test.ts
@@ -12,17 +12,22 @@ import {
 } from "../src/utils/json-parse";
 
 describe("streaming lifetime regressions", () => {
-	for (const exit of ["break", "consumer-error", "source-error", "natural", "timeout"] as const) {
+	for (const exit of ["break", "consumer-error", "source-error", "natural", "abort", "timeout"] as const) {
 		it(`closes the source exactly once on ${exit}, without waiting for return`, async () => {
 			let closes = 0;
 			let reads = 0;
 			const failure = new Error("source failed");
+			const controller = new AbortController();
 			const source: AsyncIterableIterator<number> = {
 				[Symbol.asyncIterator]() {
 					return this;
 				},
 				async next() {
 					if (exit === "source-error") throw failure;
+					if (exit === "abort") {
+						controller.abort(failure);
+						return Promise.withResolvers<IteratorResult<number>>().promise;
+					}
 					if (exit === "timeout") return Promise.withResolvers<IteratorResult<number>>().promise;
 					return reads++ === 0 ? { done: false, value: 7 } : { done: true, value: undefined };
 				},
@@ -36,43 +41,45 @@ describe("streaming lifetime regressions", () => {
 				for await (const value of iterateWithIdleTimeout(source, {
 					errorMessage: "timeout",
 					idleTimeoutMs: exit === "timeout" ? 5 : undefined,
+					abortSignal: controller.signal,
 				})) {
 					values.push(value);
 					if (exit === "break") break;
 					if (exit === "consumer-error") throw failure;
 				}
 			};
-			if (exit === "consumer-error" || exit === "source-error") await expect(consume()).rejects.toBe(failure);
+			if (exit === "consumer-error" || exit === "source-error" || exit === "abort")
+				await expect(consume()).rejects.toBe(failure);
 			else if (exit === "timeout") await expect(consume()).rejects.toThrow("timeout");
 			else await consume();
-			expect(values).toEqual(exit === "source-error" || exit === "timeout" ? [] : [7]);
+			expect(values).toEqual(exit === "source-error" || exit === "abort" || exit === "timeout" ? [] : [7]);
 			expect(closes).toBe(exit === "natural" ? 0 : 1);
 		});
 	}
 
-	it("preserves a source error when iterator cleanup throws synchronously", async () => {
-		const sourceFailure = new Error("source failed");
-		const cleanupFailure = new Error("cleanup failed");
-		const source: AsyncIterableIterator<number> = {
-			[Symbol.asyncIterator]() {
-				return this;
-			},
-			async next() {
-				throw sourceFailure;
-			},
-			return() {
-				throw cleanupFailure;
-			},
-		};
-
-		await expect(
-			(async () => {
-				for await (const _value of iterateWithIdleTimeout(source, { errorMessage: "timeout" })) {
-					// The source fails before yielding.
-				}
-			})(),
-		).rejects.toBe(sourceFailure);
-	});
+	for (const closeFailure of ["throw", "reject"] as const) {
+		it(`preserves source rejection when return fails with ${closeFailure}`, async () => {
+			let closes = 0;
+			const sourceFailure = new Error("source failed");
+			const returnFailure = new Error("return failed");
+			const source: AsyncIterableIterator<number> = {
+				[Symbol.asyncIterator]() {
+					return this;
+				},
+				async next() {
+					throw sourceFailure;
+				},
+				return() {
+					closes++;
+					if (closeFailure === "throw") throw returnFailure;
+					return Promise.reject(returnFailure);
+				},
+			};
+			const iterator = iterateWithIdleTimeout(source, { errorMessage: "timeout" });
+			await expect(iterator.next()).rejects.toBe(sourceFailure);
+			expect(closes).toBe(1);
+		});
+	}
 
 	for (const finish of [complete, completeSimple]) {
 		for (const outcome of ["done", "error", "throw"] as const) {

--- a/packages/ai/test/streaming-perf.test.ts
+++ b/packages/ai/test/streaming-perf.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "bun:test";
+import { registerCustomApi, unregisterCustomApis } from "../src/api-registry";
+import { createMockModel } from "../src/providers/mock";
+import { complete, completeSimple } from "../src/stream";
+import type { AssistantMessage } from "../src/types";
+import { AssistantMessageEventStream } from "../src/utils/event-stream";
+import { iterateWithIdleTimeout } from "../src/utils/idle-iterator";
+import {
+	collectUnsafeUnicodeEscapeEvidence,
+	findUnnecessaryUnicodeEscape,
+	parseJsonWithRepair,
+} from "../src/utils/json-parse";
+
+describe("streaming lifetime regressions", () => {
+	for (const exit of ["break", "consumer-error", "source-error", "natural", "timeout"] as const) {
+		it(`closes the source exactly once on ${exit}, without waiting for return`, async () => {
+			let closes = 0;
+			let reads = 0;
+			const failure = new Error("source failed");
+			const source: AsyncIterableIterator<number> = {
+				[Symbol.asyncIterator]() {
+					return this;
+				},
+				async next() {
+					if (exit === "source-error") throw failure;
+					if (exit === "timeout") return Promise.withResolvers<IteratorResult<number>>().promise;
+					return reads++ === 0 ? { done: false, value: 7 } : { done: true, value: undefined };
+				},
+				return() {
+					closes++;
+					return Promise.withResolvers<IteratorResult<number>>().promise;
+				},
+			};
+			const values: number[] = [];
+			const consume = async () => {
+				for await (const value of iterateWithIdleTimeout(source, {
+					errorMessage: "timeout",
+					idleTimeoutMs: exit === "timeout" ? 5 : undefined,
+				})) {
+					values.push(value);
+					if (exit === "break") break;
+					if (exit === "consumer-error") throw failure;
+				}
+			};
+			if (exit === "consumer-error" || exit === "source-error") await expect(consume()).rejects.toBe(failure);
+			else if (exit === "timeout") await expect(consume()).rejects.toThrow("timeout");
+			else await consume();
+			expect(values).toEqual(exit === "source-error" || exit === "timeout" ? [] : [7]);
+			expect(closes).toBe(exit === "natural" ? 0 : 1);
+		});
+	}
+
+	for (const finish of [complete, completeSimple]) {
+		for (const outcome of ["done", "error", "throw"] as const) {
+			it(`${finish.name} drains events and preserves ${outcome} result semantics`, async () => {
+				const api = `perf-${finish.name}-${outcome}`;
+				const mock = createMockModel();
+				const model = { ...mock.model, api };
+				const message: AssistantMessage = {
+					role: "assistant",
+					content: [{ type: "text", text: "answer" }],
+					api,
+					provider: model.provider,
+					model: model.id,
+					timestamp: 0,
+					usage: {
+						input: 0,
+						output: 0,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 0,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+					},
+					stopReason: outcome === "error" ? "error" : "stop",
+					...(outcome === "error" ? { errorMessage: "provider error" } : {}),
+				};
+				const events = new AssistantMessageEventStream();
+				const failure = new Error("transport failed");
+				registerCustomApi(
+					api,
+					() => {
+						for (let i = 0; i < 4096; i++)
+							events.push({ type: "text_delta", contentIndex: 0, delta: "x", partial: message });
+						if (outcome === "throw") events.fail(failure);
+						else if (outcome === "error") events.push({ type: "error", reason: "error", error: message });
+						else events.push({ type: "done", reason: "stop", message });
+						return events;
+					},
+					api,
+				);
+				try {
+					if (outcome === "throw") await expect(finish(model, { messages: [] })).rejects.toBe(failure);
+					else expect(await finish(model, { messages: [] })).toBe(message);
+					expect(events.queue).toEqual([]);
+					expect(events.hasActiveConsumer).toBe(false);
+				} finally {
+					unregisterCustomApis(api);
+				}
+			});
+		}
+	}
+
+	it("preserves escape-dense JSON and detects a final printable escape", () => {
+		const value = { text: '\\"\n\t'.repeat(20_000), other: ["plain", "한글"] };
+		const json = JSON.stringify(value);
+		expect(parseJsonWithRepair(json)).toEqual(JSON.parse(json));
+		expect(findUnnecessaryUnicodeEscape(json)).toBeUndefined();
+		expect(collectUnsafeUnicodeEscapeEvidence(json)).toBeUndefined();
+		const escaped = json.slice(0, -1) + String.raw`,"end":"\u0061"}`;
+		expect(findUnnecessaryUnicodeEscape(escaped)).toBe(String.raw`\u0061`);
+		expect(parseJsonWithRepair(escaped)).toEqual(JSON.parse(escaped));
+		expect(collectUnsafeUnicodeEscapeEvidence(escaped)).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Summary
Fix all five findings from the PR agent+ai performance sweep:

- `packages/agent/src/agent-loop.ts`: a reused pending abort promise retained one race reaction per stream event. Keep one stream abort listener, settle only the current per-read resolver, and clear it in `finally`; preserve pre/post-read abort checks and iterator close.
- `packages/agent/src/append-only-context.ts`: prefix validation and synchronization hashed history twice. Hash the synchronized message array once and reuse it for prefix comparison, retained state, and seeded rebases.
- `packages/ai/src/utils/idle-iterator.ts`: early consumer exits did not forward source `return()`. Close idempotently from the wrapper's `finally` unless naturally exhausted, without awaiting source return.
- `packages/ai/src/stream.ts`: completion-only calls retained unused events. Drain and discard events before returning the terminal message, preserving error-message versus thrown-error semantics.
- `packages/ai/src/utils/json-parse.ts`: escape-dense strings repeatedly searched the same suffix for quotes. Cache quote/backslash offsets and search again only after advancing past them.

Skipped findings: none. Updated both package Unreleased changelogs. No provider API or runtime configuration changes.

## Verification
Final focused run: **214 passed, 0 failed**, 11,806 assertions across 10 files.

```sh
bun test ./packages/agent/test/streaming-perf.test.ts ./packages/agent/test/agent-force-abort.test.ts ./packages/agent/test/agent-loop.test.ts ./packages/agent/test/append-only-context.test.ts ./packages/agent/test/append-only-seeded-rebase.test.ts ./packages/ai/test/streaming-perf.test.ts ./packages/ai/test/idle-iterator.test.ts ./packages/ai/test/json-parse.test.ts ./packages/ai/test/json-parse-windows-home.test.ts ./packages/ai/test/event-stream.test.ts
bun --cwd=packages/agent run check
bun --cwd=packages/ai run check
git diff --check
```

Both package checks pass. Existing unrelated diagnostics remain visible: agent `src/agent.ts:121` Function-type warning; ai `src/providers/openai-codex-responses.ts:137,149` two unnecessary-String.raw informational diagnostics. Initial agent check runs exposed formatting/import order and test EventListener typing issues; all fixed before the final passing run.

Initial new-test-only command also passed (15 passed, 0 failed):
```sh
bun test ./packages/agent/test/streaming-perf.test.ts ./packages/ai/test/streaming-perf.test.ts
```

New regressions cover 4,096 stream reads with a counting fake AbortSignal, late abort cleanup, same-length history mutation, consumer break/throw and source throw/timeout cleanup with non-settling return promises, natural exhaustion, completion success/error/failure queue drainage, and escape-dense JSON parity against JSON.parse. No network-backed provider tests or full-repository checks were run.

## Review contract

- [ ] `low-risk`
- [x] `regression-risk`
- [ ] `high-risk`

gajae.pr-review-verdict.v1 merge-approved sha256:8a9dc0a67c79008df5ee7b77bf3f4e2bfa1b39961a5bcfbe49861580f6160fba reviewer:human reviewer-id:probepark evidence:ci-contract-gate-only;digest-matches-ci-8a9dc0a6;abort-race-bounded-one-listener-detached;iterator-close-idempotent;drain-preserves-errorMessage-vs-throw;json-scan-cache-monotonic;hash-reuse-behavior-identical;changelog-fragments-routed;no-mock-module-or-spy-leak

Abort-race follow-up is bound to this exact head; hosted validation is being refreshed.

<!-- gjc-maintenance-01a083b2 -->
Current maintenance snapshot: base `f19e6867547068d1c7eec237c68150c0fd69bcab`, head `3b6b8ea2cc74ac67b251e121df980890e1cd41df`. Earlier narrative/test evidence is historical unless explicitly rebound to this head. Rebase/diff verification does not replace required CI or independent approval.
<!-- /gjc-maintenance-01a083b2 -->
