### PR TITLE
test(coding-agent): bound sidecar accounting fixture

### DIFF
--- a/packages/coding-agent/test/session-state-sidecar.test.ts
+++ b/packages/coding-agent/test/session-state-sidecar.test.ts
@@ -3939,7 +3939,9 @@ describe("coordinator runtime tool activity", () => {
 
 		// Far more concurrent calls than the public list holds. The private set is
 		// current state, not history, so none of them may be silently dropped.
-		const LIVE_CALLS = 65;
+		// Two full public windows plus one proves overflow without turning this
+		// correctness test into a benchmark of synced atomic state-file writes.
+		const LIVE_CALLS = 17;
 		for (let index = 0; index < LIVE_CALLS; index++) {
 			await toolEvent(stateFile, "start", {
 				at: new Date(Date.UTC(2026, 2, 1, 0, 0, index + 1)).toISOString(),
@@ -3954,22 +3956,33 @@ describe("coordinator runtime tool activity", () => {
 
 		// A duplicate start for a live call is idempotent; it never double-counts.
 		await toolEvent(stateFile, "start", { at: "2026-03-01T00:02:00.000Z", callId: "call-0", label: "bash" });
-		expect(await activityOf(stateFile)).toMatchObject({ seq: 66, active_tool_count: LIVE_CALLS });
+		expect(await activityOf(stateFile)).toMatchObject({ seq: LIVE_CALLS + 1, active_tool_count: LIVE_CALLS });
 
 		// call-0 is far outside the public top 8, but ending it still removes exactly
 		// one entry from the exact total.
 		await toolEvent(stateFile, "end", { at: "2026-03-01T00:02:01.000Z", callId: "call-0", label: "bash" });
-		expect(await activityOf(stateFile)).toMatchObject({ seq: 67, active_tool_count: 64, elapsed_ms: 120_000 });
+		expect(await activityOf(stateFile)).toMatchObject({
+			seq: LIVE_CALLS + 2,
+			active_tool_count: LIVE_CALLS - 1,
+			elapsed_ms: 120_000,
+		});
 
 		// A duplicate end and an unmatched end change nothing but the snapshot header.
 		await toolEvent(stateFile, "end", { at: "2026-03-01T00:02:02.000Z", callId: "call-0", label: "bash" });
 		await toolEvent(stateFile, "end", { at: "2026-03-01T00:02:03.000Z", callId: "never-started", label: "bash" });
-		expect(await activityOf(stateFile)).toMatchObject({ seq: 69, active_tool_count: 64, elapsed_ms: null });
+		expect(await activityOf(stateFile)).toMatchObject({
+			seq: LIVE_CALLS + 4,
+			active_tool_count: LIVE_CALLS - 1,
+			elapsed_ms: null,
+		});
 
 		// A missing call id cannot correlate, so it must not corrupt accounting.
 		await toolEvent(stateFile, "start", { at: "2026-03-01T00:02:04.000Z", label: "bash" });
 		await toolEvent(stateFile, "end", { at: "2026-03-01T00:02:05.000Z", callId: "   ", label: "bash" });
-		expect(await activityOf(stateFile)).toMatchObject({ seq: 71, active_tool_count: 64 });
+		expect(await activityOf(stateFile)).toMatchObject({
+			seq: LIVE_CALLS + 6,
+			active_tool_count: LIVE_CALLS - 1,
+		});
 
 		// Ending every remaining live call drains the set to exactly zero.
 		for (let index = 1; index < LIVE_CALLS; index++) {


### PR DESCRIPTION
## What

Right-size the coordinator runtime tool-accounting fixture from 65 concurrent calls to 17: two complete public-cap windows plus one overflow entry. Sequence and active-count expectations are expressed from `LIVE_CALLS` rather than hard-coded values.

The runtime accounting implementation is unchanged. Exact private counting, the eight-entry public projection, duplicate/unmatched event handling, correlation outside the public window, missing IDs, and complete drain-to-zero assertions remain intact.

Closes #5332.

## Root cause

The test performed about 135 sequential state transitions. Each transition exercises the production locked, atomic, directory-synced sidecar persistence path. Isolated parent and failing-head controls pass in roughly 9–11 seconds, but four parallel controls consistently reached the existing 15-second test limit. The failing dev merge did not change this implementation or test.

This is a contention-sensitive fixture workload, not a reproduced product accounting defect. Increasing the timeout or weakening accounting was rejected.

## Verification

- Parent `ed67422699299b0257dd45ec1d37167b474b4918`: three isolated passes, 9.59–10.95s.
- Failing dev `c10db31866eb84efc7b420cf2f45d319195d52f4`: three isolated passes, 8.85–10.55s.
- Failing dev under four-way parallel control: four timeouts at 15.40–15.45s.
- Fixed focused test: three passes, 3.04–3.28s.
- Fixed four-way parallel control: four passes, 7.81–10.36s.
- `bun test packages/coding-agent/test/session-state-sidecar.test.ts`: 160 pass, 0 fail.
- `bun --cwd=packages/coding-agent run check`: pass.
- `bun --cwd=packages/coding-agent run build`: pass.

## Risk classification

- [x] `low-risk` — test-only fixture scale; no production code, timeout, accounting, public projection, or persistence behavior changes.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies.
- [ ] `high-risk` — security/auth/install/remove/public API/destructive lifecycle/architecture change requiring independent review.

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:6f4b91ff7269fb23e96cf3e91697abf0e59bf206bb599fee1c13cc6988b1e301 reviewer:human reviewer-id:probepark evidence:https://github.com/Yeachan-Heo/gajae-code/pull/5335#pullrequestreview-5124071614; exact-head Dev CI https://github.com/Yeachan-Heo/gajae-code/actions/runs/34009707779 passed
```

---

- [x] Target branch is `dev`
- [x] No blanket timeout increase
- [x] No accounting or drain assertion weakened
- [x] Directly affected test only
- [x] No CHANGELOG entry: no user-facing/runtime behavior changed

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*