### PR TITLE
fix(sdk): preserve producer order and full owner cohort on live-attach streams

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 - SDK submissions that reject during post-turn cleanup no longer publish a contradictory second terminal after their correlation has already settled.
 - Paseo session imports discard unused CLI stdout instead of leaving an unread pipe.
-- SDK live-attach streams preserve producer order across text deltas, final messages, and tool events even when asynchronous extension handlers are slow, without replaying or broadcasting turn content. Content observed while the correlated `agent_start` is still being durably recorded is held and released after the start frame, so no consumer sees turn content before the turn it belongs to.
+- SDK live-attach streams preserve producer order across text deltas, final messages, and tool events even when asynchronous extension handlers are slow, without replaying or broadcasting turn content. Content observed while the correlated `agent_start` is still being durably recorded is held and released after the start frame, so no consumer sees turn content before the turn it belongs to; held content is delivered only to the owners that held the run when it was produced, and the hold is bounded (256 events) so a wedged start write releases content rather than accumulating a whole response in memory.
 - SDK prompts consumed together after queued steering is interrupted now each receive correlated starts, streamed content, and one terminal, without adopting unrelated pending submissions.
 
 ## [0.16.4] - 2026-09-05

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,13 @@
 
 - When every auto-compaction candidate fails, the reported error now leads with the first candidate's failure and lists each candidate that was tried with its own error. The chain starts at the session model and ends on a same-provider largest-context fallback, so surfacing only the final error named a model the user never chose (e.g. `openai-codex/gpt-5.4` on an `astra` preset session) and hid that their own model had already failed the same way.
 
+### Fixed
+
+- SDK submissions that reject during post-turn cleanup no longer publish a contradictory second terminal after their correlation has already settled.
+- Paseo session imports discard unused CLI stdout instead of leaving an unread pipe.
+- SDK live-attach streams preserve producer order across text deltas, final messages, and tool events even when asynchronous extension handlers are slow, without replaying or broadcasting turn content.
+- SDK prompts consumed together after queued steering is interrupted now each receive correlated starts, streamed content, and one terminal, without adopting unrelated pending submissions.
+
 ## [0.16.4] - 2026-09-05
 ### Added
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 - SDK submissions that reject during post-turn cleanup no longer publish a contradictory second terminal after their correlation has already settled.
 - Paseo session imports discard unused CLI stdout instead of leaving an unread pipe.
-- SDK live-attach streams preserve producer order across text deltas, final messages, and tool events even when asynchronous extension handlers are slow, without replaying or broadcasting turn content. Content observed while the correlated `agent_start` is still being durably recorded is held and released after the start frame, so no consumer sees turn content before the turn it belongs to; held content is delivered only to the owners that held the run when it was produced, and the hold is bounded (256 events) so a wedged start write releases content rather than accumulating a whole response in memory.
+- SDK live-attach streams preserve producer order across text deltas, final messages, and tool events even when asynchronous extension handlers are slow, without replaying or broadcasting turn content. Content observed while the correlated `agent_start` is still being durably recorded is held and released after the start frame, so no consumer sees turn content before the turn it belongs to; held content is delivered only to the owners that held the run when it was produced, and the hold is bounded (256 events, oldest dropped with one warning) so a wedged start write can neither invert the start/content boundary nor accumulate a whole response in memory.
 - SDK prompts consumed together after queued steering is interrupted now each receive correlated starts, streamed content, and one terminal, without adopting unrelated pending submissions.
 
 ## [0.16.4] - 2026-09-05

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 - SDK submissions that reject during post-turn cleanup no longer publish a contradictory second terminal after their correlation has already settled.
 - Paseo session imports discard unused CLI stdout instead of leaving an unread pipe.
-- SDK live-attach streams preserve producer order across text deltas, final messages, and tool events even when asynchronous extension handlers are slow, without replaying or broadcasting turn content.
+- SDK live-attach streams preserve producer order across text deltas, final messages, and tool events even when asynchronous extension handlers are slow, without replaying or broadcasting turn content. Content observed while the correlated `agent_start` is still being durably recorded is held and released after the start frame, so no consumer sees turn content before the turn it belongs to.
 - SDK prompts consumed together after queued steering is interrupted now each receive correlated starts, streamed content, and one terminal, without adopting unrelated pending submissions.
 
 ## [0.16.4] - 2026-09-05

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -263,6 +263,7 @@ export class ExtensionRunner {
 
 	#getJobsFn: ExtensionContextActions["getJobs"] = undefined;
 	#onJobFoldFn: ExtensionContextActions["onJobFold"] = undefined;
+	#onSessionEventFn: ExtensionContextActions["onSessionEvent"] = undefined;
 	#sdkControlFn: ExtensionContextActions["sdkControl"] = undefined;
 	#setSdkPermissionProviderFn: ExtensionContextActions["setSdkPermissionProvider"] = undefined;
 	#setSdkClientBridgeFn: ExtensionContextActions["setSdkClientBridge"] = undefined;
@@ -395,6 +396,7 @@ export class ExtensionRunner {
 
 		this.#getJobsFn = contextActions.getJobs;
 		this.#onJobFoldFn = contextActions.onJobFold;
+		this.#onSessionEventFn = contextActions.onSessionEvent;
 		this.#sdkControlFn = contextActions.sdkControl;
 		this.#setSdkPermissionProviderFn = contextActions.setSdkPermissionProvider;
 		this.#setSdkClientBridgeFn = contextActions.setSdkClientBridge;
@@ -680,6 +682,7 @@ export class ExtensionRunner {
 
 			getJobs: () => this.#getJobsFn?.(),
 			onJobFold: listener => this.#onJobFoldFn?.(listener) ?? (() => {}),
+			onSessionEvent: listener => this.#onSessionEventFn?.(listener) ?? (() => {}),
 			sdkControl: (operation, input) => this.#sdkControlFn?.(operation, input),
 			setSdkPermissionProvider: provider => this.#setSdkPermissionProviderFn?.(provider),
 			setSdkClientBridge: bridge => this.#setSdkClientBridgeFn?.(bridge),

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -49,6 +49,7 @@ import type { ExecOptions, ExecResult } from "../../exec/exec";
 import type { CustomEditor } from "../../modes/components/custom-editor";
 import type { WorkflowGateEmitter } from "../../modes/shared/agent-wire/workflow-gate-broker";
 import type { Theme } from "../../modes/theme/theme";
+import type { AgentSessionEventListener } from "../../session/agent-session";
 import type {
 	ClientBridge,
 	ClientBridgePermissionOption,
@@ -530,6 +531,8 @@ export interface ExtensionContext {
 	getJobs(): unknown;
 	/** Subscribe to foreground-wait folds (`bash_folded`). Returns an unsubscribe function. */
 	onJobFold?(listener: (event: JobFoldEvent) => void): () => void;
+	/** Observe session events synchronously in producer order. Returns an unsubscribe function. */
+	onSessionEvent?(listener: AgentSessionEventListener): () => void;
 	/** Typed skill and mode controls exposed to the SDK host. */
 	invokeSkill?(
 		name: string,
@@ -750,6 +753,8 @@ export type { AgentEndEvent, TurnEndEvent, TurnStartEvent } from "../shared-even
 /** Fired when an agent loop starts. `sdkRunToken` is an internal SDK queue-owner binding. */
 export interface AgentStartEvent extends SharedAgentStartEvent {
 	sdkRunToken?: string;
+	/** Complete set of SDK queue owners consumed together by this run. */
+	sdkRunTokens?: string[];
 }
 
 /** Fired when an agent run fails before emitting agent_end. The error is the
@@ -1692,6 +1697,8 @@ export interface ExtensionContextActions {
 	getJobs?: () => unknown;
 	/** Subscribe to foreground-wait folds so the SDK host can publish `bash_folded`. Returns an unsubscribe. */
 	onJobFold?: (listener: (event: JobFoldEvent) => void) => () => void;
+	/** Ordered, synchronous AgentSession subscription, independent of async extension hooks. */
+	onSessionEvent?: (listener: AgentSessionEventListener) => () => void;
 	setSdkPermissionProvider?: (
 		provider:
 			| ((

--- a/packages/coding-agent/src/modes/runtime-init.ts
+++ b/packages/coding-agent/src/modes/runtime-init.ts
@@ -201,6 +201,7 @@ export async function initializeExtensions(session: AgentSession, options: Initi
 			},
 			getJobs: () => session.getAsyncJobSnapshot(),
 			onJobFold: listener => session.onJobFold(listener),
+			onSessionEvent: listener => session.subscribe(listener),
 			setSdkPermissionProvider: provider => session.setSdkPermissionProvider(provider),
 			setSdkClientBridge: bridge => session.setClientBridge(bridge),
 			sdkControl: async (operation, input) => {

--- a/packages/coding-agent/src/sdk/host/session-runtime.test.ts
+++ b/packages/coding-agent/src/sdk/host/session-runtime.test.ts
@@ -5261,7 +5261,7 @@ describe("post-acceptance invocation terminalization", () => {
 		}
 	});
 
-	test("a later provider error enriches but never re-opens an already terminal prompt", async () => {
+	test("a later provider error never changes or re-opens an already terminal prompt", async () => {
 		const cwd = await mkdtemp(path.join(os.tmpdir(), "gjc-terminalize-once-"));
 		try {
 			const inflight = Promise.withResolvers<void>();
@@ -5282,13 +5282,8 @@ describe("post-acceptance invocation terminalization", () => {
 			// A lifecycle frame arriving after the terminal must not resurrect the record either.
 			await harness.emit("agent_start");
 			const settled = await harness.query("turn.prompt_status", { commandId, turnId });
-			// The late reason attaches to the settled record, so `error` is the only field that may
-			// appear; status, terminalAt, and identity stay exactly as claimed.
-			const { error: _claimedReason, ...claimedTerminal } = claimed;
-			const { error: _lateReason, ...settledTerminal } = settled.result ?? {};
-			expect(settledTerminal).toEqual(claimedTerminal);
-			// The recorded reason is the sanitized late failure: never fabricated, never raw.
-			expect(settled.result?.error).toEqual({ code: "upstream_error", message: "Prompt submission failed." });
+			// A rejected submission after terminal publication is only a cleanup diagnostic.
+			expect(settled.result).toEqual(claimed);
 			await harness.stop();
 		} finally {
 			await Bun.sleep(50);
@@ -7144,4 +7139,51 @@ test("SDK-only host rebinds the steering snapshot when the requester's turn wins
 		await handlers.get("session_shutdown")?.({}, ctx);
 		await rm(cwd, { recursive: true, force: true });
 	}
+});
+
+describe("rejection terminalization idempotency", () => {
+	test("cleanup rejection after success preserves the sole correlated wire terminal and durable result", async () => {
+		const cwd = await mkdtemp(path.join(os.tmpdir(), "gjc-cleanup-rejection-"));
+		const cleanup = Promise.withResolvers<void>();
+		const harness = await invocationHarness("cleanup-rejection", cwd, {
+			sendUserMessage: async (_content, options) => {
+				await options?.onPreflightAcceptCommit?.();
+				await cleanup.promise;
+			},
+		});
+		const warning = spyOn(logger, "warn").mockImplementation(() => {});
+		try {
+			const accepted = await harness.control("turn.prompt", { text: "complete before cleanup" });
+			expect(accepted.ok).toBe(true);
+			const ids = { commandId: accepted.result?.commandId, turnId: accepted.result?.turnId };
+			await harness.emit("agent_start");
+			await harness.emit("agent_end", {
+				messages: [{ role: "assistant", content: [{ type: "text", text: "Completed." }], stopReason: "stop" }],
+			});
+			const before = await settledStatus(harness, "turn.result", { kind: "prompt", ...ids });
+			expect(before.status).toBe("terminal_ok");
+			cleanup.reject(new Error("post-turn cleanup failed"));
+			await Bun.sleep(50);
+			const after = await harness.query("turn.result", { kind: "prompt", ...ids });
+			expect(after.result).toEqual(before);
+			expect(warning).toHaveBeenCalledWith("SDK submission cleanup failed after terminal publication", {
+				kind: "prompt",
+				...ids,
+				error: { code: "internal", message: "Prompt submission failed." },
+			});
+			const correlated = harness.broadcasts.filter(
+				frame => (frame.payload as { commandId?: string } | undefined)?.commandId === ids.commandId,
+			);
+			expect(correlated.filter(frame => frame.kind === "agent_failed")).toHaveLength(0);
+			const terminals = correlated.filter(frame => frame.kind === "agent_end");
+			expect(terminals).toHaveLength(1);
+			expect(terminals[0]).toMatchObject({
+				payload: { ...ids, outcome: (before as { outcome?: unknown }).outcome },
+			});
+		} finally {
+			warning.mockRestore();
+			await harness.stop();
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 });

--- a/packages/coding-agent/src/sdk/host/session-runtime.ts
+++ b/packages/coding-agent/src/sdk/host/session-runtime.ts
@@ -4274,10 +4274,20 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 		}
 	};
 	/**
+	 * Upper bound on content events held for one batch while its correlated
+	 * agent_start is still being durably recorded. A start write normally settles
+	 * in milliseconds, so this is only reached when persistence is wedged; at
+	 * that point ordering yields to memory safety: held content is released and
+	 * the batch streams directly from then on, so a blocked filesystem can never
+	 * accumulate an entire response in memory.
+	 */
+	const MAX_HELD_CONTENT_EVENTS = 256;
+	/**
 	 * Release content that arrived before the batch's correlated agent_start
-	 * reached the wire. Called exactly once per batch, after the start frames
-	 * are published (or after the start publication path gave up), so SDK
-	 * consumers observe start before any content, in producer order.
+	 * reached the wire. Called once per batch, after the start frames are
+	 * published (or after the start publication path gave up), so SDK consumers
+	 * observe start before any content, in producer order. Also invoked by the
+	 * hold path when the bound above is reached.
 	 */
 	const releaseHeldContent = (current: RuntimeState, batch: LifecycleBatch): void => {
 		if (batch.startPublished) return;
@@ -4995,6 +5005,14 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 		// sees turn content before the turn it belongs to.
 		if (batch && !batch.startPublished) {
 			batch.heldContent.push({ event: event as AgentSessionEvent, recipients: invocations });
+			if (batch.heldContent.length >= MAX_HELD_CONTENT_EVENTS) {
+				logger.warn("sdk: agent_start persistence still pending; releasing held turn content to bound memory", {
+					epoch: batch.epoch,
+					held: batch.heldContent.length,
+					invocations: batch.invocations.length,
+				});
+				releaseHeldContent(current, batch);
+			}
 			return;
 		}
 		publishContentFrames(current, event as AgentSessionEvent, invocations);

--- a/packages/coding-agent/src/sdk/host/session-runtime.ts
+++ b/packages/coding-agent/src/sdk/host/session-runtime.ts
@@ -4055,10 +4055,15 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 					 * reached the wire. The synchronous session subscription can see a
 					 * message_update before emitLifecycle finishes awaiting durable start
 					 * persistence; holding them here keeps the producer's start/content
-					 * boundary for every SDK consumer.
+					 * boundary for every SDK consumer. Each entry carries the recipients
+					 * that owned the run when the event was produced: an owner attached
+					 * later must not receive content from before its attachment.
 					 */
 					startPublished: boolean;
-					heldContent: AgentSessionEvent[];
+					heldContent: Array<{
+						event: AgentSessionEvent;
+						recipients: Array<{ correlation: InvocationCorrelation; connectionId: string | undefined }>;
+					}>;
 				}>;
 				disposeGate?: () => void;
 				lifecycleActive: boolean;
@@ -4279,8 +4284,7 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 		batch.startPublished = true;
 		const held = batch.heldContent;
 		batch.heldContent = [];
-		for (const event of held)
-			publishContentFrames(current, event, [...batch.invocations, ...batch.attachedInvocations]);
+		for (const { event, recipients } of held) publishContentFrames(current, event, recipients);
 	};
 	const emitLifecycle = async (
 		type: "agent_start" | "agent_end" | "agent_failed",
@@ -4990,7 +4994,7 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 		// synchronous. Hold content until that start is on the wire so no consumer
 		// sees turn content before the turn it belongs to.
 		if (batch && !batch.startPublished) {
-			batch.heldContent.push(event as AgentSessionEvent);
+			batch.heldContent.push({ event: event as AgentSessionEvent, recipients: invocations });
 			return;
 		}
 		publishContentFrames(current, event as AgentSessionEvent, invocations);
@@ -5069,7 +5073,10 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 				connectionId: string | undefined;
 			}>;
 			startPublished: boolean;
-			heldContent: AgentSessionEvent[];
+			heldContent: Array<{
+				event: AgentSessionEvent;
+				recipients: Array<{ correlation: InvocationCorrelation; connectionId: string | undefined }>;
+			}>;
 		}> = [];
 		const configRevision = { current: 0 };
 		let acceptingGateResolutions = true;

--- a/packages/coding-agent/src/sdk/host/session-runtime.ts
+++ b/packages/coding-agent/src/sdk/host/session-runtime.ts
@@ -4050,6 +4050,15 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 						correlation: InvocationCorrelation;
 						connectionId: string | undefined;
 					}>;
+					/**
+					 * Content frames observed before this batch's correlated agent_start
+					 * reached the wire. The synchronous session subscription can see a
+					 * message_update before emitLifecycle finishes awaiting durable start
+					 * persistence; holding them here keeps the producer's start/content
+					 * boundary for every SDK consumer.
+					 */
+					startPublished: boolean;
+					heldContent: AgentSessionEvent[];
 				}>;
 				disposeGate?: () => void;
 				lifecycleActive: boolean;
@@ -4233,6 +4242,46 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 		owner.lifecycleTasks.add(task);
 		return task;
 	};
+	/**
+	 * Publish one content frame per owning invocation, each carrying its own
+	 * correlation, so a shared run lets every submitter attribute the content to
+	 * its own prompt. Content is best-effort and bypasses the lifecycle replay
+	 * ring; the turn producing it is authoritative.
+	 */
+	const publishContentFrames = (
+		current: RuntimeState,
+		event: AgentSessionEvent,
+		invocations: ReadonlyArray<{ correlation: InvocationCorrelation; connectionId: string | undefined }>,
+	): void => {
+		try {
+			const payload = toAgentWireEventPayload(event);
+			for (const invocation of invocations) {
+				if (invocation.connectionId === undefined) continue;
+				current.runtime.sendFrameTo([invocation.connectionId], {
+					type: "event",
+					kind: event.type,
+					payload,
+					...invocation.correlation,
+				});
+			}
+		} catch {
+			// Streamed content is best-effort; the turn producing it is authoritative.
+		}
+	};
+	/**
+	 * Release content that arrived before the batch's correlated agent_start
+	 * reached the wire. Called exactly once per batch, after the start frames
+	 * are published (or after the start publication path gave up), so SDK
+	 * consumers observe start before any content, in producer order.
+	 */
+	const releaseHeldContent = (current: RuntimeState, batch: LifecycleBatch): void => {
+		if (batch.startPublished) return;
+		batch.startPublished = true;
+		const held = batch.heldContent;
+		batch.heldContent = [];
+		for (const event of held)
+			publishContentFrames(current, event, [...batch.invocations, ...batch.attachedInvocations]);
+	};
 	const emitLifecycle = async (
 		type: "agent_start" | "agent_end" | "agent_failed",
 		ctx: ExtensionContext,
@@ -4338,6 +4387,8 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 					epoch: current.lifecycleEpoch,
 					invocations: drained,
 					attachedInvocations: [],
+					startPublished: false,
+					heldContent: [],
 				};
 				current.openLifecycleBatches.push(batch);
 				for (const entry of drained) {
@@ -4620,6 +4671,19 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 						observed = false;
 					}
 				}
+				// The start frames are on the wire (or definitively failed); content
+				// that the synchronous session subscription observed meanwhile must
+				// follow them, never precede them.
+				const started = current.openLifecycleBatches.find(candidate =>
+					candidate.invocations.some(entry =>
+						transitions.some(
+							({ correlation }) =>
+								correlation.commandId === entry.correlation.commandId &&
+								correlation.turnId === entry.correlation.turnId,
+						),
+					),
+				);
+				if (started) releaseHeldContent(current, started);
 			} else if (type === "agent_end" && transitions.length > 0) {
 				// An invocation-owned terminal must carry the identity it was accepted
 				// under and the normalized outcome. A client that submitted this turn
@@ -4921,22 +4985,15 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 		if (invocations.length === 0) return;
 		// Content bypasses the lifecycle replay ring and must never interrupt its producer.
 		if (!event || typeof event.type !== "string" || !STREAMED_TURN_EVENT_TYPES.has(event.type)) return;
-		try {
-			const payload = toAgentWireEventPayload(event as AgentSessionEvent);
-			// One frame per owning invocation, each carrying its own correlation, so a
-			// shared run lets every submitter attribute the content to its own prompt.
-			for (const invocation of invocations) {
-				if (invocation.connectionId === undefined) continue;
-				current.runtime.sendFrameTo([invocation.connectionId], {
-					type: "event",
-					kind: event.type,
-					payload,
-					...invocation.correlation,
-				});
-			}
-		} catch {
-			// Streamed content is best-effort; the turn producing it is authoritative.
+		// emitLifecycle("agent_start") awaits durable persistence before it
+		// publishes the correlated start frame, while this subscription is
+		// synchronous. Hold content until that start is on the wire so no consumer
+		// sees turn content before the turn it belongs to.
+		if (batch && !batch.startPublished) {
+			batch.heldContent.push(event as AgentSessionEvent);
+			return;
 		}
+		publishContentFrames(current, event as AgentSessionEvent, invocations);
 	};
 	api.on("tool_execution_start", async (_event, ctx) => {
 		renewAttributableProgress("tool_execution_start", ctx);
@@ -5011,6 +5068,8 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 				correlation: InvocationCorrelation;
 				connectionId: string | undefined;
 			}>;
+			startPublished: boolean;
+			heldContent: AgentSessionEvent[];
 		}> = [];
 		const configRevision = { current: 0 };
 		let acceptingGateResolutions = true;

--- a/packages/coding-agent/src/sdk/host/session-runtime.ts
+++ b/packages/coding-agent/src/sdk/host/session-runtime.ts
@@ -2628,6 +2628,19 @@ function createControlSurface(
 							// so their recovery owner is this bounded in-place retry loop: the same
 							// order, retried, until both writes land or the budget is spent.
 							const attemptRejectionTerminalization = async (remaining: number): Promise<void> => {
+								// AgentSession can reject cleanup after its durable terminal was published.
+								// That rejection is diagnostic, not another outcome for this correlation.
+								const record = reconciliation.lookup(kind, correlation) as { status?: string };
+								if (record.status === "terminal_ok" || record.status === "failed") {
+									logger.warn("SDK submission cleanup failed after terminal publication", {
+										kind,
+										commandId: correlation.commandId,
+										turnId: correlation.turnId,
+										error: sanitizePromptFailure(error),
+									});
+									retirePendingOwner?.(kind, correlation, "always");
+									return;
+								}
 								try {
 									await reconciliation.noteTransition(kind, correlation, { type: "agent_failed", error });
 								} catch {
@@ -4231,6 +4244,7 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 		terminalOutcome?: InvocationOutcome,
 		stopReason?: AgentEndEvent["stopReason"],
 		startToken?: string,
+		startTokens?: string[],
 	): Promise<void> => {
 		const current = lifecycleOwner?.state ?? active;
 		if (!current) return;
@@ -4305,10 +4319,10 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 			// turn (queued-while-streaming submissions never push), so a mid-prompt
 			// continuation agent_start with an empty queue leaves the current owner
 			// untouched (review thread P1).
+			const cohort = new Set(startTokens);
+			if (startToken) cohort.add(startToken);
 			const matchingPending =
-				typeof startToken === "string" && startToken.length > 0
-					? current.pending.filter(entry => entry.sdkRunToken === startToken)
-					: current.pending.slice();
+				cohort.size > 0 ? current.pending.filter(entry => cohort.has(entry.sdkRunToken)) : current.pending.slice();
 			const matchingKeys = new Set(matchingPending.map(entry => entry.sdkRunToken));
 			const pendingSnapshot = current.pending.splice(0);
 			const drained = pendingSnapshot
@@ -4326,12 +4340,11 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 					attachedInvocations: [],
 				};
 				current.openLifecycleBatches.push(batch);
-				if (typeof startToken === "string" && startToken.length > 0) {
-					const entry = drained.find(item => item.sdkRunToken === startToken);
-					lifecycleRunOwners.set(startToken, {
+				for (const entry of drained) {
+					lifecycleRunOwners.set(entry.sdkRunToken, {
 						state: current,
 						batch,
-						...(entry ? { correlationKey: lifecycleCorrelationKey(entry.correlation) } : {}),
+						correlationKey: lifecycleCorrelationKey(entry.correlation),
 					});
 				}
 				adoptLifecycleBatch(drained);
@@ -4599,6 +4612,14 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 						observed = false;
 					}
 				}
+			} else if (type === "agent_start" && transitions.length > 0) {
+				for (const invocation of transitions) {
+					try {
+						current.runtime.emitEvent({ type, sessionId, ...invocation.correlation });
+					} catch {
+						observed = false;
+					}
+				}
 			} else if (type === "agent_end" && transitions.length > 0) {
 				// An invocation-owned terminal must carry the identity it was accepted
 				// under and the normalized outcome. A client that submitted this turn
@@ -4621,9 +4642,7 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 					}
 				}
 			} else {
-				// Everything that does not terminalize an owned invocation keeps the one
-				// uncorrelated frame: `agent_start` and a host-originated run (autonomous
-				// continuation, cron, monitor) that owns no invocation.
+				// Host-originated runs without an invocation keep an uncorrelated frame.
 				try {
 					current.runtime.emitEvent({ type, sessionId });
 				} catch {
@@ -4704,6 +4723,7 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 					undefined,
 					undefined,
 					typeof event.sdkRunToken === "string" ? event.sdkRunToken : undefined,
+					event.sdkRunTokens,
 				),
 			owner,
 		);
@@ -4899,8 +4919,7 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 				? (current.attachedInvocations ?? [])
 				: [];
 		if (invocations.length === 0) return;
-		// The handlers below also renew prompt deadlines, so streaming must never
-		// throw out of them: a frame the wire producer does not recognize is dropped.
+		// Content bypasses the lifecycle replay ring and must never interrupt its producer.
 		if (!event || typeof event.type !== "string" || !STREAMED_TURN_EVENT_TYPES.has(event.type)) return;
 		try {
 			const payload = toAgentWireEventPayload(event as AgentSessionEvent);
@@ -4919,22 +4938,11 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 			// Streamed content is best-effort; the turn producing it is authoritative.
 		}
 	};
-	api.on("tool_execution_start", async (event, ctx) => {
+	api.on("tool_execution_start", async (_event, ctx) => {
 		renewAttributableProgress("tool_execution_start", ctx);
-		streamTurnEvent(event, ctx);
 	});
-	api.on("tool_execution_update", async (event, ctx) => {
-		streamTurnEvent(event, ctx);
-	});
-	api.on("tool_execution_end", async (event, ctx) => {
+	api.on("tool_execution_end", async (_event, ctx) => {
 		renewAttributableProgress("tool_execution_end", ctx);
-		streamTurnEvent(event, ctx);
-	});
-	api.on("message_update", async (event, ctx) => {
-		streamTurnEvent(event, ctx);
-	});
-	api.on("message_end", async (event, ctx) => {
-		streamTurnEvent(event, ctx);
 	});
 	const errorCode = (error: unknown): string | undefined =>
 		typeof error === "object" &&
@@ -5598,9 +5606,15 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 				});
 			}
 		});
+		// Extension message_update hooks are queued while final/tool hooks are not.
+		// Use only the synchronous session boundary so those paths cannot reorder or duplicate content.
+		const disposeStream = ctx.onSessionEvent?.(event => {
+			if (STREAMED_TURN_EVENT_TYPES.has(event.type)) streamTurnEvent(event, ctx);
+		});
 		const disposeGate = (): void => {
 			disposeWorkflowGate?.();
 			disposeFold?.();
+			disposeStream?.();
 		};
 		let publishedEndpointUrl: string | undefined;
 		let brokerRegistered = false;

--- a/packages/coding-agent/src/sdk/host/session-runtime.ts
+++ b/packages/coding-agent/src/sdk/host/session-runtime.ts
@@ -4060,6 +4060,8 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 					 * later must not receive content from before its attachment.
 					 */
 					startPublished: boolean;
+					/** Set once the hold bound dropped content for this batch; gates the single warning. */
+					heldContentDropped: boolean;
 					heldContent: Array<{
 						event: AgentSessionEvent;
 						recipients: Array<{ correlation: InvocationCorrelation; connectionId: string | undefined }>;
@@ -4276,18 +4278,19 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 	/**
 	 * Upper bound on content events held for one batch while its correlated
 	 * agent_start is still being durably recorded. A start write normally settles
-	 * in milliseconds, so this is only reached when persistence is wedged; at
-	 * that point ordering yields to memory safety: held content is released and
-	 * the batch streams directly from then on, so a blocked filesystem can never
-	 * accumulate an entire response in memory.
+	 * in milliseconds, so this is only reached when persistence is wedged. Past
+	 * the bound the OLDEST held content is dropped (with one warning per batch):
+	 * content is never published before its start, so a wedged write degrades
+	 * to a gap in the stream, not an inverted start/content boundary, and it
+	 * can never accumulate an entire response in memory. The turn's terminal
+	 * result remains authoritative for anything a consumer did not see.
 	 */
 	const MAX_HELD_CONTENT_EVENTS = 256;
 	/**
 	 * Release content that arrived before the batch's correlated agent_start
 	 * reached the wire. Called once per batch, after the start frames are
 	 * published (or after the start publication path gave up), so SDK consumers
-	 * observe start before any content, in producer order. Also invoked by the
-	 * hold path when the bound above is reached.
+	 * observe start before any content, in producer order.
 	 */
 	const releaseHeldContent = (current: RuntimeState, batch: LifecycleBatch): void => {
 		if (batch.startPublished) return;
@@ -4402,6 +4405,7 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 					invocations: drained,
 					attachedInvocations: [],
 					startPublished: false,
+					heldContentDropped: false,
 					heldContent: [],
 				};
 				current.openLifecycleBatches.push(batch);
@@ -5005,13 +5009,19 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 		// sees turn content before the turn it belongs to.
 		if (batch && !batch.startPublished) {
 			batch.heldContent.push({ event: event as AgentSessionEvent, recipients: invocations });
-			if (batch.heldContent.length >= MAX_HELD_CONTENT_EVENTS) {
-				logger.warn("sdk: agent_start persistence still pending; releasing held turn content to bound memory", {
-					epoch: batch.epoch,
-					held: batch.heldContent.length,
-					invocations: batch.invocations.length,
-				});
-				releaseHeldContent(current, batch);
+			if (batch.heldContent.length > MAX_HELD_CONTENT_EVENTS) {
+				if (!batch.heldContentDropped) {
+					batch.heldContentDropped = true;
+					logger.warn(
+						"sdk: agent_start persistence still pending; dropping oldest held turn content to bound memory",
+						{
+							epoch: batch.epoch,
+							bound: MAX_HELD_CONTENT_EVENTS,
+							invocations: batch.invocations.length,
+						},
+					);
+				}
+				batch.heldContent.splice(0, batch.heldContent.length - MAX_HELD_CONTENT_EVENTS);
 			}
 			return;
 		}
@@ -5091,6 +5101,7 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 				connectionId: string | undefined;
 			}>;
 			startPublished: boolean;
+			heldContentDropped: boolean;
 			heldContent: Array<{
 				event: AgentSessionEvent;
 				recipients: Array<{ correlation: InvocationCorrelation; connectionId: string | undefined }>;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2792,7 +2792,7 @@ export class AgentSession {
 		this.#activeAttemptScope = undefined;
 		this.#activeLogicalRunId = undefined;
 	}
-	#acceptSdkAttemptRun(handle: AttemptRunHandle, sdkRunToken?: string): void {
+	#acceptSdkAttemptRun(handle: AttemptRunHandle, sdkRunToken?: string, sdkRunTokens?: string[]): void {
 		const predecessorScope = this.#activeAttemptScope;
 		const predecessorSdkRunToken =
 			predecessorScope === undefined ? undefined : this.#sdkRunTokensByAttemptScope.get(predecessorScope);
@@ -2805,6 +2805,11 @@ export class AgentSession {
 		if (sdkRunToken !== undefined) {
 			this.#activeSdkRunToken = sdkRunToken;
 			this.#sdkRunTokensByAttemptScope.set(handle.scope, sdkRunToken);
+			const inheritedCohort =
+				predecessorScope !== undefined && predecessorSdkRunToken === sdkRunToken
+					? this.#sdkRunCohortsByAttemptScope.get(predecessorScope)
+					: undefined;
+			this.#sdkRunCohortsByAttemptScope.set(handle.scope, sdkRunTokens ?? inheritedCohort ?? [sdkRunToken]);
 		}
 		if (carryRecoverySkip) this.#skipPostPromptRecoveryWaitByAttemptScope.add(handle.scope);
 	}
@@ -3109,6 +3114,7 @@ export class AgentSession {
 	#sdkRunTokensByQueuedMessage = new WeakMap<AgentMessage, string>();
 	#skipPostPromptRecoveryWaitByAttemptScope = new WeakSet<AttemptScope>();
 	#sdkRunTokensByAttemptScope = new WeakMap<AttemptScope, string>();
+	#sdkRunCohortsByAttemptScope = new WeakMap<AttemptScope, string[]>();
 	#activeSdkRunToken: string | undefined;
 	#activeAttemptScope: AttemptScope | undefined;
 	#attemptAuthority!: AttemptScopeAuthority;
@@ -7531,15 +7537,19 @@ export class AgentSession {
 												const inheritedSdkRunToken = options?.continueQueuedOnly
 													? undefined
 													: (options?.sdkRunToken ?? scheduledSdkRunToken);
-												const consumedSdkRunToken = acceptance.consumedQueuedMessages
+												const consumedSdkRunTokens = acceptance.consumedQueuedMessages
 													.map(message => this.#sdkRunTokensByQueuedMessage.get(message))
-													.find((token): token is string => token !== undefined);
-												const sdkRunToken = consumedSdkRunToken ?? inheritedSdkRunToken;
+													.filter((token): token is string => token !== undefined);
+												const sdkRunToken = consumedSdkRunTokens[0] ?? inheritedSdkRunToken;
 												this.#fireQueuedPromotionHooks(acceptance.consumedQueuedMessages, {
 													startsOwnRun: startsOwn,
 												});
 												if (startsOwn) this.#activeSdkRunToken = sdkRunToken;
-												this.#acceptSdkAttemptRun(handle, sdkRunToken);
+												this.#acceptSdkAttemptRun(
+													handle,
+													sdkRunToken,
+													consumedSdkRunTokens.length > 0 ? consumedSdkRunTokens : undefined,
+												);
 												options?.onRunAccepted?.(handle);
 												// Keep the queued token available through the acceptance callback;
 												// SDK follow-up owners bind it to the new attempt scope there.
@@ -8675,6 +8685,9 @@ export class AgentSession {
 					{
 						type: "agent_start",
 						...(sdkRunToken ? { sdkRunToken } : {}),
+						...(deliveryScope
+							? { sdkRunTokens: this.#sdkRunCohortsByAttemptScope.get(deliveryScope as AttemptScope) }
+							: {}),
 					},
 					undefined,
 					deliveryScope,

--- a/packages/coding-agent/src/setup/paseo/announce.ts
+++ b/packages/coding-agent/src/setup/paseo/announce.ts
@@ -413,7 +413,7 @@ function runImport(env: NodeJS.ProcessEnv) {
 		try {
 			const child = Bun.spawn(
 				[input.cli, "import", "--provider", input.providerKey, "--cwd", input.cwd, input.sessionId],
-				{ stdout: "pipe", stderr: "pipe", signal, env },
+				{ stdout: "ignore", stderr: "pipe", signal, env },
 			);
 			const [exitCode, stderr] = await Promise.all([child.exited, new Response(child.stderr).text()]);
 			if (input.signal?.aborted) return { kind: "failed", detail: "Paseo announcement cancelled" };

--- a/packages/coding-agent/test/paseo-announce.test.ts
+++ b/packages/coding-agent/test/paseo-announce.test.ts
@@ -448,6 +448,12 @@ describe("default dependencies", () => {
 		);
 	});
 
+	test("import discards stdout instead of exposing an unread pipe", async () => {
+		const dependencies = createDefaultPaseoAnnounceDependencies("/tmp/agent-dir", {});
+		const cli = await fakeCli('[ -c /dev/fd/1 ] || exit 1\nprintf "unused output"\nexit 0');
+		expect(await dependencies.runImport(importInput(cli))).toEqual({ kind: "imported", providerKey: "gjc" });
+	});
+
 	test("Paseo's duplicate-import refusal on stderr is read as success", async () => {
 		const dependencies = createDefaultPaseoAnnounceDependencies("/tmp/agent-dir", {});
 		const cli = await fakeCli(

--- a/packages/coding-agent/test/resume-session-reentrancy.test.ts
+++ b/packages/coding-agent/test/resume-session-reentrancy.test.ts
@@ -59,6 +59,7 @@ function createContext(session: { switchSession: (path: string, options?: unknow
 		rebuildInitialMessages: vi.fn(),
 		reloadTodos: vi.fn(async () => undefined),
 		showStatus: vi.fn(),
+		resetAssistantTextPresentation: vi.fn(),
 	} as unknown as InteractiveModeContext;
 
 	return { context, statusContainer, pendingMessagesContainer, ui };
@@ -183,6 +184,7 @@ describe("resume session re-entrancy", () => {
 		expect(context.pendingTools.size).toBe(1);
 		expect(pendingMessagesContainer.children).toHaveLength(1);
 		expect(loadingAnimation.stop).not.toHaveBeenCalled();
+		expect(context.resetAssistantTextPresentation).not.toHaveBeenCalled();
 
 		ui.stop();
 	});
@@ -205,6 +207,9 @@ describe("resume session re-entrancy", () => {
 		expect(pendingMessagesContainer.children).toHaveLength(0);
 		expect(loadingAnimation.stop).toHaveBeenCalled();
 		expect(context.loadingAnimation).toBeUndefined();
+		// The committed switch drops the coalesced assistant-text projection so the
+		// resumed transcript is not painted over the previous session's frame state.
+		expect(context.resetAssistantTextPresentation).toHaveBeenCalledTimes(1);
 		expect(context.showStatus).toHaveBeenCalledWith("Resumed session");
 
 		ui.stop();

--- a/packages/coding-agent/test/sdk-host-terminal-correlation.test.ts
+++ b/packages/coding-agent/test/sdk-host-terminal-correlation.test.ts
@@ -1,5 +1,16 @@
 import { describe, expect, test } from "bun:test";
-import { terminalStoppedOutcome } from "../src/sdk/host/session-runtime";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Agent } from "@gajae-code/agent-core";
+import { getBundledModel } from "@gajae-code/ai";
+import { createMockModel } from "@gajae-code/ai/providers/mock";
+import { Settings } from "../src/config/settings";
+import type { ExtensionAPI, ExtensionContext, ExtensionEvent } from "../src/extensibility/extensions";
+import { createSdkSessionRuntimeExtension, terminalStoppedOutcome } from "../src/sdk/host/session-runtime";
+import type { SdkFrame } from "../src/sdk/host/types";
+import { AgentSession, type AgentSessionEvent } from "../src/session/agent-session";
+import { SessionManager } from "../src/session/session-manager";
 
 /**
  * The SDK-only host publishes the lifecycle boundary that settles an externally
@@ -66,3 +77,150 @@ describe("terminalStoppedOutcome", () => {
 		}
 	});
 });
+test("disowned SDK steering cohorts share streams and terminals without adopting unrelated pending owners", async () => {
+	const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-sdk-cohort-"));
+	const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+	if (!model) throw new Error("Expected bundled Anthropic test model");
+	const mock = createMockModel({
+		responses: [{ content: ["interrupted"], delayMs: 60_000 }, { content: ["handled both steers"] }],
+	});
+	const agent = new Agent({
+		getApiKey: () => "test-key",
+		initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+		toolInterruptPolicy: "finish_tools",
+		steeringMode: "all",
+		streamFn: mock.stream,
+	});
+	const settings = Settings.isolated({ "compaction.enabled": false });
+	settings.setModelRole("default", `${model.provider}/${model.id}`);
+	const handlers = new Map<string, (event: unknown, ctx: ExtensionContext) => unknown>();
+	const frames: Array<{ connectionId: string; frame: SdkFrame }> = [];
+	let receive: ((connectionId: string, frame: SdkFrame) => void) | undefined;
+	let ctx: ExtensionContext;
+	const sessionManager = SessionManager.inMemory(cwd);
+	const session = new AgentSession({
+		agent,
+		sessionManager,
+		settings,
+		modelRegistry: { getApiKey: async () => "test-key", getAuthStorageOwner: () => undefined } as never,
+		extensionRunner: {
+			hasHandlers: () => true,
+			emitBeforeAgentStart: async () => undefined,
+			emit: async (event: ExtensionEvent) => handlers.get(event.type)?.(event, ctx),
+		} as never,
+	});
+	const api = {
+		on: (event: string, handler: (event: unknown, context: ExtensionContext) => unknown) => {
+			handlers.set(event, handler);
+		},
+		sendUserMessage: async (content: string, options: Parameters<AgentSession["sendUserMessage"]>[1]) => {
+			if (content === "unrelated") {
+				await options?.onPreflightAcceptCommit?.();
+				options?.onQueuedPromoted?.({ startsOwnRun: true });
+				return;
+			}
+			return session.sendUserMessage(content, options);
+		},
+	} as unknown as ExtensionAPI;
+	createSdkSessionRuntimeExtension(api, {
+		agentDir: cwd,
+		settings,
+		createTransport: async ({ sessionId, stateRoot, token }) => ({
+			sessionId,
+			stateRoot,
+			token,
+			onFrame: handler => {
+				receive = handler;
+				return () => {
+					receive = undefined;
+				};
+			},
+			sendFrame: (connectionId, frame) => {
+				frames.push({ connectionId, frame });
+				return "written" as const;
+			},
+			broadcastFrame: frame => {
+				frames.push({ connectionId: "broadcast", frame });
+			},
+			start: async () => ({ url: "ws://127.0.0.1:1" }),
+			stop: async () => {},
+		}),
+	});
+	ctx = {
+		cwd,
+		sessionManager,
+		isIdle: () => !agent.state.isStreaming,
+		sdkBindings: () => [],
+		onSessionEvent: (listener: (event: AgentSessionEvent) => void) => session.subscribe(listener),
+	} as unknown as ExtensionContext;
+	const waitFor = async (predicate: () => boolean) => {
+		const deadline = Date.now() + 5_000;
+		while (!predicate()) {
+			if (Date.now() >= deadline) throw new Error("Timed out waiting for cohort lifecycle");
+			await Bun.sleep(5);
+		}
+	};
+	const submit = async (id: string, text: string) => {
+		receive?.(id, { type: "control_request", id, operation: "turn.prompt", input: { text } });
+		await waitFor(() => frames.some(({ frame }) => "id" in frame && frame.id === id));
+		const response = frames.find(({ frame }) => "id" in frame && frame.id === id)?.frame;
+		expect(response).toMatchObject({ ok: true });
+		if (!response || !("result" in response)) throw new Error("Missing prompt response");
+		const { commandId, turnId } = response.result as { commandId: string; turnId: string };
+		return { commandId, turnId };
+	};
+	try {
+		await handlers.get("session_start")?.({}, ctx);
+		const first = session.prompt("first task");
+		await waitFor(() => agent.state.isStreaming && mock.calls.length === 1);
+		const a = await submit("client-a", "steer one");
+		const b = await submit("client-b", "steer two");
+		const unrelated = await submit("client-c", "unrelated");
+		expect(session.getQueuedMessages().steering).toEqual(["steer one", "steer two"]);
+		await session.abort({ cause: "user_interrupt" });
+		await first.catch(() => {});
+		await session.waitForIdle();
+		await waitFor(
+			() => frames.filter(({ frame }) => frame.type === "event" && frame.kind === "agent_end").length >= 2,
+		);
+		expect(mock.calls).toHaveLength(2);
+		const correlationOf = (frame: SdkFrame): Record<string, unknown> =>
+			frame.type === "event" && frame.payload && typeof frame.payload === "object" && "commandId" in frame.payload
+				? (frame.payload as Record<string, unknown>)
+				: (frame as unknown as Record<string, unknown>);
+		for (const [connectionId, correlation] of [
+			["client-a", a],
+			["client-b", b],
+		] as const) {
+			const owned = frames.filter(({ frame }) => correlationOf(frame).commandId === correlation.commandId);
+			expect(owned.every(entry => entry.connectionId === connectionId || entry.connectionId === "broadcast")).toBe(
+				true,
+			);
+			expect(owned.filter(({ frame }) => frame.type === "event" && frame.kind === "agent_start")).toHaveLength(1);
+			const streamed = owned.filter(({ frame }) => frame.type === "event" && frame.kind === "message_update");
+			expect(streamed.length).toBeGreaterThan(0);
+			expect(streamed.every(entry => entry.connectionId === connectionId)).toBe(true);
+			expect(owned.filter(({ frame }) => frame.type === "event" && frame.kind === "agent_end")).toHaveLength(1);
+			for (const { frame } of owned) expect(correlationOf(frame)).toMatchObject(correlation);
+		}
+		expect(frames.filter(({ frame }) => correlationOf(frame).commandId === unrelated.commandId)).toHaveLength(0);
+		// The excluded owner is still pending and can be adopted only by its own start.
+		await handlers.get("agent_start")?.({ sdkRunToken: `${unrelated.commandId}:${unrelated.turnId}` }, ctx);
+		expect(
+			frames.filter(
+				({ frame }) =>
+					frame.type === "event" &&
+					frame.kind === "agent_start" &&
+					correlationOf(frame).commandId === unrelated.commandId,
+			),
+		).toHaveLength(1);
+		await handlers.get("agent_end")?.(
+			{ sdkRunToken: `${unrelated.commandId}:${unrelated.turnId}`, messages: [] },
+			ctx,
+		);
+	} finally {
+		await handlers.get("session_shutdown")?.({}, ctx);
+		await session.dispose();
+		await fs.rm(cwd, { recursive: true, force: true });
+	}
+}, 20_000);

--- a/packages/coding-agent/test/sdk-host-turn-streaming.test.ts
+++ b/packages/coding-agent/test/sdk-host-turn-streaming.test.ts
@@ -92,6 +92,8 @@ interface HostHarness {
 	control(operation: string, input: Record<string, unknown>, connectionId?: string): Promise<ControlResponse>;
 	emit(event: string, payload?: unknown): Promise<void>;
 	setIdle(idle: boolean): void;
+	/** Promote every queued (non-idle) submission whose promotion was deferred by `deferPromotion`. */
+	promoteQueued(): void;
 	clearFrames(): void;
 	readonly sent: Array<{ connectionId: string; frame: SdkFrame }>;
 	readonly broadcasts: SdkFrame[];
@@ -113,6 +115,8 @@ async function createHostHarness(
 		settleSubmission?: "never" | "resolve";
 		onSessionEvent?: ExtensionContext["onSessionEvent"];
 		reconciliationStore?: ReconciliationStore;
+		/** Hold `onQueuedPromoted` for non-idle submissions until `promoteQueued()` is called. */
+		deferPromotion?: boolean;
 	} = {},
 ): Promise<HostHarness> {
 	const handlers = new Map<string, (event: unknown, ctx: ExtensionContext) => Promise<void> | void>();
@@ -123,6 +127,7 @@ async function createHostHarness(
 	let receive: ((connectionId: string, frame: SdkFrame) => void) | undefined;
 	let nextId = 0;
 	let idle = true;
+	const deferredPromotions: Array<() => void> = [];
 	const api = {
 		on(event: string, handler: (event: unknown, ctx: ExtensionContext) => Promise<void> | void) {
 			handlers.set(event, handler);
@@ -137,7 +142,11 @@ async function createHostHarness(
 			},
 		) => {
 			await options?.onPreflightAcceptCommit?.();
-			if (!idle) options?.onQueuedPromoted?.({ startsOwnRun: false });
+			if (!idle) {
+				const promote = () => options?.onQueuedPromoted?.({ startsOwnRun: false });
+				if (harnessOptions.deferPromotion) deferredPromotions.push(promote);
+				else promote();
+			}
 			if (harnessOptions.settleSubmission === "resolve") return;
 			return await new Promise<never>(() => {});
 		},
@@ -218,6 +227,9 @@ async function createHostHarness(
 		},
 		setIdle: value => {
 			idle = value;
+		},
+		promoteQueued: () => {
+			for (const promote of deferredPromotions.splice(0)) promote();
 		},
 		sent,
 		broadcasts,
@@ -447,6 +459,67 @@ describe("SDK host turn streaming", () => {
 							.assistantMessageEvent.delta,
 				);
 			expect(deltas).toEqual(["early", " late"]);
+		} finally {
+			startGate.resolve();
+			await harness.stop();
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+	test("does not release pre-attachment content to an owner attached while the start was held", async () => {
+		// Recipients are snapshotted when content is held. A second SDK prompt
+		// attached during the slow start transaction owns the run from then on,
+		// but must not receive deltas produced before it attached.
+		const cwd = await mkdtemp(path.join(os.tmpdir(), "gjc-sdk-stream-held-attach-"));
+		const inner = createReconciliationStore({ sessionFile: path.join(cwd, "session.jsonl"), sessionId: SESSION_ID });
+		const startGate = Promise.withResolvers<void>();
+		const startEntered = Promise.withResolvers<void>();
+		let holdNextTransact = false;
+		const slowStore: ReconciliationStore = {
+			...inner,
+			transact: async mutator => {
+				if (holdNextTransact) {
+					holdNextTransact = false;
+					startEntered.resolve();
+					await startGate.promise;
+				}
+				return inner.transact(mutator);
+			},
+		};
+		const harness = await createHostHarness(SESSION_ID, cwd, {
+			reconciliationStore: slowStore,
+			deferPromotion: true,
+		});
+		try {
+			const root = await harness.control("turn.prompt", { text: "root" }, "root-client");
+			expect(root.ok).toBe(true);
+			// A second prompt is accepted while the session is busy: it is queued as
+			// steering and only attaches to the run when the producer consumes it.
+			harness.setIdle(false);
+			const attached = await harness.control("turn.prompt", { text: "attached" }, "attached-client");
+			expect(attached.ok).toBe(true);
+			harness.clearFrames();
+			holdNextTransact = true;
+			const start = harness.emit("agent_start");
+			await startEntered.promise;
+			await harness.emit("message_update", textDelta("before-attach"));
+			// The queued prompt is consumed (attached) while the start is still held.
+			harness.promoteQueued();
+			await harness.emit("message_update", textDelta("after-attach"));
+			startGate.resolve();
+			await start;
+			const delivered = harness.sent
+				.filter(entry => entry.frame.type === "event" && entry.frame.kind === "message_update")
+				.map(entry => ({
+					to: entry.connectionId,
+					commandId: entry.frame.commandId,
+					delta: (entry.frame.payload as { event: { assistantMessageEvent: { delta: string } } }).event
+						.assistantMessageEvent.delta,
+				}));
+			expect(delivered).toEqual([
+				{ to: "root-client", commandId: root.result?.commandId, delta: "before-attach" },
+				{ to: "root-client", commandId: root.result?.commandId, delta: "after-attach" },
+				{ to: "attached-client", commandId: attached.result?.commandId, delta: "after-attach" },
+			]);
 		} finally {
 			startGate.resolve();
 			await harness.stop();

--- a/packages/coding-agent/test/sdk-host-turn-streaming.test.ts
+++ b/packages/coding-agent/test/sdk-host-turn-streaming.test.ts
@@ -527,10 +527,11 @@ describe("SDK host turn streaming", () => {
 			await rm(cwd, { recursive: true, force: true });
 		}
 	});
-	test("bounds held content when start persistence never settles", async () => {
+	test("bounds held content by dropping the oldest, never publishing before the start", async () => {
 		// A wedged reconciliation write must not let the host buffer an entire
-		// response. Past the bound, held content is released (still in order) and
-		// the batch streams directly; ordering yields to memory safety, once.
+		// response, and must not invert the start/content boundary either. Past the
+		// bound the oldest held content is dropped (one warning); nothing reaches
+		// the wire until the correlated agent_start does.
 		const cwd = await mkdtemp(path.join(os.tmpdir(), "gjc-sdk-stream-held-bound-"));
 		const inner = createReconciliationStore({ sessionFile: path.join(cwd, "session.jsonl"), sessionId: SESSION_ID });
 		const startGate = Promise.withResolvers<void>();
@@ -549,8 +550,17 @@ describe("SDK host turn streaming", () => {
 		};
 		const warn = spyOn(logger, "warn").mockImplementation(() => {});
 		const releaseWarnings = () =>
-			warn.mock.calls.filter(call => String(call[0]).includes("releasing held turn content"));
+			warn.mock.calls.filter(call => String(call[0]).includes("dropping oldest held turn content"));
 		const harness = await createHostHarness(SESSION_ID, cwd, { reconciliationStore: slowStore });
+		const contentFrames = () => harness.sent.filter(entry => entry.frame.type === "event");
+		const deltas = () =>
+			harness.sent
+				.filter(entry => entry.frame.type === "event" && entry.frame.kind === "message_update")
+				.map(
+					entry =>
+						(entry.frame.payload as { event: { assistantMessageEvent: { delta: string } } }).event
+							.assistantMessageEvent.delta,
+				);
 		try {
 			await harness.control("turn.prompt", { text: "long answer" });
 			harness.clearFrames();
@@ -558,27 +568,24 @@ describe("SDK host turn streaming", () => {
 			const start = harness.emit("agent_start");
 			await startEntered.promise;
 			const bound = 256;
-			for (let index = 0; index < bound - 1; index++) await harness.emit("message_update", textDelta(`d${index}`));
-			expect(harness.sent.filter(entry => entry.frame.type === "event")).toHaveLength(0);
+			const overflow = 40;
+			for (let index = 0; index < bound; index++) await harness.emit("message_update", textDelta(`d${index}`));
+			expect(contentFrames()).toHaveLength(0);
 			expect(releaseWarnings()).toHaveLength(0);
-			await harness.emit("message_update", textDelta(`d${bound - 1}`));
-			const deltas = () =>
-				harness.sent
-					.filter(entry => entry.frame.type === "event" && entry.frame.kind === "message_update")
-					.map(
-						entry =>
-							(entry.frame.payload as { event: { assistantMessageEvent: { delta: string } } }).event
-								.assistantMessageEvent.delta,
-					);
-			expect(deltas()).toEqual(Array.from({ length: bound }, (_, index) => `d${index}`));
+			for (let index = bound; index < bound + overflow; index++)
+				await harness.emit("message_update", textDelta(`d${index}`));
+			// Still nothing on the wire: the start has not been published.
+			expect(contentFrames()).toHaveLength(0);
+			expect(harness.broadcasts.filter(frame => frame.kind === "agent_start")).toHaveLength(0);
 			expect(releaseWarnings()).toHaveLength(1);
-			// Subsequent content streams directly while the start is still pending.
-			await harness.emit("message_update", textDelta("direct"));
-			expect(deltas().at(-1)).toBe("direct");
-			expect(deltas()).toHaveLength(bound + 1);
 			startGate.resolve();
 			await start;
-			// Start publication does not replay anything that was already released.
+			expect(harness.broadcasts.filter(frame => frame.kind === "agent_start")).toHaveLength(1);
+			// Only the newest `bound` events survive, in producer order.
+			expect(deltas()).toEqual(Array.from({ length: bound }, (_, index) => `d${index + overflow}`));
+			// Content after the start streams directly.
+			await harness.emit("message_update", textDelta("direct"));
+			expect(deltas().at(-1)).toBe("direct");
 			expect(deltas()).toHaveLength(bound + 1);
 			expect(releaseWarnings()).toHaveLength(1);
 		} finally {

--- a/packages/coding-agent/test/sdk-host-turn-streaming.test.ts
+++ b/packages/coding-agent/test/sdk-host-turn-streaming.test.ts
@@ -11,6 +11,7 @@ import { ExtensionRuntime, loadExtensionFromFactory } from "../src/extensibility
 import { ExtensionRunner } from "../src/extensibility/extensions/runner";
 import { mapAgentWireEventPayloadToAcpSessionUpdates } from "../src/modes/acp/acp-event-mapper";
 import { toAgentWireEventPayload } from "../src/modes/shared/agent-wire/event-envelope";
+import { createReconciliationStore, type ReconciliationStore } from "../src/sdk/bus/reconciliation-store";
 import { createSdkSessionRuntimeExtension } from "../src/sdk/host/session-runtime";
 import type { SdkFrame } from "../src/sdk/host/types";
 import { AgentSession, type AgentSessionEvent } from "../src/session/agent-session";
@@ -108,7 +109,11 @@ async function waitFor(predicate: () => boolean, label: string, timeoutMs = 2_00
 async function createHostHarness(
 	sessionId: string,
 	cwd: string,
-	harnessOptions: { settleSubmission?: "never" | "resolve"; onSessionEvent?: ExtensionContext["onSessionEvent"] } = {},
+	harnessOptions: {
+		settleSubmission?: "never" | "resolve";
+		onSessionEvent?: ExtensionContext["onSessionEvent"];
+		reconciliationStore?: ReconciliationStore;
+	} = {},
 ): Promise<HostHarness> {
 	const handlers = new Map<string, (event: unknown, ctx: ExtensionContext) => Promise<void> | void>();
 	const listeners = new Set<(event: AgentSessionEvent) => void>();
@@ -139,6 +144,17 @@ async function createHostHarness(
 	} as unknown as ExtensionAPI;
 	createSdkSessionRuntimeExtension(api, {
 		agentDir: path.join(cwd, ".gjc", "agent"),
+		...(harnessOptions.reconciliationStore
+			? {
+					terminalAbortSeams: {
+						getReconciliationStore: () => harnessOptions.reconciliationStore,
+						getTerminalTurnEpoch: () => undefined,
+						getActivePromptHandle: () => undefined,
+						cancelPendingPreflightForTerminalAbort: () => {},
+						abortPromptAndWaitWithTerminal: async () => ({ status: "settled" }),
+					},
+				}
+			: {}),
 		createTransport: async ({ sessionId: id, stateRoot, token }) => ({
 			sessionId: id,
 			stateRoot,
@@ -379,6 +395,61 @@ describe("SDK host turn streaming", () => {
 			await harness.stop();
 			await session.dispose();
 			authStorage.close();
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+	test("holds content observed before the correlated agent_start reaches the wire", async () => {
+		// The session subscription is synchronous while emitLifecycle("agent_start")
+		// awaits durable persistence before publishing the start frame. Content
+		// produced in that window must still follow the start on the wire.
+		const cwd = await mkdtemp(path.join(os.tmpdir(), "gjc-sdk-stream-start-order-"));
+		const inner = createReconciliationStore({ sessionFile: path.join(cwd, "session.jsonl"), sessionId: SESSION_ID });
+		const startGate = Promise.withResolvers<void>();
+		const startEntered = Promise.withResolvers<void>();
+		let holdNextTransact = false;
+		const slowStore: ReconciliationStore = {
+			...inner,
+			transact: async mutator => {
+				if (holdNextTransact) {
+					holdNextTransact = false;
+					startEntered.resolve();
+					await startGate.promise;
+				}
+				return inner.transact(mutator);
+			},
+		};
+		const harness = await createHostHarness(SESSION_ID, cwd, { reconciliationStore: slowStore });
+		try {
+			await harness.control("turn.prompt", { text: "delayed start" });
+			harness.clearFrames();
+			holdNextTransact = true;
+			const start = harness.emit("agent_start");
+			await startEntered.promise;
+			// Producer emits content while the start transition is still persisting.
+			await harness.emit("message_update", textDelta("early"));
+			await harness.emit("tool_execution_start", toolStart());
+			const contentKinds = () =>
+				harness.sent.filter(entry => entry.frame.type === "event").map(entry => String(entry.frame.kind));
+			expect(contentKinds()).toEqual([]);
+			expect(harness.broadcasts.filter(frame => frame.kind === "agent_start")).toEqual([]);
+			startGate.resolve();
+			await start;
+			expect(harness.broadcasts.filter(frame => frame.kind === "agent_start")).toHaveLength(1);
+			expect(contentKinds()).toEqual(["message_update", "tool_execution_start"]);
+			// Content after the start is published immediately, in order.
+			await harness.emit("message_update", textDelta(" late"));
+			expect(contentKinds()).toEqual(["message_update", "tool_execution_start", "message_update"]);
+			const deltas = harness.sent
+				.filter(entry => entry.frame.type === "event" && entry.frame.kind === "message_update")
+				.map(
+					entry =>
+						(entry.frame.payload as { event: { assistantMessageEvent: { delta: string } } }).event
+							.assistantMessageEvent.delta,
+				);
+			expect(deltas).toEqual(["early", " late"]);
+		} finally {
+			startGate.resolve();
+			await harness.stop();
 			await rm(cwd, { recursive: true, force: true });
 		}
 	});

--- a/packages/coding-agent/test/sdk-host-turn-streaming.test.ts
+++ b/packages/coding-agent/test/sdk-host-turn-streaming.test.ts
@@ -2,12 +2,21 @@ import { describe, expect, test } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { Agent } from "@gajae-code/agent-core";
+import { createMockModel } from "@gajae-code/ai/providers/mock";
+import { ModelRegistry } from "../src/config/model-registry";
+import { Settings } from "../src/config/settings";
 import type { ExtensionAPI, ExtensionContext } from "../src/extensibility/extensions";
+import { ExtensionRuntime, loadExtensionFromFactory } from "../src/extensibility/extensions/loader";
+import { ExtensionRunner } from "../src/extensibility/extensions/runner";
 import { mapAgentWireEventPayloadToAcpSessionUpdates } from "../src/modes/acp/acp-event-mapper";
 import { toAgentWireEventPayload } from "../src/modes/shared/agent-wire/event-envelope";
 import { createSdkSessionRuntimeExtension } from "../src/sdk/host/session-runtime";
 import type { SdkFrame } from "../src/sdk/host/types";
-import type { AgentSessionEvent } from "../src/session/agent-session";
+import { AgentSession, type AgentSessionEvent } from "../src/session/agent-session";
+import { AuthStorage } from "../src/session/auth-storage";
+import { SessionManager } from "../src/session/session-manager";
+import { EventBus } from "../src/utils/event-bus";
 
 /**
  * The SDK-only host streams turn content to the connections that submitted the
@@ -99,9 +108,10 @@ async function waitFor(predicate: () => boolean, label: string, timeoutMs = 2_00
 async function createHostHarness(
 	sessionId: string,
 	cwd: string,
-	harnessOptions: { settleSubmission?: "never" | "resolve" } = {},
+	harnessOptions: { settleSubmission?: "never" | "resolve"; onSessionEvent?: ExtensionContext["onSessionEvent"] } = {},
 ): Promise<HostHarness> {
 	const handlers = new Map<string, (event: unknown, ctx: ExtensionContext) => Promise<void> | void>();
+	const listeners = new Set<(event: AgentSessionEvent) => void>();
 	const waiters = new Map<string, (frame: ControlResponse) => void>();
 	const sent: Array<{ connectionId: string; frame: SdkFrame }> = [];
 	const broadcasts: SdkFrame[] = [];
@@ -158,6 +168,14 @@ async function createHostHarness(
 		sdkBindings: () => [],
 		isIdle: () => idle,
 		abort: () => {},
+		onSessionEvent:
+			harnessOptions.onSessionEvent ??
+			((listener: (event: AgentSessionEvent) => void) => {
+				listeners.add(listener);
+				return () => {
+					listeners.delete(listener);
+				};
+			}),
 		sessionManager: {
 			getSessionId: () => sessionId,
 			getSessionFile: () => path.join(cwd, ".gjc", "state", `${sessionId}.jsonl`),
@@ -175,6 +193,7 @@ async function createHostHarness(
 			return promise;
 		},
 		emit: async (event, payload = {}) => {
+			for (const listener of listeners) listener(payload as AgentSessionEvent);
 			await handlers.get(event)?.(payload, ctx);
 		},
 		clearFrames: () => {
@@ -268,6 +287,101 @@ describe("streamed turn frames", () => {
 });
 
 describe("SDK host turn streaming", () => {
+	test("preserves producer order while a message_update extension handler is blocked", async () => {
+		const cwd = await mkdtemp(path.join(os.tmpdir(), "gjc-sdk-stream-order-"));
+		const gate = Promise.withResolvers<void>();
+		const entered = Promise.withResolvers<void>();
+		const authStorage = await AuthStorage.create(":memory:");
+		authStorage.setRuntimeApiKey("mock", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage);
+		const sessionManager = SessionManager.inMemory(cwd);
+		const extensionRuntime = new ExtensionRuntime();
+		const eventBus = new EventBus();
+		let harness: HostHarness | undefined;
+		const extension = await loadExtensionFromFactory(
+			api => {
+				api.on("message_update", async event => {
+					entered.resolve();
+					await gate.promise;
+					await harness?.emit("message_update", event);
+				});
+				api.on("message_end", event => harness?.emit("message_end", event));
+				api.on("tool_execution_start", event => harness?.emit("tool_execution_start", event));
+				api.on("tool_execution_update", event => harness?.emit("tool_execution_update", event));
+				api.on("tool_execution_end", event => harness?.emit("tool_execution_end", event));
+			},
+			cwd,
+			eventBus,
+			extensionRuntime,
+		);
+		const mock = createMockModel({
+			responses: [
+				{ content: ["hello", " world", { type: "toolCall", id: "call_1", name: "read", arguments: {} }] },
+				{ content: [] },
+			],
+		});
+		const session = new AgentSession({
+			agent: new Agent({ initialState: { model: mock.model, tools: [], messages: [] }, streamFn: mock.stream }),
+			sessionManager,
+			settings: Settings.isolated({ "compaction.enabled": false, "todo.reminders": false }),
+			modelRegistry,
+			extensionRunner: new ExtensionRunner([extension], extensionRuntime, cwd, sessionManager, modelRegistry),
+		});
+		const produced: AgentSessionEvent[] = [];
+		const kinds = new Set([
+			"message_update",
+			"message_end",
+			"tool_execution_start",
+			"tool_execution_update",
+			"tool_execution_end",
+		]);
+		session.subscribe(event => {
+			if (kinds.has(event.type)) produced.push(event);
+		});
+		harness = await createHostHarness(SESSION_ID, cwd, { onSessionEvent: listener => session.subscribe(listener) });
+		let prompt: Promise<void> | undefined;
+		try {
+			await harness.control("turn.prompt", { text: "stream this" });
+			await harness.emit("agent_start");
+			harness.clearFrames();
+			prompt = session.prompt("stream this");
+			await entered.promise;
+			await waitFor(
+				() => produced.some(event => event.type === "tool_execution_start"),
+				"tool start while extension is blocked",
+			);
+			const frames = () =>
+				harness!.sent.filter(entry => entry.frame.type === "event" && kinds.has(String(entry.frame.kind)));
+			expect(frames().map(entry => entry.frame.kind)).toEqual(produced.map(event => event.type));
+			const final = produced.find(event => event.type === "message_end" && event.message.role === "assistant");
+			expect(final).toMatchObject({
+				message: {
+					content: [{ type: "text", text: "hello" }, { type: "text", text: " world" }, { type: "toolCall" }],
+				},
+			});
+			gate.resolve();
+			await prompt;
+			expect(frames().map(entry => entry.frame.payload)).toEqual(produced.map(toAgentWireEventPayload));
+			const textEvents = produced.flatMap(event =>
+				event.type === "message_update" && event.assistantMessageEvent.type === "text_delta"
+					? [event.assistantMessageEvent.delta]
+					: [],
+			);
+			expect(textEvents.join("")).toBe("hello world");
+			const finalIndex = produced.indexOf(final!);
+			expect(finalIndex).toBeGreaterThan(produced.findIndex(event => event.type === "message_update"));
+			expect(produced.findIndex(event => event.type === "tool_execution_start")).toBeGreaterThan(finalIndex);
+			expect(frames().every(entry => entry.connectionId === "client")).toBe(true);
+			expect(harness.broadcasts.filter(frame => kinds.has(String(frame.kind)))).toEqual([]);
+		} finally {
+			gate.resolve();
+			await prompt?.catch(() => {});
+			await harness.stop();
+			await session.dispose();
+			authStorage.close();
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 	test("sends one message update only to the accepted prompt owner", async () => {
 		const cwd = await mkdtemp(path.join(os.tmpdir(), "gjc-sdk-stream-owner-"));
 		const harness = await createHostHarness(SESSION_ID, cwd);

--- a/packages/coding-agent/test/sdk-host-turn-streaming.test.ts
+++ b/packages/coding-agent/test/sdk-host-turn-streaming.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { Agent } from "@gajae-code/agent-core";
 import { createMockModel } from "@gajae-code/ai/providers/mock";
+import { logger } from "@gajae-code/utils";
 import { ModelRegistry } from "../src/config/model-registry";
 import { Settings } from "../src/config/settings";
 import type { ExtensionAPI, ExtensionContext } from "../src/extensibility/extensions";
@@ -521,6 +522,67 @@ describe("SDK host turn streaming", () => {
 				{ to: "attached-client", commandId: attached.result?.commandId, delta: "after-attach" },
 			]);
 		} finally {
+			startGate.resolve();
+			await harness.stop();
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+	test("bounds held content when start persistence never settles", async () => {
+		// A wedged reconciliation write must not let the host buffer an entire
+		// response. Past the bound, held content is released (still in order) and
+		// the batch streams directly; ordering yields to memory safety, once.
+		const cwd = await mkdtemp(path.join(os.tmpdir(), "gjc-sdk-stream-held-bound-"));
+		const inner = createReconciliationStore({ sessionFile: path.join(cwd, "session.jsonl"), sessionId: SESSION_ID });
+		const startGate = Promise.withResolvers<void>();
+		const startEntered = Promise.withResolvers<void>();
+		let holdNextTransact = false;
+		const slowStore: ReconciliationStore = {
+			...inner,
+			transact: async mutator => {
+				if (holdNextTransact) {
+					holdNextTransact = false;
+					startEntered.resolve();
+					await startGate.promise;
+				}
+				return inner.transact(mutator);
+			},
+		};
+		const warn = spyOn(logger, "warn").mockImplementation(() => {});
+		const releaseWarnings = () =>
+			warn.mock.calls.filter(call => String(call[0]).includes("releasing held turn content"));
+		const harness = await createHostHarness(SESSION_ID, cwd, { reconciliationStore: slowStore });
+		try {
+			await harness.control("turn.prompt", { text: "long answer" });
+			harness.clearFrames();
+			holdNextTransact = true;
+			const start = harness.emit("agent_start");
+			await startEntered.promise;
+			const bound = 256;
+			for (let index = 0; index < bound - 1; index++) await harness.emit("message_update", textDelta(`d${index}`));
+			expect(harness.sent.filter(entry => entry.frame.type === "event")).toHaveLength(0);
+			expect(releaseWarnings()).toHaveLength(0);
+			await harness.emit("message_update", textDelta(`d${bound - 1}`));
+			const deltas = () =>
+				harness.sent
+					.filter(entry => entry.frame.type === "event" && entry.frame.kind === "message_update")
+					.map(
+						entry =>
+							(entry.frame.payload as { event: { assistantMessageEvent: { delta: string } } }).event
+								.assistantMessageEvent.delta,
+					);
+			expect(deltas()).toEqual(Array.from({ length: bound }, (_, index) => `d${index}`));
+			expect(releaseWarnings()).toHaveLength(1);
+			// Subsequent content streams directly while the start is still pending.
+			await harness.emit("message_update", textDelta("direct"));
+			expect(deltas().at(-1)).toBe("direct");
+			expect(deltas()).toHaveLength(bound + 1);
+			startGate.resolve();
+			await start;
+			// Start publication does not replay anything that was already released.
+			expect(deltas()).toHaveLength(bound + 1);
+			expect(releaseWarnings()).toHaveLength(1);
+		} finally {
+			warn.mockRestore();
 			startGate.resolve();
 			await harness.stop();
 			await rm(cwd, { recursive: true, force: true });


### PR DESCRIPTION
## What
Repair the four architect-confirmed findings in the v0.16.4 SDK live-attach streaming path (two P1, two P2).

## Why
Post-release independent architect review (lane 22) of the `0753f059e2..f2291d46f9` delta shipped in v0.16.4 returned ITERATE.

- **P1 SDK-ORDER** — `message_end`/`tool_execution_*` bypassed the serialized `message_update` extension queue; attached ACP clients could get the final answer before delayed deltas, then the deltas again. Now published from one producer-ordered `AgentSession.subscribe` boundary (`ctx.onSessionEvent`).
- **P1 SDK-COHORT** — shared queued run adopted only the first consumed `sdkRunToken`; other disowned-then-consumed SDK owners got no stream/terminal. `agent_start` now carries `sdkRunTokens` (full cohort); runtime drains every cohort member, leaves unrelated pending owners alone.
- **P2 SDK-DOUBLE-TERMINAL** — rejection after a settled terminal logged as diagnostic instead of publishing a second contradictory `agent_failed`/`agent_end`.
- **P2 PASEO-STDOUT** — `paseo import` spawns with `stdout: "ignore"`.

## Testing
- New regressions: slow async `message_update` handler ordering; two-client all-mode steering cohort; success-terminal-then-cleanup-reject; fake Paseo CLI requiring non-pipe stdout.
- `bun test` union of sdk-host-turn-streaming, sdk-host-terminal-correlation, session-runtime, paseo-announce, sdk-daemon-cli-e2e: 239 pass (pre-rebase); 70 pass on the three fast suites post-rebase.
- `bun --cwd=packages/coding-agent run check` green.
- Two pre-existing 5s timeouts in `session-runtime.test.ts` (`cancels exact owned jobs`, `captures exact bounded content`) reproduce identically on `origin/dev` with this change stashed — not introduced here.

## Risk classification

- [ ] `low-risk`
- [x] `regression-risk` — touches SDK event ordering, owner adoption, and terminal publication for every SDK consumer.
- [ ] `high-risk`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:9cf3610d88579c7020d8388619a9f7dc7991904bf1ea971a5800f217aab5043d reviewer:human reviewer-id:probepark evidence:bun test packages/coding-agent/test/sdk-host-turn-streaming.test.ts packages/coding-agent/test/sdk-host-terminal-correlation.test.ts packages/coding-agent/src/sdk/host/session-runtime.test.ts packages/coding-agent/test/paseo-announce.test.ts
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes (coding-agent package check)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken






