### PR TITLE
test(session): isolate TTSR runtime state (#5331)

### DIFF
--- a/packages/coding-agent/test/agent-session-concurrent.test.ts
+++ b/packages/coding-agent/test/agent-session-concurrent.test.ts
@@ -1432,7 +1432,7 @@ describe("AgentSession TTSR resume gate", () => {
 			},
 		});
 
-		const sessionManager = SessionManager.inMemory();
+		const sessionManager = SessionManager.inMemory(tempDir);
 		const settings = Settings.isolated();
 		const authStorage = await AuthStorage.create(path.join(tempDir, "testauth-int.db"));
 		authStorages.push(authStorage);
@@ -1507,7 +1507,7 @@ describe("AgentSession TTSR resume gate", () => {
 			},
 		});
 
-		const sessionManager = SessionManager.inMemory();
+		const sessionManager = SessionManager.inMemory(tempDir);
 		const settings = Settings.isolated();
 		const authStorage = await AuthStorage.create(path.join(tempDir, "testauth-def.db"));
 		authStorages.push(authStorage);
@@ -1578,7 +1578,7 @@ describe("AgentSession TTSR resume gate", () => {
 			},
 		});
 
-		const sessionManager = SessionManager.inMemory();
+		const sessionManager = SessionManager.inMemory(tempDir);
 		const settings = Settings.isolated();
 		const authStorage = await AuthStorage.create(path.join(tempDir, "testauth-abt.db"));
 		authStorages.push(authStorage);
@@ -1689,7 +1689,7 @@ describe("AgentSession TTSR resume gate", () => {
 			},
 		});
 
-		const sessionManager = SessionManager.inMemory();
+		const sessionManager = SessionManager.inMemory(tempDir);
 		const settings = Settings.isolated();
 		const authStorage = await AuthStorage.create(path.join(tempDir, "testauth-tool.db"));
 		authStorages.push(authStorage);
@@ -1798,7 +1798,7 @@ describe("AgentSession TTSR resume gate", () => {
 			},
 		});
 
-		const sessionManager = SessionManager.inMemory();
+		const sessionManager = SessionManager.inMemory(tempDir);
 		const settings = Settings.isolated();
 		const authStorage = await AuthStorage.create(path.join(tempDir, "testauth-never-tool.db"));
 		authStorages.push(authStorage);
@@ -1934,7 +1934,7 @@ describe("AgentSession TTSR resume gate", () => {
 			},
 		});
 
-		const sessionManager = SessionManager.inMemory();
+		const sessionManager = SessionManager.inMemory(tempDir);
 		const settings = Settings.isolated();
 		const authStorage = await AuthStorage.create(path.join(tempDir, "testauth-dup.db"));
 		authStorages.push(authStorage);
@@ -2042,7 +2042,7 @@ describe("AgentSession TTSR resume gate", () => {
 
 		session = new AgentSession({
 			agent,
-			sessionManager: SessionManager.inMemory(),
+			sessionManager: SessionManager.inMemory(tempDir),
 			settings: Settings.isolated({ "compaction.enabled": false, "contextPromotion.enabled": true }),
 			modelRegistry,
 		});


### PR DESCRIPTION
## Summary

- isolate every `AgentSession TTSR resume gate` fixture's in-memory session cwd to its existing unique temp directory
- stop hosted shards from contending on one lifecycle-sidecar runtime-state path
- preserve the production TTSR resume gate and PR #5318's `agent-session.ts` ownership unchanged

## Root cause

Dev CI `34005224531`, shard 7 job `101411818172`, ran the first three TTSR cases successfully and then failed four later cases at 6.3–7.4s. Every failure came from bounded `AgentSession.dispose()` waiting for coordinator persistence, not from a TTSR assertion.

The fixtures created unique temp directories for auth/model state but used `SessionManager.inMemory()` with the shared project cwd. Under the hosted lifecycle session identity, coordinator sidecar writes from concurrent work therefore targeted the same project/session runtime-state path. Binding `SessionManager.inMemory(tempDir)` makes the already-isolated fixture state complete and deterministic.

## Verification

- Parent `ed67422699299b0257dd45ec1d37167b474b4918`, complete-file `--rerun-each 3`: reproduced (89 pass / 10 fail / 4 errors)
- Failing head `c10db31866eb84efc7b420cf2f45d319195d52f4`, complete-file `--rerun-each 3`: reproduced (93 pass / 6 fail / 3 errors), including the hosted TTSR disposal signature
- Pre-fix isolated TTSR control: 49/49 passed, confirming contention sensitivity rather than a TTSR product defect
- Fixed TTSR, 25 fresh processes: passed
- Fixed TTSR, four concurrent lanes × five fresh processes: passed
- Hosted shard order through the affected file (nine fresh-process files): passed
- Rebased exact head, affected file: 33/33 passed
- Rebased exact head, TTSR fresh-process stress: 70/70 passed
- `bun --cwd=packages/coding-agent run check`: passed
- `bun --cwd=packages/coding-agent run build`: passed
- Independent architect review: CLEAR / APPROVE, no findings
- Independent executor adversarial QA: PASS across all seven TTSR variants, no blockers
- Supported live PR-contract validator: passed on exact base/head after the rebased signed risk record

All verification commands ran with a scrubbed environment containing no provider credentials.

## Risk classification

- [x] `low-risk` — deterministic test-fixture cwd isolation only; no production code, timeout, assertion, or fallback change
- [ ] `regression-risk`
- [ ] `high-risk`

## GJC verdict

gajae.pr-review-verdict.v1 merge-self-approved sha256:195d8151a15c9718a2fa53e06d2263a18a6960eccc513f445d7dc86b285cd2a8 reviewer:architect reviewer-id:Yeachan-Heo evidence:architect-agent-8-clear-executor-agent-9-pass-and-leader-verification

Fixes #5331

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
