### PR TITLE
fix(compaction): report every failed candidate, first failure leading

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- When every auto-compaction candidate fails, the reported error now leads with the first candidate's failure and lists each candidate that was tried with its own error. The chain starts at the session model and ends on a same-provider largest-context fallback, so surfacing only the final error named a model the user never chose (e.g. `openai-codex/gpt-5.4` on an `astra` preset session) and hid that their own model had already failed the same way.
 
 ## [0.16.4] - 2026-09-05
 ### Added

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -439,6 +439,7 @@ import {
 	type ConfiguredFallbackChain,
 	cappedExponentialWithFullJitter,
 	compactionRetryDelay,
+	describeCompactionCandidateFailures,
 	effectiveFallbackDelay,
 	FallbackChainController,
 	type FallbackChainRuntimeState,
@@ -20160,6 +20161,10 @@ export class AgentSession {
 				const telemetry = resolveTelemetry(this.agent.telemetry, this.sessionId);
 				let compactResult: CompactionResult | undefined;
 				let lastError: unknown;
+				// Every candidate that was tried and failed, in order. Only the last failure
+				// used to reach the user, which named whichever same-provider fallback the
+				// chain ended on and hid that the session model itself had already failed.
+				const candidateFailures: Array<{ model: string; message: string }> = [];
 
 				for (const candidate of candidates) {
 					const apiKey = await this.#modelRegistry.getApiKey(candidate, this.credentialSessionId);
@@ -20193,6 +20198,7 @@ export class AgentSession {
 							const message = error instanceof Error ? error.message : String(error);
 							if (this.#isCompactionAuthFailure(error)) {
 								lastError = this.#buildCompactionAuthError();
+								candidateFailures.push({ model: `${candidate.provider}/${candidate.id}`, message });
 								break;
 							}
 							const retryAfterMs = this.#parseRetryAfterMsFromError(message);
@@ -20205,6 +20211,7 @@ export class AgentSession {
 									isUsageLimitError(message));
 							if (!shouldRetry) {
 								lastError = error;
+								candidateFailures.push({ model: `${candidate.provider}/${candidate.id}`, message });
 								break;
 							}
 
@@ -20229,6 +20236,7 @@ export class AgentSession {
 										model: `${candidate.provider}/${candidate.id}`,
 									});
 									lastError = error;
+									candidateFailures.push({ model: `${candidate.provider}/${candidate.id}`, message });
 									break; // Exit retry loop, continue to next candidate
 								}
 								// No more candidates - we have to wait
@@ -20254,7 +20262,9 @@ export class AgentSession {
 
 				if (!compactResult) {
 					if (lastError) {
-						throw lastError;
+						throw candidateFailures.length > 1
+							? describeCompactionCandidateFailures(candidateFailures, lastError)
+							: lastError;
 					}
 					throw new Error("Compaction failed: no available model");
 				}

--- a/packages/coding-agent/src/session/fallback-chain-controller.ts
+++ b/packages/coding-agent/src/session/fallback-chain-controller.ts
@@ -265,6 +265,33 @@ export function compactionRetryDelay(
 	return Math.max(0, bounded);
 }
 
+export interface CompactionCandidateFailure {
+	readonly model: string;
+	readonly message: string;
+}
+
+/**
+ * Error for an auto-compaction run whose every candidate failed.
+ *
+ * The candidate chain starts at the session model and ends on a same-provider
+ * largest-context fallback, so surfacing only the final error named a model
+ * the user never chose and hid that their own model had already failed the
+ * same way. The message leads with the first failure (the one the user can act
+ * on), then lists every candidate that was tried with its own error. `cause`
+ * is the final error so callers that classify by type keep the same object.
+ */
+export function describeCompactionCandidateFailures(
+	failures: readonly CompactionCandidateFailure[],
+	lastError: unknown,
+): Error {
+	const first = failures[0]!;
+	const lines = failures.map(failure => `  ${failure.model}: ${failure.message}`);
+	return new Error(
+		`${first.message} (${first.model}); ${failures.length} compaction candidates failed:\n${lines.join("\n")}`,
+		{ cause: lastError },
+	);
+}
+
 /** Retry-After is intentionally uncapped. */
 export function effectiveFallbackDelay(
 	baseDelayMs: number,

--- a/packages/coding-agent/src/session/fallback-chain-controller.ts
+++ b/packages/coding-agent/src/session/fallback-chain-controller.ts
@@ -1,3 +1,4 @@
+import { cleanReason } from "@gajae-code/ai/auth-broker/redact";
 import type { FallbackTriggerClass } from "@gajae-code/ai/utils/fallback-transport";
 
 /** Immutable configured fallback intent. Transient attempt state never belongs here. */
@@ -270,6 +271,11 @@ export interface CompactionCandidateFailure {
 	readonly message: string;
 }
 
+function sanitizeCompactionCandidateFailureMessage(message: string): string {
+	const cleaned = cleanReason(message) ?? "Compaction candidate failed.";
+	return cleaned.replace(/\b[a-z][a-z0-9+.-]*:\/\/[^\s<>'"]+/gi, "[redacted URL]");
+}
+
 /**
  * Error for an auto-compaction run whose every candidate failed.
  *
@@ -284,10 +290,15 @@ export function describeCompactionCandidateFailures(
 	failures: readonly CompactionCandidateFailure[],
 	lastError: unknown,
 ): Error {
+	if (failures.length === 0)
+		return new Error("Compaction failed: no candidate failure details available.", { cause: lastError });
 	const first = failures[0]!;
-	const lines = failures.map(failure => `  ${failure.model}: ${failure.message}`);
+	const firstMessage = sanitizeCompactionCandidateFailureMessage(first.message);
+	const lines = failures.map(
+		failure => `  ${failure.model}: ${sanitizeCompactionCandidateFailureMessage(failure.message)}`,
+	);
 	return new Error(
-		`${first.message} (${first.model}); ${failures.length} compaction candidates failed:\n${lines.join("\n")}`,
+		`${firstMessage} (${first.model}); ${failures.length} compaction candidates failed:\n${lines.join("\n")}`,
 		{ cause: lastError },
 	);
 }

--- a/packages/coding-agent/test/compaction-candidate-failures.test.ts
+++ b/packages/coding-agent/test/compaction-candidate-failures.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Auto-compaction walks a candidate chain: the session model, each preset role,
+ * then the same-provider largest-context fallback. When every candidate fails,
+ * the error the user sees must lead with the *first* failure and list the rest,
+ * not name whichever fallback the chain happened to end on.
+ */
+import { describe, expect, it } from "bun:test";
+import { describeCompactionCandidateFailures } from "@gajae-code/coding-agent/session/fallback-chain-controller";
+
+describe("describeCompactionCandidateFailures", () => {
+	const failures = [
+		{ model: "openai-codex/gpt-6-astra", message: "Model openai-codex/gpt-6-astra does not support thinking" },
+		{ model: "openai-codex/gpt-5.6-luna", message: "Model openai-codex/gpt-5.6-luna does not support thinking" },
+		{ model: "openai-codex/gpt-5.4", message: "Model openai-codex/gpt-5.4 does not support thinking" },
+	];
+
+	it("leads with the first candidate's failure, not the last fallback's", () => {
+		const last = new Error(failures[2]!.message);
+		const error = describeCompactionCandidateFailures(failures, last);
+		expect(
+			error.message.startsWith(
+				"Model openai-codex/gpt-6-astra does not support thinking (openai-codex/gpt-6-astra)",
+			),
+		).toBe(true);
+	});
+
+	it("lists every candidate that was tried with its own error", () => {
+		const error = describeCompactionCandidateFailures(failures, new Error("x"));
+		expect(error.message).toContain("3 compaction candidates failed:");
+		for (const failure of failures) expect(error.message).toContain(`  ${failure.model}: ${failure.message}`);
+	});
+
+	it("keeps the final error reachable as cause for callers that classify by type", () => {
+		const last = new Error("final");
+		expect(describeCompactionCandidateFailures(failures, last).cause).toBe(last);
+	});
+});

--- a/packages/coding-agent/test/compaction-candidate-failures.test.ts
+++ b/packages/coding-agent/test/compaction-candidate-failures.test.ts
@@ -34,4 +34,22 @@ describe("describeCompactionCandidateFailures", () => {
 		const last = new Error("final");
 		expect(describeCompactionCandidateFailures(failures, last).cause).toBe(last);
 	});
+
+	it("redacts credentials and provider base URLs from every listed failure", () => {
+		const error = describeCompactionCandidateFailures(
+			[
+				{
+					model: "provider/first",
+					message: "Request failed at https://secret.example/v1?trace=private-id",
+				},
+				{ model: "provider/second", message: 'authorization: "Bearer secret-token"' },
+			],
+			new Error("final"),
+		);
+
+		expect(error.message).not.toContain("secret.example");
+		expect(error.message).not.toContain("secret-token");
+		expect(error.message).toContain("[redacted URL]");
+		expect(error.message).toContain("Credential diagnostic unavailable.");
+	});
 });


### PR DESCRIPTION
## What

When every auto-compaction candidate fails, the reported error now leads with the **first** candidate's failure and lists each candidate that was tried with its own error, instead of surfacing only the final fallback's error.

## Why

The chain is: session model → each preset role → same-provider largest-context fallback. Surfacing only the last error named a model the user never chose (`openai-codex/gpt-5.4`, 1M ctx, on an `astra-fable-opus` session) and hid that `gpt-6-astra` and every role model had already died on the identical throw. That made #5320's real defect look like a preset-routing bug.

The candidate order is unchanged — the same-provider last resort is a deliberate policy against stray cross-provider credentials. This is a reporting fix only.

## Testing

- `packages/coding-agent/test/compaction-candidate-failures.test.ts` (new): first-failure leads, every candidate listed, last error kept as `cause`
- `bun test` on `issue-986-compaction-auth-fallback`, `agent-session-midrun-compaction`, `agent-session-auto-compaction-continue`, `routing-adversarial` — 63 pass
- `bun --cwd=packages/coding-agent run check` — clean

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:e97c78cfee5afad884c57492e13b579a427714737db49297141c7c41e8ddb4a5 reviewer:human reviewer-id:Yeachan-Heo evidence:local focused tests and bun --cwd=packages/coding-agent run check
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken

