### PR TITLE
fix(sdk): reconcile router endpoint timestamp precision

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixed
 
 - Disconnecting an MCP server during its initial connection now returns after cancelling the acquisition instead of waiting forever when an uncooperative transport ignores abort. The pool still owns and closes any late connection, retains cleanup failures for retry, and releases the manager's pending-cleanup fence after successful settlement (#5329).
+- SDK session routing now uses the Broker's endpoint timestamp comparison, accepting sub-millisecond representation differences while retaining device/inode and exact file-replacement checks. Valid live sessions no longer become unavailable solely because timestamp conversions round differently.
 - When every auto-compaction candidate fails, the reported error now leads with the first candidate's failure and lists each candidate that was tried with its own error. The chain starts at the session model and ends on a same-provider largest-context fallback, so surfacing only the final error named a model the user never chose (e.g. `openai-codex/gpt-5.4` on an `astra` preset session) and hid that their own model had already failed the same way.
 
 ### Fixed

--- a/packages/coding-agent/src/sdk/router/session-router.ts
+++ b/packages/coding-agent/src/sdk/router/session-router.ts
@@ -2,6 +2,7 @@ import * as crypto from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { logger, resolveEquivalentPath } from "@gajae-code/utils";
+import { matchesIndexedEndpointFile } from "../broker/endpoint-authority";
 import {
 	canonicalSessionCwd,
 	SessionIndex as DefaultSessionIndex,
@@ -27,6 +28,7 @@ import {
 import { ACP_SESSION_RECONNECT, SESSION_REQUEST_TIMEOUT_MS } from "../session-reconnect";
 
 export interface SessionEndpointIdentity {
+	readonly dev: bigint;
 	readonly mtimeMs: number;
 	readonly mtimeNs: bigint;
 	readonly ctimeNs: bigint;
@@ -56,6 +58,7 @@ export function sessionAttachmentAuthorityId(input: {
 		.digest("hex");
 	const endpointIdentity = input.endpointIdentity
 		? {
+				dev: input.endpointIdentity.dev.toString(),
 				mtimeMs: input.endpointIdentity.mtimeMs,
 				mtimeNs: input.endpointIdentity.mtimeNs.toString(),
 				ctimeNs: input.endpointIdentity.ctimeNs.toString(),
@@ -456,6 +459,7 @@ async function lstatEndpoint(file: string): Promise<SessionEndpointIdentity | un
 	)
 		return undefined;
 	return {
+		dev: identity.dev,
 		mtimeMs: stat.mtimeMs,
 		mtimeNs: identity.mtimeNs,
 		ctimeNs: identity.ctimeNs,
@@ -470,6 +474,7 @@ function warningAffectsSession(warning: string, sessionId: string): boolean {
 
 function sameEndpointIdentity(expected: SessionEndpointIdentity, current: SessionEndpointIdentity): boolean {
 	return (
+		expected.dev === current.dev &&
 		expected.mtimeMs === current.mtimeMs &&
 		expected.mtimeNs === current.mtimeNs &&
 		expected.ctimeNs === current.ctimeNs &&
@@ -1360,7 +1365,7 @@ export class SessionRouter {
 		// cannot keep the old attachment authorized.
 		const identityBefore = await lstatEndpoint(attached.endpoint.path);
 		if (!identityBefore || !sameEndpointIdentity(attached.endpointIdentity, identityBefore)) return false;
-		if (identityBefore.mtimeMs !== indexed.endpointMtimeMs) return false;
+		if (!matchesIndexedEndpointFile(identityBefore, indexed)) return false;
 		let raw: Record<string, unknown>;
 		try {
 			const parsed = JSON.parse(await Bun.file(attached.endpoint.path).text());
@@ -1384,7 +1389,7 @@ export class SessionRouter {
 		const identityAfter = await lstatEndpoint(attached.endpoint.path);
 		return (
 			identityAfter !== undefined &&
-			identityAfter.mtimeMs === indexed.endpointMtimeMs &&
+			matchesIndexedEndpointFile(identityAfter, indexed) &&
 			sameEndpointIdentity(attached.endpointIdentity, identityAfter)
 		);
 	}
@@ -1416,7 +1421,7 @@ export class SessionRouter {
 		const endpointIdentity = await lstatEndpoint(endpointPath);
 		const endpoint = await readSdkSessionEndpoint(cwd, indexed.sessionId, scope);
 		if (!endpoint || endpoint.stale || endpoint.pid !== indexed.pid) return null;
-		if (!endpointIdentity || endpointIdentity.mtimeMs !== indexed.endpointMtimeMs) return null;
+		if (!endpointIdentity || !matchesIndexedEndpointFile(endpointIdentity, indexed)) return null;
 		// Identity is proven INSIDE this authority read (#4730 review): sampling it
 		// afterwards would let an identical rename between the read and the sample
 		// install the replacement's inode as the trusted baseline.
@@ -1441,7 +1446,7 @@ export class SessionRouter {
 		const endpointIdentityAfterRead = await lstatEndpoint(endpoint.path);
 		if (
 			!endpointIdentityAfterRead ||
-			endpointIdentityAfterRead.mtimeMs !== indexed.endpointMtimeMs ||
+			!matchesIndexedEndpointFile(endpointIdentityAfterRead, indexed) ||
 			!sameEndpointIdentity(endpointIdentity, endpointIdentityAfterRead)
 		)
 			return null;

--- a/packages/coding-agent/test/sdk-chat-daemon-worker.test.ts
+++ b/packages/coding-agent/test/sdk-chat-daemon-worker.test.ts
@@ -1591,6 +1591,7 @@ describe("chat daemon worker", () => {
 						url: host.endpoint.url,
 						token: host.endpoint.token,
 						endpointIdentity: {
+							dev: endpointIdentity.dev,
 							mtimeMs: host.endpointMtimeMs,
 							mtimeNs: endpointIdentity.mtimeNs,
 							ctimeNs: endpointIdentity.ctimeNs,

--- a/packages/coding-agent/test/sdk-session-router-authority.test.ts
+++ b/packages/coding-agent/test/sdk-session-router-authority.test.ts
@@ -17,6 +17,7 @@ import {
 	type SessionRouterClient,
 	SessionRouterError,
 	type SessionRouterFrame,
+	sessionAttachmentAuthorityId,
 } from "../src/sdk/router";
 import { SESSION_REQUEST_TIMEOUT_MS } from "../src/sdk/session-reconnect";
 
@@ -2662,6 +2663,57 @@ describe("SessionRouter dispatch authority", () => {
 			await router.stop();
 		}
 	});
+	test("attachment authority distinguishes otherwise identical endpoint devices", () => {
+		const input = {
+			sessionId: "device-identity",
+			generation: 1,
+			pid: 42,
+			endpointMtimeMs: 1_700_000_000_000,
+			url: "ws://router.test",
+			token: "fixture-token",
+			endpointIdentity: {
+				dev: 1n,
+				ino: 17n,
+				mtimeMs: 1_700_000_000_000,
+				mtimeNs: 1_700_000_000_000_000_000n,
+				ctimeNs: 1_700_000_000_000_000_000n,
+				size: 100n,
+			},
+		};
+		expect(sessionAttachmentAuthorityId(input)).not.toBe(
+			sessionAttachmentAuthorityId({ ...input, endpointIdentity: { ...input.endpointIdentity, dev: 2n } }),
+		);
+	});
+
+	for (const delta of [-0.000244140625, 0.000244140625]) {
+		test(`endpoint rounding difference ${delta} permits attachment and maintenance, not replacement`, async () => {
+			const fixture = await routerFixture({ start: false });
+			const timestamp = new Date(1_700_000_000_000);
+			await fsPromises.utimes(fixture.endpointFile, timestamp, timestamp);
+			const original = await fsPromises.lstat(fixture.endpointFile);
+			fixture.authority.endpointMtimeMs = original.mtimeMs + delta;
+			try {
+				await fixture.router.start();
+				const attachment = fixture.router.attachment(fixture.sessionId);
+				expect(attachment?.isCurrent()).toBe(true);
+				await attachment!.sendMaintenance?.("rounding-safe");
+				expect(fixture.clients[0].sent).toHaveLength(1);
+				const staging = `${fixture.endpointFile}.replacement`;
+				await Bun.write(staging, await Bun.file(fixture.endpointFile).text());
+				await fsPromises.rename(staging, fixture.endpointFile);
+				await fsPromises.utimes(fixture.endpointFile, timestamp, timestamp);
+				const replacement = await fsPromises.lstat(fixture.endpointFile);
+				expect(replacement.mtimeMs).toBe(original.mtimeMs);
+				expect(Math.abs(replacement.mtimeMs - fixture.authority.endpointMtimeMs)).toBeLessThanOrEqual(0.001);
+				expect(replacement.ino).not.toBe(original.ino);
+				await expect(attachment!.sendMaintenance?.("replaced")).rejects.toBeInstanceOf(SessionRouterError);
+				expect(fixture.clients[0].sent).toHaveLength(1);
+			} finally {
+				await fixture.router.stop();
+			}
+		});
+	}
+
 	test("sendMaintenance fails closed when the endpoint file is replaced under it (#4730 review)", async () => {
 		// A replacement that preserves sessionId/pid/url/token and even mtime must
 		// not keep the old attachment authorized: mtime is not a replacement-safe


### PR DESCRIPTION
## What

Fix valid SDK sessions being rejected by SessionRouter because Broker registration and filesystem reads round the same endpoint timestamp differently.

- Reuse the existing Broker `matchesIndexedEndpointFile` comparator at the four file-to-index checks (tolerance: **0.001 ms**, with indexed device/inode matching when available).
- Preserve exact per-attachment device, inode, nanosecond timestamps and size comparisons; do not apply tolerance to attachment continuity.
- Include device identity in the durable attachment authority digest.
- Add regressions for both signs of a timestamp rounding difference, device-only digest differences, and timestamp-preserving endpoint replacement. Update the affected worker fixture and changelog.

Four files; one logical fix. The separate Markdown cache branch is not included.

## Why

Live sessions were listed but Router-based control returned `session_unavailable`. On the affected host, ordinary `stat.mtimeMs` and `Number(stat.mtimeNs) / 1_000_000` differed by **0.000244140625 ms** for the same unchanged endpoint file. Router required exact numeric equality with the indexed timestamp and rejected the session before attaching.

History points to `6399fcb04b45a10d172b20345974313d7ba2212f` in #4934 changing registration to the nanosecond-derived representation while Router retained its old comparison. The historical producer/comparison expressions were exercised against the same endpoint metadata: both failing samples passed the prior representation and failed the changed representation. This is a focused historical-path reproduction, not a full historical-session bisect.

The Broker already has a shared timestamp/file-identity matcher; this change makes Router use that contract rather than introducing another tolerance implementation.

## Testing

Re-run on the final rebased head:

```sh
bun test packages/coding-agent/test/sdk-session-router-authority.test.ts packages/coding-agent/test/sdk-endpoint-authority.test.ts packages/coding-agent/test/sdk-chat-daemon-worker.test.ts packages/coding-agent/test/sdk-search-cli.test.ts packages/coding-agent/test/sdk-session-cli-control-envelope.test.ts packages/coding-agent/test/sdk-session-cli-wait-budget.test.ts packages/coding-agent/test/sdk-router-exit-promptness.test.ts
bun --cwd=packages/coding-agent run check
bun scripts/verify-gjc-state-writers.ts --fail
git diff --check
```

- **103 tests passed, 0 failed; 464 assertions** across seven SDK suites.
- coding-agent Biome and TypeScript checks passed.
- State-writer scan: zero sites outside the sanctioned writer/allowlist.
- The two rounding regressions failed before the Router fix. The device-only digest regression failed before adding `dev` to the digest.
- The replacement cases preserve the original mtime and captured indexed timestamp, verify the timestamp still lies within tolerance, verify a different inode, and require rejection without another maintenance frame.
- Before the final rebase, the source CLI successfully sent a prompt to a previously unavailable live session and received `BROKER-TIMESTAMP-ROUNDTRIP-OK` with a present terminal receipt. Both affected sessions became `reachable`. This was source execution, not an installed-binary rebuild.
- Two independent AI red-team review lanes reapproved the corrected delta. This is **not** an authenticated independent human GitHub approval. The final rebase retained both changelog entries; implementation/test files were not conflict-resolved.

Not run: full root `bun run check`, full repository suite, installed binary rebuild, or cross-platform live-session verification. Existing missing-file-ID and pathname-read limitations are not claimed resolved.

## Risk classification

- [ ] `low-risk` — ordinary fix/maintenance
- [ ] `regression-risk` — fix with material regression risk
- [x] `high-risk` — touches SDK session authority checks and durable attachment identity

Small diff, but an authority boundary: classified by behavior, not line count. Independent maintainer review is required. Yeachan-Heo is requested based on ownership of the master-mode integration and SDK authority work.

## GJC verdict

An authenticated independent maintainer approval is recorded on the exact head. The verdict is bound to the immutable base, exact head, and recomputed binary diff digest.

Base: `3bb72969910de49ac50b2b697e550c7f732b1d1b`
Head: `d30b83c28b28833b3999280f47295783ca8ba80d`
Digest: `git diff --binary --full-index --no-ext-diff <base>...<head>` hashed with SHA-256.

```text
gajae.pr-review-verdict.v1 merge-approved sha256:6ad536d28632f28f7443dcc1ce22bb5441b37c65f6fbc35c6440bef5c9dd53bf reviewer:human reviewer-id:Yeachan-Heo evidence:https://github.com/Yeachan-Heo/gajae-code/actions/runs/34011108670
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes (full root check not run; package check passed)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken

