### PR TITLE
test(plugins): observe stable hash reads

### DIFF
--- a/packages/coding-agent/test/gjc-plugin-runtime-adapters.test.ts
+++ b/packages/coding-agent/test/gjc-plugin-runtime-adapters.test.ts
@@ -149,9 +149,9 @@ export default pi => ({ name: "late_tool", label: "Late", description: "late", p
 		const r = await installGjcBundle({ cwd }, "project", sixSurface);
 		expect(r.ok).toBe(true);
 		const installedRoot = path.join(cwd, ".gjc", "gjc-plugins", "valid-six-surface-bundle");
-		const readFileSpy = spyOn(fs, "readFile");
+		const openSpy = spyOn(fs, "open");
 		const pluginReadCount = () =>
-			readFileSpy.mock.calls.filter(args => typeof args[0] === "string" && args[0].startsWith(installedRoot)).length;
+			openSpy.mock.calls.filter(args => typeof args[0] === "string" && args[0].startsWith(installedRoot)).length;
 
 		try {
 			const first = await renderSkillAdvertisement({ cwd, skillName: "ralplan", phase: "planner" });
@@ -163,7 +163,7 @@ export default pi => ({ name: "late_tool", label: "Late", description: "late", p
 			expect(second).toContain('activation_arg="design"');
 			expect(pluginReadCount()).toBe(afterFirst);
 		} finally {
-			readFileSpy.mockRestore();
+			openSpy.mockRestore();
 		}
 	});
 
@@ -173,9 +173,9 @@ export default pi => ({ name: "late_tool", label: "Late", description: "late", p
 		expect(r.ok).toBe(true);
 		const installed = path.join(cwd, ".gjc", "gjc-plugins", "valid-six-surface-bundle", "tools", "domain-note.ts");
 		const installedRoot = path.join(cwd, ".gjc", "gjc-plugins", "valid-six-surface-bundle");
-		const readFileSpy = spyOn(fs, "readFile");
+		const openSpy = spyOn(fs, "open");
 		const pluginReadCount = () =>
-			readFileSpy.mock.calls.filter(args => typeof args[0] === "string" && args[0].startsWith(installedRoot)).length;
+			openSpy.mock.calls.filter(args => typeof args[0] === "string" && args[0].startsWith(installedRoot)).length;
 
 		try {
 			await renderSkillAdvertisement({ cwd, skillName: "ralplan", phase: "planner" });
@@ -187,7 +187,7 @@ export default pi => ({ name: "late_tool", label: "Late", description: "late", p
 			expect(res.tools.map(t => t.name)).not.toContain("domain_note");
 			expect(res.quarantine.some(q => q.code === "runtime_mismatch")).toBe(true);
 		} finally {
-			readFileSpy.mockRestore();
+			openSpy.mockRestore();
 		}
 	});
 


### PR DESCRIPTION
## Summary

- update plugin registry cache tests to observe the authenticated `fs.open` stable-read path
- preserve repeated-call hash reuse assertions and metadata-drift rehash/quarantine assertions
- leave product runtime caching and fail-closed behavior unchanged

## Classification

The failure is instrumentation drift: runtime hashing uses `fs.open` plus `FileHandle.read`, while the tests still spied on `fs.readFile` and therefore observed zero reads.

## Risk classification

- [x] `low-risk`
- [ ] `regression-risk`
- [ ] `high-risk`

## Validation

- failing head `c10db31866eb84efc7b420cf2f45d319195d52f4`: 8 pass / 2 fail
- prior parent `ed67422699299b0257dd45ec1d37167b474b4918`: same 8 pass / 2 fail
- repaired exact file: 10 pass / 0 fail across five fresh runs
- adjacent registry-v2, appendix, and observability suites: 21 pass / 0 fail
- `bun --cwd=packages/coding-agent run check`
- `bun --cwd=packages/coding-agent run build`
- independent read-only architect verdict: `MERGE_READY` for exact head `2da02522584702bdc783aa17a4277197e38cbbfa`
- signed low-risk owner review record is bound to the exact base/head/diff digest

gajae.pr-review-verdict.v1 merge-self-approved sha256:c1c4b928684b5cb0ea75881abfab5cf839d78ade0775da982bee7e543fa78123 reviewer:human reviewer-id:Yeachan-Heo evidence:independent architect MERGE_READY; focused 10/10 repeated, adjacent 21/21, package check and build passed

Fixes #5330

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
