### PR TITLE
fix(mcp): settle disconnect during initial connect

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Fixed
 
+- Disconnecting an MCP server during its initial connection now returns after cancelling the acquisition instead of waiting forever when an uncooperative transport ignores abort. The pool still owns and closes any late connection, retains cleanup failures for retry, and releases the manager's pending-cleanup fence after successful settlement (#5329).
 - When every auto-compaction candidate fails, the reported error now leads with the first candidate's failure and lists each candidate that was tried with its own error. The chain starts at the session model and ends on a same-provider largest-context fallback, so surfacing only the final error named a model the user never chose (e.g. `openai-codex/gpt-5.4` on an `astra` preset session) and hid that their own model had already failed the same way.
 
 ### Fixed

--- a/packages/coding-agent/src/runtime-mcp/manager.ts
+++ b/packages/coding-agent/src/runtime-mcp/manager.ts
@@ -382,6 +382,11 @@ export class MCPManager {
 		pending?.delete(error);
 		if (pending?.size === 0) this.#pendingAcquireCleanups.delete(name);
 	}
+	#pruneSettledPendingAcquireCleanups(name: string): void {
+		for (const error of this.#pendingAcquireCleanups.get(name) ?? []) {
+			if (!this.#pool.hasPendingAcquireCleanup(error)) this.#removePendingAcquireCleanup(name, error);
+		}
+	}
 
 	#retainPendingAcquireCleanup(name: string, error: MCPPoolAcquireAbortError): void {
 		if (error.cleanupGeneration === undefined || !error.cleanup || !this.#pool.hasPendingAcquireCleanup(error))
@@ -393,7 +398,11 @@ export class MCPManager {
 		}
 		if (pending.has(error)) return;
 		pending.add(error);
-		void error.cleanup.catch(() => {});
+		void error.cleanup
+			.finally(() => {
+				if (!this.#pool.hasPendingAcquireCleanup(error)) this.#removePendingAcquireCleanup(name, error);
+			})
+			.catch(() => {});
 	}
 
 	#retainConnectionCleanupFailure(name: string, error: unknown): MCPConnectionCleanupFailure | undefined {
@@ -518,6 +527,7 @@ export class MCPManager {
 			onRequest: (method, params) => this.#handleServerRequest(method, params),
 			onCleanupPending: error => this.#retainPendingAcquireCleanup(name, error),
 		});
