### PR TITLE
fix(ai): fail closed for unverified Anthropic reasoning

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Maintenance reasoning now fails closed for Anthropic models routed through an unverified custom endpoint and for raw reasoning-enabled models without thinking metadata. This prevents unsupported thinking controls and avoids a synchronous missing-metadata crash before provider wire transformation.
+
 ## [0.16.4] - 2026-09-05
 
 ### Added

--- a/packages/ai/src/model-thinking.ts
+++ b/packages/ai/src/model-thinking.ts
@@ -242,7 +242,6 @@ export function modelSupportsReasoningControl<TApi extends Api>(
 	resolvedBaseUrl?: string,
 ): boolean {
 	if (!model.reasoning) return false;
-
 	if (model.api === "openai-completions") {
 		const completionsModel = model as ApiModel<"openai-completions">;
 		const explicitSupport = completionsModel.compat?.supportsReasoningEffort;
@@ -364,6 +363,18 @@ export function clampThinkingLevelForModel<TApi extends Api>(
 		return requested;
 	}
 	if (!modelSupportsReasoningControl(model) || requested === undefined) {
+		return undefined;
+	}
+	if (model.api === "anthropic-messages" && model.provider === "anthropic") {
+		const baseUrl = model.baseUrl;
+		try {
+			const url = new URL(baseUrl || "https://api.anthropic.com");
+			if (url.protocol !== "https:" || url.hostname !== "api.anthropic.com") return undefined;
+		} catch {
+			return undefined;
+		}
+	}
+	if (!model.thinking) {
 		return undefined;
 	}
 

--- a/packages/ai/test/anthropic-alignment.test.ts
+++ b/packages/ai/test/anthropic-alignment.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import * as tls from "node:tls";
-import { Effort } from "@gajae-code/ai";
+import { clampThinkingLevelForModel, Effort } from "@gajae-code/ai";
 import {
 	applyClaudeToolPrefix,
 	buildAnthropicClientOptions,
@@ -1087,6 +1087,26 @@ describe("Anthropic request fingerprint alignment", () => {
 			{ thinkingEnabled: false },
 		)) as { thinking?: { type?: string } };
 
+		expect(payload.thinking).toBeUndefined();
+	});
+
+	it("omits wire thinking for unverified Anthropic reasoning transports", async () => {
+		const model: Model<"anthropic-messages"> = {
+			...ANTHROPIC_MODEL,
+			provider: "anthropic",
+			baseUrl: "http://proxy.invalid/v1",
+		};
+		const reasoning = clampThinkingLevelForModel(model, Effort.High);
+		const payload = (await captureAnthropicPayload(
+			model,
+			{
+				systemPrompt: ["Stay concise."],
+				messages: [{ role: "user", content: "Hi", timestamp: Date.now() }],
+			},
+			{ thinkingEnabled: reasoning !== undefined, reasoning },
+		)) as { thinking?: unknown };
+
+		expect(reasoning).toBeUndefined();
 		expect(payload.thinking).toBeUndefined();
 	});
 

--- a/packages/ai/test/model-thinking.test.ts
+++ b/packages/ai/test/model-thinking.test.ts
@@ -56,6 +56,28 @@ describe("thinking control modes", () => {
 });
 
 describe("model thinking metadata", () => {
+	it("fails closed when a reasoning model lacks thinking metadata", () => {
+		const model = createModel({
+			id: "claude-sonnet-4-5",
+			api: "anthropic-messages",
+			provider: "anthropic",
+		});
+		const rawModel = { ...model, thinking: undefined };
+
+		expect(clampThinkingLevelForModel(rawModel, Effort.High)).toBeUndefined();
+	});
+
+	it("fails closed for Anthropic models routed through an unknown proxy", () => {
+		const model = createModel({
+			id: "claude-sonnet-4-5",
+			api: "anthropic-messages",
+			provider: "anthropic",
+		});
+		const proxiedModel = { ...model, baseUrl: "http://proxy.invalid/v1" };
+
+		expect(clampThinkingLevelForModel(proxiedModel, Effort.High)).toBeUndefined();
+	});
+
 	it("derives conservative direct xAI effort ranges from the Grok generation", () => {
 		const grok45 = createModel({
 			id: "grok-4.5",


### PR DESCRIPTION
## Follow-up to #5320

PR #5320 correctly fixed the observed proxied `openai-codex` failure, but post-merge review found a narrower shared clamp compatibility gap:

- `anthropic-messages` models supplied through an unknown `anthropic` proxy were still treated as reasoning-control capable, so maintenance could emit `high` without an audited transport guarantee.
- A raw reasoning-enabled model with missing `thinking` metadata could throw synchronously before provider mapping.

This follow-up fails closed for those two cases without changing the merged PR. It adds a real Anthropic provider payload test using `streamAnthropic`'s payload seam, plus model-thinking coverage.

### Verification

- `bun test packages/ai/test/model-thinking.test.ts packages/ai/test/anthropic-alignment.test.ts packages/agent/test/compaction-reasoning-clamp.test.ts`
- `bun --cwd=packages/ai run check`
- `bun --cwd=packages/agent run check`

### Risk classification

- [ ] `low-risk`
- [x] `regression-risk`
- [ ] `high-risk`

Origin: Discord channel `1508831529856663612`, follow-up `1545837354542178344`.

gajae.pr-review-verdict.v1 merge-approved sha256:7c81b2aaefd4ca3389cac6593307d8a373c56edb6ea99acf1e136765a9194835 reviewer:human reviewer-id:snowykr evidence:GitHub review APPROVED at exact head 809ca0ea57325332631387a865d73e2458de0a21; focused tests and package checks pass; real streamAnthropic wire transformation is covered.