### PR TITLE
fix(compaction): clamp maintenance reasoning to the target model

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Compaction summary, turn-prefix summary, and handoff generation now clamp their reasoning effort to the model they are about to call instead of hard-coding `high`. A reasoning-capable model on a transport without reasoning control (the registry strips `thinking` when `openai-codex` or `anthropic` is routed through a non-audited proxy `baseUrl`) rejected the raw effort inside the provider mapper with "Model <provider>/<id> does not support thinking"; since the compaction fallback chain then reaches for the same-provider largest-context model, every candidate died on that throw and auto-compaction reported only the last one. The agent turn already clamps through `clampThinkingLevelForModel`; the maintenance calls were the one path still sending an unclamped effort.
+
 ## [0.16.4] - 2026-09-05
 
 - Provider calls now carry the agent-owned opaque provider conversation identity separately from generic session/cache affinity, including compaction, handoff, turn-prefix summary, and branch-summary maintenance calls. This lets provider-specific conversation headers remain stable without treating prompt-derived gateway cache keys as conversation authority (#5295).

--- a/packages/agent/src/compaction/compaction.ts
+++ b/packages/agent/src/compaction/compaction.ts
@@ -8,6 +8,7 @@
 import * as os from "node:os";
 import {
 	type AssistantMessage,
+	clampThinkingLevelForModel,
 	Effort,
 	type Message,
 	type MessageAttribution,
@@ -1023,7 +1024,7 @@ export async function generateSummary(
 			maxTokens,
 			signal,
 			apiKey,
-			reasoning: Effort.High,
+			reasoning: maintenanceReasoning(model),
 			initiatorOverride: options?.initiatorOverride,
 			metadata: options?.metadata,
 			sessionId: options?.sessionId,
@@ -1120,7 +1121,7 @@ export async function generateHandoff(
 		{
 			apiKey,
 			signal,
-			reasoning: Effort.High,
+			reasoning: maintenanceReasoning(model),
 			toolChoice: "none",
 			initiatorOverride: options.initiatorOverride,
 			metadata: options.metadata,
@@ -1347,6 +1348,22 @@ export function prepareCompaction(
 const TURN_PREFIX_SUMMARIZATION_PROMPT = prompt.render(compactionTurnPrefixPrompt);
 
 /**
+ * Reasoning effort for a maintenance one-shot call (summary, turn-prefix
+ * summary, handoff), sized against the model that will actually run it.
+ *
+ * These calls want `high`, but they must never *demand* it: the fallback
+ * chain hands them whatever same-provider model has the most context, and a
+ * reasoning-capable model on a transport without reasoning control (the
+ * registry strips `thinking` for a proxied `openai-codex` baseUrl) rejects any
+ * explicit effort inside the provider mapper. The agent turn already clamps
+ * through this helper; the maintenance calls must not be the one path that
+ * still sends a raw effort.
+ */
+function maintenanceReasoning(model: Model): Effort | undefined {
+	return clampThinkingLevelForModel(model, Effort.High);
+}
+
+/**
  * Generate summaries for compaction using prepared data.
  * Returns CompactionResult - SessionManager adds id/parentId when saving.
  *
@@ -1555,7 +1572,7 @@ async function generateTurnPrefixSummary(
 			maxTokens,
 			signal,
 			apiKey,
-			reasoning: Effort.High,
+			reasoning: maintenanceReasoning(model),
 			initiatorOverride: options?.initiatorOverride,
 			metadata: options?.metadata,
 			sessionId: options?.sessionId,

--- a/packages/agent/test/compaction-reasoning-clamp.test.ts
+++ b/packages/agent/test/compaction-reasoning-clamp.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Maintenance one-shot calls (compaction summary, turn-prefix summary, handoff)
+ * must size their reasoning effort against the model they are about to call.
+ *
+ * They used to hard-code `Effort.High`. A reasoning-capable model whose
+ * transport is not an audited reasoning-control endpoint (the registry strips
+ * `thinking` and `modelSupportsReasoningControl` reports false — a proxied
+ * `openai-codex` baseUrl is the everyday case) then fails inside
+ * `requireSupportedEffort` with "does not support thinking", and because the
+ * compaction fallback chain picks the same-provider largest-context model,
+ * every candidate dies on the same throw and auto-compaction reports the last
+ * one. The agent turn itself survives because it clamps through the same
+ * helper; only the maintenance calls skipped it.
+ */
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import {
+	type CompactionPreparation,
+	compact,
+	createFileOps,
+	DEFAULT_COMPACTION_SETTINGS,
+	generateHandoff,
+	generateSummary,
+} from "@gajae-code/agent-core/compaction";
+import type { AgentMessage } from "@gajae-code/agent-core/types";
+import type { AssistantMessage, Model, SimpleStreamOptions, Usage } from "@gajae-code/ai";
+import * as ai from "@gajae-code/ai";
+import { Effort } from "@gajae-code/ai";
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+/** Reasoning-capable Codex model served through a non-audited proxy host. */
+const PROXIED_CODEX: Model = {
+	id: "gpt-5.4",
+	name: "GPT-5.4",
+	api: "openai-codex-responses",
+	provider: "openai-codex",
+	baseUrl: "http://10.0.0.1:8317/backend-api",
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 1_000_000,
+	maxTokens: 128_000,
+};
+
+/** Same model on its audited first-party host, with thinking metadata intact. */
+const FIRST_PARTY_CODEX: Model = {
+	...PROXIED_CODEX,
+	baseUrl: "https://chatgpt.com/backend-api",
+	thinking: { mode: "effort", minLevel: Effort.Low, maxLevel: Effort.XHigh },
+};
+
+/** Model whose declared ceiling is below `high`. */
+const CAPPED_MODEL: Model = {
+	...FIRST_PARTY_CODEX,
+	id: "capped",
+	thinking: { mode: "effort", minLevel: Effort.Low, maxLevel: Effort.Medium },
+};
+
+function makeUsage(): Usage {
+	return {
+		input: 10,
+		output: 10,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 20,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+}
+
+function makeAssistantMessage(text: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "mock",
+		provider: "mock",
+		model: "mock-model",
+		usage: makeUsage(),
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+function makeUserMessage(text: string): AgentMessage {
+	return { role: "user", content: text, timestamp: Date.now() };
+}
+
+function makePreparation(overrides: Partial<CompactionPreparation> = {}): CompactionPreparation {
+	return {
+		firstKeptEntryId: "kept-1",
+		messagesToSummarize: [makeUserMessage("Hello"), makeAssistantMessage("Hi back")],
+		turnPrefixMessages: [],
+		recentMessages: [makeUserMessage("Next question")],
+		isSplitTurn: false,
+		tokensBefore: 12345,
+		fileOps: createFileOps(),
+		settings: { ...DEFAULT_COMPACTION_SETTINGS, remoteEnabled: false },
+		tokenCorrection: { ratio: 1, keepRecentTokensCorrected: DEFAULT_COMPACTION_SETTINGS.keepRecentTokens },
+		...overrides,
+	};
+}
+
+function spyCompleteSimple(): SimpleStreamOptions[] {
+	const captured: SimpleStreamOptions[] = [];
+	vi.spyOn(ai, "completeSimple").mockImplementation(async (_model, _ctx, options) => {
+		captured.push(options as SimpleStreamOptions);
+		return makeAssistantMessage("summary text");
+	});
+	return captured;
+}
+
+describe("maintenance calls clamp reasoning to the target model", () => {
+	it("sends no reasoning to a reasoning model whose transport has no reasoning control", async () => {
+		const captured = spyCompleteSimple();
+		await generateSummary([makeUserMessage("Hi")], PROXIED_CODEX, 4096, "k");
+		expect(captured).toHaveLength(1);
+		expect(captured[0]?.reasoning).toBeUndefined();
+	});
+
+	it("keeps high effort on the audited first-party transport", async () => {
+		const captured = spyCompleteSimple();
+		await generateSummary([makeUserMessage("Hi")], FIRST_PARTY_CODEX, 4096, "k");
+		expect(captured[0]?.reasoning).toBe(Effort.High);
+	});
+
+	it("clamps to the model's declared ceiling when it is below high", async () => {
+		const captured = spyCompleteSimple();
+		await generateSummary([makeUserMessage("Hi")], CAPPED_MODEL, 4096, "k");
+		expect(captured[0]?.reasoning).toBe(Effort.Medium);
+	});
+
+	it("generateHandoff applies the same clamp", async () => {
+		const captured = spyCompleteSimple();
+		await generateHandoff([makeUserMessage("Hi")], PROXIED_CODEX, "k", { systemPrompt: ["sys"], tools: [] });
+		expect(captured[0]?.reasoning).toBeUndefined();
+	});
+
+	it("split-turn compact() clamps both the history and turn-prefix summaries", async () => {
+		const captured = spyCompleteSimple();
+		await compact(
+			makePreparation({
+				isSplitTurn: true,
+				turnPrefixMessages: [makeUserMessage("prefix"), makeAssistantMessage("prefix reply")],
+			}),
+			PROXIED_CODEX,
+			"k",
+		);
+		expect(captured).toHaveLength(2);
+		for (const options of captured) expect(options.reasoning).toBeUndefined();
+	});
+
+	it("the unclamped effort is exactly what the provider mapper rejects", () => {
+		// Pin the failure mode this file guards: `requireSupportedEffort` is what the
+		// OpenAI option mapper runs on `options.reasoning`, and it throws for this model.
+		expect(() => ai.requireSupportedEffort(PROXIED_CODEX, Effort.High)).toThrow(
+			"Model openai-codex/gpt-5.4 does not support thinking",
+		);
+		expect(ai.clampThinkingLevelForModel(PROXIED_CODEX, Effort.High)).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Symptom

```
Warning: Auto-compaction failed: Model openai-codex/gpt-5.4 does not support thinking
```

Seen on a session running the `astra-fable-opus` preset (`openai-codex/gpt-6-astra`). The model in the message is **not** the session model and not in the preset's role bindings, which is the confusing part.

## Root cause chain (all measured on the live registry)

1. `~/.gjc/agent/models.yml` routes `openai-codex` (and `anthropic`) through a proxy `baseUrl` (`http://10.103.111.232:8317/...`).
2. `modelSupportsReasoningControl()` is fail-closed for `openai-codex-responses`: any host outside the audited list (`api.openai.com`, `chatgpt.com`, `openai.azure.com`) reports `false`.
3. `enrichModelThinking()` therefore strips `thinking` from **every** `openai-codex` model in `getAvailable()` — measured: 22/22 with `thinking=undefined, reasoningControl=false`.
4. `#getCompactionModelCandidates()` tries the session model, then each preset role, then the **same-provider largest-context** model. Under this registry that last fallback is `gpt-5.4` (1,000,000 ctx), which is why it appears in the message; `gpt-6-astra` (272k) and the role models had already failed with the identical throw.
5. `generateSummary` / `generateTurnPrefixSummary` / `generateHandoff` hard-code `reasoning: Effort.High`. The OpenAI option mapper runs `requireSupportedEffort(model, "high")` on it, which throws `Model openai-codex/gpt-5.4 does not support thinking`.

The agent turn itself is fine because `thinking.ts` clamps the session's level through `clampThinkingLevelForModel` before calling the provider. The three maintenance one-shot calls in `@gajae-code/agent-core/compaction` bypass that and were the only path still sending an unclamped effort.

## Change

`packages/agent/src/compaction/compaction.ts`: the three sites now use `clampThinkingLevelForModel(model, Effort.High)`:

- audited first-party transport → still `high`
- reasoning model on a non-audited transport → `undefined` (summary without thinking; compaction succeeding beats summary quality)
- model with a declared ceiling below `high` → clamped to its ceiling

No change to `modelSupportsReasoningControl` — the audited-transport gate stays fail-closed for unknown endpoints.

## Tests

`packages/agent/test/compaction-reasoning-clamp.test.ts` (new): 6 cases through the `completeSimple` spy seam used by `compaction-transport.test.ts`. Before this change 4 fail (`Received: "high"`), plus a pin that `requireSupportedEffort` throws the exact user-visible message for the proxied model while `clampThinkingLevelForModel` returns `undefined`.

## Verification

- `bun test packages/agent/test/compaction-reasoning-clamp.test.ts …transport …telemetry …summary-input-bound remote-compaction emergency-compaction` — 46 pass
- `bun test packages/coding-agent/test/{compaction,agent-session-compaction,agent-session-handoff,compaction-prefer-current-model,issue-697-compaction-provider-route,issue-986-compaction-auth-fallback,compaction-hooks}.test.ts` — 74 pass / 15 skip (auth-gated)
- `bun --cwd=packages/agent run check` — tsc clean; one pre-existing biome warning at `src/agent.ts:121` (`Function` type), untouched

Not verified: a live compaction against the proxy gateway.

## Out of scope (noted, not changed)

The fallback order that lets a 1M-context `gpt-5.4` summarize an `astra` session is unrelated to the throw and a separate discussion.

## Risk classification

- [ ] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [x] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken
gajae.pr-review-verdict.v1 merge-approved sha256:593e814079d2e7fc9fc82739b011968371474c5948a65463ff63c93c986a1bfd reviewer:human reviewer-id:Yeachan-Heo evidence:Independent exact-head APPROVED review plus focused current-head verification; live proxy execution remains unverified.