+		this.#pruneSettledPendingAcquireCleanups(name);
 		if (trackManagerLease) this.#leaseByConnection.set(lease.connection, lease);
 		if (!this.#toolsOnly) lease.updateRoots(this.#getRoots().roots);
 		return lease;
@@ -1040,6 +1050,10 @@ export class MCPManager {
 		const connectionTasks: ConnectionTask[] = [];
 
 		for (const [name, config] of Object.entries(configs)) {
+			// Another manager sharing the pool may have retried and completed an
+			// abandoned-acquire cleanup. Retire this manager's observation before
+			// applying its reconnect fence; pool ownership remains authoritative.
+			this.#pruneSettledPendingAcquireCleanups(name);
 			const pendingAcquire = this.#pendingAcquireCleanups.get(name);
 			const pendingCleanup = this.#pendingConnectionCleanups.get(name);
 			if (pendingCleanup || pendingAcquire) {
@@ -1781,7 +1795,11 @@ export class MCPManager {
 
 		let closeError: unknown;
 		try {
-			await this.#closePendingConnectionCleanup(name);
+			// A transport may ignore its abort signal while the initial connection
+			// is still opening. The pool owns that abandoned flight and closes any
+			// late connection, so disconnect must not wait for the uncooperative
+			// opener. Already-materialized cleanup failures are still retried here.
+			await this.#closePendingConnectionCleanup(name, false);
 		} catch (error) {
 			closeError = error;
 		}

--- a/packages/coding-agent/src/runtime-mcp/pool.test.ts
+++ b/packages/coding-agent/src/runtime-mcp/pool.test.ts
@@ -462,7 +462,7 @@ describe("MCPConnectionPool", () => {
 		expect(recoveryTransports).toHaveLength(2);
 	});
 
-	test("manager disconnect joins and retries pool-owned late cleanup without spawning", async () => {
+	test("manager disconnect preserves late cleanup failure until pool retry clears every manager fence", async () => {
 		const firstFlight = Promise.withResolvers<MCPServerConnection>();
 		const firstStarted = Promise.withResolvers<void>();
 		const cleanupTransport = new FakeTransport();
@@ -481,7 +481,7 @@ describe("MCPConnectionPool", () => {
 					firstStarted.resolve();
 					return firstFlight.promise;
 				}
-				return connection(name, cfg, new FakeTransport());
+				return connection(name, cfg, new ToolListTransport());
 			},
 		});
 		const manager = new MCPManager(".", null, { pool, sessionId: "disconnect-cleanup" });
@@ -492,16 +492,19 @@ describe("MCPConnectionPool", () => {
 		});
 		await firstStarted.promise;
 		controller.abort(new Error("abort before deferred cleanup failure"));
-		await expect(operation).rejects.toBeInstanceOf(MCPPoolAcquireAbortError);
+		const abortedAcquire = await operation.catch(error => error);
+		expect(abortedAcquire).toBeInstanceOf(MCPPoolAcquireAbortError);
+		if (!(abortedAcquire instanceof MCPPoolAcquireAbortError)) throw new Error("Expected aborted acquisition");
 		expect(manager.pendingConnectionCleanupCountForTests).toBe(1);
 
-		const disconnect = manager.disconnectServer("server");
+		await manager.disconnectServer("server");
 		const fenced = await manager.connectServers({ server: serverConfig }, {});
 		expect(fenced.errors.has("server")).toBe(true);
 		expect(opens).toBe(1);
 		const primaryFailure = new Error("late connection cleanup failed");
 		firstFlight.reject(new MCPConnectionCleanupFailure(primaryFailure, cleanupTransport));
-		const disconnectError = await disconnect.catch(error => error);
+		await expect(abortedAcquire.cleanup).rejects.toBeInstanceOf(MCPConnectionCleanupFailure);
+		const disconnectError = await manager.disconnectServer("server").catch(error => error);
 		expect(disconnectError).toBeInstanceOf(MCPConnectionCleanupFailure);
 		if (!(disconnectError instanceof MCPConnectionCleanupFailure)) {
 			throw new Error("Expected retained disconnect cleanup failure");
@@ -513,14 +516,20 @@ describe("MCPConnectionPool", () => {
 		expect(manager.pendingConnectionCleanupCountForTests).toBe(1);
 		expect(pool.pendingAcquireCleanupCountForTests).toBe(1);
 
-		await manager.disconnectServer("server");
-		expect(cleanupAttempts).toBe(2);
-		expect(manager.pendingConnectionCleanupCountForTests).toBe(0);
-		expect(pool.pendingAcquireCleanupCountForTests).toBe(0);
-		await manager.withPreparedLease("server", serverConfig, async lease => {
+		const recoveryManager = new MCPManager(".", null, { pool, sessionId: "disconnect-cleanup" });
+		await recoveryManager.withPreparedLease("server", serverConfig, async lease => {
 			expect(lease.serverName).toBe("server");
 		});
-		expect(opens).toBe(2);
+		expect(cleanupAttempts).toBe(2);
+		expect(pool.pendingAcquireCleanupCountForTests).toBe(0);
+		expect(manager.pendingConnectionCleanupCountForTests).toBe(1);
+
+		const recovered = await manager.connectServers({ server: serverConfig }, {});
+		expect(recovered.errors.size).toBe(0);
+		expect(recovered.connectedServers).toEqual(["server"]);
+		expect(manager.pendingConnectionCleanupCountForTests).toBe(0);
+		expect(opens).toBe(3);
+		await recoveryManager.disconnectAll();
 		await manager.disconnectAll();
 	});
 

--- a/packages/coding-agent/test/mcp-lifecycle-cleanup.test.ts
+++ b/packages/coding-agent/test/mcp-lifecycle-cleanup.test.ts
@@ -67,6 +67,8 @@ describe("MCP lifecycle cleanup", () => {
 
 		await manager.disconnectServer("slow");
 		expect(capturedSignal?.aborted).toBe(true);
+		expect(manager.getConnectionStatus("slow")).toBe("disconnected");
+		expect(manager.pendingConnectionCleanupCountForTests).toBe(1);
 
 		release.resolve(
 			makeConnection("slow", async () => {
@@ -78,6 +80,7 @@ describe("MCP lifecycle cleanup", () => {
 
 		expect(manager.getConnection("slow")).toBeUndefined();
 		expect(closedLateConnection).toBe(true);
+		expect(manager.pendingConnectionCleanupCountForTests).toBe(0);
 	});
 
 	it("disconnectAll aborts pending initial connection work", async () => {

--- a/packages/coding-agent/test/runtime-mcp/manager-lifecycle.test.ts
+++ b/packages/coding-agent/test/runtime-mcp/manager-lifecycle.test.ts
@@ -1654,6 +1654,7 @@ setInterval(() => {}, 1000);
 			const reconnect = manager.reconnectServer("stale");
 			await waitFor(() => initializeCount === 2);
 			await manager.disconnectServer("stale");
+			await waitFor(() => manager.pendingConnectionCleanupCountForTests === 0);
 			const result = await manager.connectServers({ stale: config }, {});
 			expect(result.errors.size).toBe(0);
 			expect(result.connectedServers).toEqual(["stale"]);


### PR DESCRIPTION
## What

Make per-server MCP disconnect hand off an aborted initial acquisition to the pool without joining an opener that may ignore `AbortSignal`. Successful background settlement removes the manager's cleanup fence; late cleanup failures remain owned, fenced, and retryable. Manager observations are also pruned when another shared-pool consumer completes a cleanup retry.

## Why

`disconnectServer()` aborted a pending initial connection and then awaited the pool's abandoned-acquire completion. An uncooperative connector could ignore abort indefinitely, so the disconnect promise and `mcp-lifecycle-cleanup.test.ts` never settled. `disconnectAll()` already used the non-blocking owned-cleanup path. Fixes #5329.

## Testing

- Parent `ed67422699299b0257dd45ec1d37167b474b4918`: exact file reproduced 4 pass / 1 timeout
- Failing dev `c10db31866eb84efc7b420cf2f45d319195d52f4`: exact file reproduced 4 pass / 1 timeout
- Exact regression stress: 100 pass across 20 repetitions
- Focused lifecycle slice after review correction/rebase: 86 pass
- MCP transport red-team: 5 pass
- `bun --cwd=packages/coding-agent run check`
- `bun --cwd=packages/coding-agent run build`
- `git range-diff c10db31866e...254b7438f9d origin/dev..HEAD` — patch-equivalent; authorship preserved

## Risk classification

- [ ] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [x] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:4b0d86f78b5cf04a35ddb10c1a14d0ace16b69020e98223bbaf580a45c3197b5 reviewer:human reviewer-id:probepark evidence:authenticated write-authority APPROVED review on exact base f6b14f1fc1c8 and head 7fffe1bd848c; independent architect APPROVE; lifecycle, cross-manager cleanup retry, red-team, package check/build passed
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken