### PR TITLE
fix(tui): bound Markdown caches and finalize streaming ownership

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 - Avoid copying unchanged terminal-control spans, reuse retained row widths, consume only the first grapheme for cursor operations, stop select-list width scans at their bounds, and avoid redundant background-row padding.
 
+### Fixed
+
+- Markdown cache ownership now finalizes after styling callbacks, so reentrant text replacement cannot inherit stale rejection hints and streaming completion releases local parse tokens. Cache diagnostics measure insertion-time payload sizes; returned render arrays are borrowed and must not be mutated.
+- Streaming Markdown retains only its current parse locally instead of publishing partial documents to the shared render/parse caches. Completed documents remain reusable, with 8 MiB render, 8 MiB parse and 4 MiB highlight accounted-payload budgets and per-entry limits. The render-cache diagnostic now includes UTF-16 keys, full token graphs, styled lines and anchors; it is not a live heap/RSS measurement.
+- Markdown reflow avoids redundant parse-cache admissions and repeated accounting of already rejected normalized content, without retaining completed parse tokens. Render payload accounting uses its owned layout schema, and oversized highlighting inputs are rejected earlier while preserving byte/line limits and guard ordering.
+
 ## [0.16.4] - 2026-09-05
 
 ### Added

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -46,14 +46,95 @@ markdownParser.setOptions({
 // (Rust FFI) work for content/layout combinations already seen this session.
 
 const RENDER_CACHE_MAX = 256; // sane cap: ~256 distinct message × width combos
-const renderCache = new LRUCache<
-	string,
-	{ source: string; lines: string[]; anchorSpans?: Array<ViewportAnchorSpan | null> }
->({
+const DOCUMENT_CACHE_SIZE = 8 * 1024 * 1024;
+const DOCUMENT_ENTRY_SIZE = 1024 * 1024;
+
+/** Account retained payload, not live heap. Stop once admission is impossible. */
+export function getMarkdownCacheEntryAccountedSize(key: string, value: unknown, cap: number): number {
+	let size = 64 + key.length * 2;
+	const visited = new Set<object>();
+	const pending: Iterator<unknown>[] = [[value][Symbol.iterator]()];
+	function* objects(object: object, array: boolean): Generator<object> {
+		for (const name in object) {
+			if (!Object.hasOwn(object, name)) continue;
+			// Array indices are canonical uint32 strings, excluding 2^32 - 1.
+			const index = array ? Number(name) >>> 0 : 0;
+			if (!array || index === 0xffffffff || String(index) !== name) {
+				size += 16 + name.length * 2;
+				if (size > cap) return;
+			}
+			const child = (object as Record<string, unknown>)[name];
+			if (typeof child === "string") size += child.length * 2;
+			else if (typeof child === "number") size += 8;
+			else if (typeof child === "boolean") size += 4;
+			else if (child !== null && typeof child === "object") yield child;
+			if (size > cap) return;
+		}
+	}
+	while (pending.length && size <= cap) {
+		const next = pending[pending.length - 1].next();
+		if (next.done) {
+			pending.pop();
+			continue;
+		}
+		const item = next.value;
+		if (typeof item === "string") size += item.length * 2;
+		else if (typeof item === "number") size += 8;
+		else if (typeof item === "boolean") size += 4;
+		else if (item !== null && typeof item === "object" && !visited.has(item)) {
+			visited.add(item);
+			const array = Array.isArray(item);
+			size += array ? 24 + item.length * 8 : 32;
+			if (size <= cap) pending.push(objects(item, array));
+		}
+	}
+	return size > cap ? cap + 1 : size;
+}
+
+interface MarkdownRenderCacheEntry {
+	source: string;
+	lines: string[];
+	anchorSpans?: Array<ViewportAnchorSpan | null>;
+}
+
+const RENDER_ENTRY_BASE_SIZE = 64 + 32 + 16 + "source".length * 2 + 16 + "lines".length * 2 + 24;
+const ANCHOR_SPAN_SIZE =
+	32 + 4 * 16 + 4 * 8 + 2 * ("graphemeStart".length + "graphemeEnd".length + "cellStart".length + "cellEnd".length);
+
+function renderCacheEntrySize(entry: MarkdownRenderCacheEntry, key: string): number {
+	// These arrays and distinct span records are constructed exclusively by #render,
+	// with no custom properties, sharing or cycles. Account that owned schema without
+	// allocating the generic token-graph traversal machinery.
+	let size = RENDER_ENTRY_BASE_SIZE + key.length * 2 + entry.source.length * 2 + entry.lines.length * 8;
+	if (size > DOCUMENT_ENTRY_SIZE) return DOCUMENT_ENTRY_SIZE + 1;
+	for (const line of entry.lines) {
+		size += line.length * 2;
+		if (size > DOCUMENT_ENTRY_SIZE) return DOCUMENT_ENTRY_SIZE + 1;
+	}
+	if (entry.anchorSpans) {
+		size += 16 + "anchorSpans".length * 2 + 24 + entry.anchorSpans.length * 8;
+		if (size > DOCUMENT_ENTRY_SIZE) return DOCUMENT_ENTRY_SIZE + 1;
+		for (const span of entry.anchorSpans) {
+			if (span) size += ANCHOR_SPAN_SIZE;
+			if (size > DOCUMENT_ENTRY_SIZE) return DOCUMENT_ENTRY_SIZE + 1;
+		}
+	}
+	return size;
+}
+
+const renderCache = new LRUCache<string, MarkdownRenderCacheEntry>({
 	max: RENDER_CACHE_MAX,
+	maxSize: DOCUMENT_CACHE_SIZE,
+	maxEntrySize: DOCUMENT_ENTRY_SIZE,
+	sizeCalculation: renderCacheEntrySize,
 });
 const PARSE_CACHE_MAX = 128;
-const parseCache = new LRUCache<string, { source: string; tokens: Token[] }>({ max: PARSE_CACHE_MAX });
+const parseCache = new LRUCache<string, { source: string; tokens: Token[] }>({
+	max: PARSE_CACHE_MAX,
+	maxSize: DOCUMENT_CACHE_SIZE,
+	maxEntrySize: DOCUMENT_ENTRY_SIZE,
+	sizeCalculation: (value, key) => getMarkdownCacheEntryAccountedSize(key, value, DOCUMENT_ENTRY_SIZE),
+});
 const MARKDOWN_STREAM_THROTTLE_MS = 64;
 let markdownNow = (): number => performance.now();
 
@@ -76,20 +157,38 @@ export function __setMarkdownNowForTest(now: (() => number) | undefined): void {
 // appends only highlight new/changed blocks instead of re-highlighting the whole
 // prefix on every chunk. Bounded LRU; cleared on theme change via clearRenderCache().
 const HIGHLIGHT_CACHE_MAX = 512;
-const highlightCache = new LRUCache<string, string[]>({ max: HIGHLIGHT_CACHE_MAX });
+const HIGHLIGHT_ENTRY_SIZE = 512 * 1024;
+const highlightCache = new LRUCache<string, string[]>({
+	max: HIGHLIGHT_CACHE_MAX,
+	maxSize: 4 * 1024 * 1024,
+	maxEntrySize: HIGHLIGHT_ENTRY_SIZE,
+	sizeCalculation: (value, key) => getMarkdownCacheEntryAccountedSize(key, value, HIGHLIGHT_ENTRY_SIZE),
+});
 
-function renderedLinesBytes(lines: readonly string[]): number {
-	let bytes = 0;
-	for (const line of lines) bytes += Buffer.byteLength(line, "utf8");
-	return bytes;
+export interface MarkdownCacheStats {
+	count: number;
+	accountedSize: number;
+	max: number;
+	maxSize: number;
+	maxEntrySize: number;
 }
 
-function anchorSpansBytes(spans: readonly (ViewportAnchorSpan | null)[]): number {
-	let bytes = spans.length * 8; // Array element references
-	for (const span of spans) {
-		if (span) bytes += 4 * 8; // Four numeric offsets
-	}
-	return bytes;
+/** Detached diagnostics; exposes neither entries nor mutable budgets. */
+export function getMarkdownCacheStats(): Record<"render" | "parse" | "highlight", MarkdownCacheStats> {
+	const snapshot = (cache: {
+		size: number;
+		calculatedSize: number;
+		max: number;
+		maxSize: number;
+		maxEntrySize: number;
+	}): MarkdownCacheStats => ({
+		count: cache.size,
+		accountedSize: cache.calculatedSize,
+		max: cache.max,
+		maxSize: cache.maxSize,
+		maxEntrySize: cache.maxEntrySize,
+	});
+	return { render: snapshot(renderCache), parse: snapshot(parseCache), highlight: snapshot(highlightCache) };
 }
 
 // F18: cap synchronous (Rust FFI) syntax highlighting so a single huge fenced block
@@ -133,16 +232,12 @@ export function clearRenderCache(): void {
 	highlightCache.clear();
 }
 
+/**
+ * Insertion-time UTF-16 accounting of global keys/tokens/lines/anchors, not heap or RSS.
+ * Rendered arrays are borrowed cache payloads: callers must not mutate them.
+ */
 export function getRenderCacheRetainedBytes(): number {
-	let bytes = 0;
-	for (const entry of renderCache.values()) {
-		bytes += Buffer.byteLength(entry.source, "utf8");
-		bytes += renderedLinesBytes(entry.lines);
-		if (entry.anchorSpans) bytes += anchorSpansBytes(entry.anchorSpans);
-	}
-	for (const entry of parseCache.values()) bytes += Buffer.byteLength(entry.source, "utf8");
-	for (const lines of highlightCache.values()) bytes += renderedLinesBytes(lines);
-	return bytes;
+	return renderCache.calculatedSize + parseCache.calculatedSize + highlightCache.calculatedSize;
 }
 
 // Stable numeric IDs for structural theme/style objects (no ID field on type).
@@ -267,6 +362,8 @@ export class Markdown implements Component {
 	#cachedWidth?: number;
 	#cachedLines?: string[];
 	#cachedAnchorSpans?: Array<ViewportAnchorSpan | null>;
+	#currentParse?: { source: string; tokens: Token[] };
+	#rejectedParseKey?: string;
 
 	#streaming = false;
 	#lastFullParseAt = 0;
@@ -297,6 +394,7 @@ export class Markdown implements Component {
 		if (options?.streaming !== undefined) {
 			this.setStreaming(options.streaming);
 		}
+		if (this.#text !== text) this.#rejectedParseKey = undefined;
 		this.#text = text;
 		if (this.#streaming) {
 			return;
@@ -336,6 +434,8 @@ export class Markdown implements Component {
 
 	dispose(): void {
 		this.#clearStaleThrottleTimer();
+		this.#currentParse = undefined;
+		this.#rejectedParseKey = undefined;
 	}
 
 	invalidate(): void {
@@ -346,14 +446,17 @@ export class Markdown implements Component {
 	}
 
 	#exceedsHighlightCap(code: string): boolean {
+		// UTF-8 requires at least one byte per UTF-16 code unit, including lone
+		// surrogates. Reject obviously oversized input without scanning or hashing it.
+		if (code.length > MAX_HIGHLIGHT_BYTES) return true;
+		// Check UTF-8 bytes before the JavaScript line scan so oversized Unicode
+		// blocks do not pay for a scan whose result cannot change rejection.
+		if (Buffer.byteLength(code, "utf8") > MAX_HIGHLIGHT_BYTES) return true;
 		let newlines = 0;
 		for (let i = 0; i < code.length; i++) {
-			if (code.charCodeAt(i) === 10) newlines += 1;
+			if (code.charCodeAt(i) === 10 && ++newlines >= MAX_HIGHLIGHT_LINES) return true;
 		}
-		if (newlines + 1 > MAX_HIGHLIGHT_LINES) return true;
-		// UTF-8 byte length (not UTF-16 code-unit count) so a non-ASCII block cannot
-		// exceed the advertised byte cap and still reach the synchronous highlighter.
-		return Buffer.byteLength(code, "utf8") > MAX_HIGHLIGHT_BYTES;
+		return false;
 	}
 
 	#highlightCodeBlock(code: string, lang: string): string[] | null {
@@ -421,6 +524,7 @@ export class Markdown implements Component {
 
 		// Don't render anything if there's no actual text
 		if (!this.#text || this.#text.trim() === "") {
+			this.#currentParse = undefined;
 			const result: string[] = [];
 			// Update per-instance cache
 			this.#cachedText = this.#text;
@@ -430,8 +534,9 @@ export class Markdown implements Component {
 			return { lines: result, spans: this.#cachedAnchorSpans };
 		}
 
-		// Replace tabs with 3 spaces for consistent rendering
-		const normalizedText = replaceTabs(this.#text);
+		// Normalize tabs using the current configured indentation width.
+		const renderedText = this.#text;
+		const normalizedText = replaceTabs(renderedText);
 		this.#clearStaleThrottleTimer();
 		const contentKey = markdownContentKey(normalizedText);
 
@@ -450,10 +555,11 @@ export class Markdown implements Component {
 			(!includeAnchors || cached.anchorSpans !== undefined)
 		) {
 			// Populate L1 so subsequent calls from this instance are O(1) map lookup.
-			this.#cachedText = this.#text;
+			this.#cachedText = renderedText;
 			this.#cachedWidth = width;
 			this.#cachedLines = cached.lines;
 			this.#cachedAnchorSpans = cached.anchorSpans;
+			if (!this.#streaming || this.#currentParse?.source !== normalizedText) this.#currentParse = undefined;
 			return { lines: cached.lines, spans: cached.anchorSpans };
 		}
 
@@ -462,13 +568,17 @@ export class Markdown implements Component {
 		// final wrapped output must differ by width.
 		const cachedParse = parseCache.get(contentKey);
 		let tokens: Token[];
-		if (cachedParse !== undefined && cachedParse.source === normalizedText) {
+		if (this.#currentParse?.source === normalizedText) {
+			tokens = this.#currentParse.tokens;
+		} else if (cachedParse !== undefined && cachedParse.source === normalizedText) {
 			tokens = cachedParse.tokens;
 		} else {
 			__markdownPerfCounters.lexerInvocations += 1;
 			__markdownPerfCounters.lexedBytes += normalizedText.length;
 			tokens = markdownParser.lexer(normalizedText);
-			parseCache.set(contentKey, { source: normalizedText, tokens });
+		}
+		if (this.#streaming && this.#text === renderedText) {
+			this.#currentParse = { source: normalizedText, tokens };
 		}
 
 		// Convert tokens to styled terminal output. When anchoring, record each
@@ -615,8 +725,24 @@ export class Markdown implements Component {
 		const result = rawResult.length > 0 ? rawResult : [""];
 		const anchorSpans = rawResult.length > 0 ? rawAnchorSpans : wrappedSpans ? [null] : undefined;
 
+		// Styling callbacks may replace text or end streaming. Publish ownership
+		// only after they finish, and never attach an old rejection to new text.
+		if (!this.#streaming && this.#text === renderedText) {
+			const completedParse = parseCache.get(contentKey);
+			// Reparse rejected documents on reflow without retaining their tokens.
+			// Occupied collisions still retry admission to preserve replacement rules.
+			if (
+				completedParse?.source !== normalizedText &&
+				(this.#rejectedParseKey !== contentKey || completedParse !== undefined)
+			) {
+				parseCache.set(contentKey, { source: normalizedText, tokens });
+				this.#rejectedParseKey = parseCache.has(contentKey) ? undefined : contentKey;
+			}
+		}
+		if (!this.#streaming || this.#text !== renderedText) this.#currentParse = undefined;
+
 		// Update L1 per-instance cache
-		this.#cachedText = this.#text;
+		this.#cachedText = renderedText;
 		this.#cachedWidth = width;
 		this.#cachedLines = result;
 		this.#cachedAnchorSpans = anchorSpans;
@@ -624,7 +750,9 @@ export class Markdown implements Component {
 
 		// Update L2 module-level LRU so future instances with the same key skip
 		// the marked.lexer + highlightCode (Rust FFI) work entirely.
-		renderCache.set(cacheKey, { source: normalizedText, lines: result, ...(anchorSpans ? { anchorSpans } : {}) });
+		if (!this.#streaming) {
+			renderCache.set(cacheKey, { source: normalizedText, lines: result, ...(anchorSpans ? { anchorSpans } : {}) });
+		}
 
 		return { lines: result, spans: anchorSpans };
 	}

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -158,7 +158,13 @@ export function __setMarkdownNowForTest(now: (() => number) | undefined): void {
 // prefix on every chunk. Bounded LRU; cleared on theme change via clearRenderCache().
 const HIGHLIGHT_CACHE_MAX = 512;
 const HIGHLIGHT_ENTRY_SIZE = 512 * 1024;
-const highlightCache = new LRUCache<string, string[]>({
+interface MarkdownHighlightCacheEntry {
+	lang: string;
+	code: string;
+	lines: string[];
+}
+
+const highlightCache = new LRUCache<string, MarkdownHighlightCacheEntry>({
 	max: HIGHLIGHT_CACHE_MAX,
 	maxSize: 4 * 1024 * 1024,
 	maxEntrySize: HIGHLIGHT_ENTRY_SIZE,
@@ -464,10 +470,10 @@ export class Markdown implements Component {
 		if (this.#exceedsHighlightCap(code)) return null;
 		const key = `${objectId(this.#theme)}\x00${lang}\x00${code}`;
 		const cached = highlightCache.get(key);
-		if (cached) return cached;
+		if (cached?.lang === lang && cached.code === code) return cached.lines;
 		highlightCallCount += 1;
 		const result = this.#theme.highlightCode(code, lang || undefined);
-		highlightCache.set(key, result);
+		highlightCache.set(key, { lang, code, lines: result });
 		return result;
 	}
 

--- a/packages/tui/test/markdown-streaming.test.ts
+++ b/packages/tui/test/markdown-streaming.test.ts
@@ -1,5 +1,11 @@
-import { beforeEach, describe, expect, it } from "bun:test";
-import { __markdownPerfCounters, clearRenderCache, Markdown } from "../src/components/markdown.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import {
+	__markdownPerfCounters,
+	__setMarkdownNowForTest,
+	clearRenderCache,
+	getMarkdownCacheStats,
+	Markdown,
+} from "../src/components/markdown.js";
 import { defaultMarkdownTheme } from "./test-themes.js";
 
 function renderPlain(markdown: Markdown, width = 80): string {
@@ -7,6 +13,7 @@ function renderPlain(markdown: Markdown, width = 80): string {
 }
 
 function freshRender(text: string, width = 80): string {
+	clearRenderCache();
 	return renderPlain(new Markdown(text, 0, 0, defaultMarkdownTheme), width);
 }
 
@@ -80,5 +87,306 @@ describe("Markdown streaming throttle", () => {
 		markdown.setText("alpha\n\nbeta");
 		markdown.render(80);
 		expect(__markdownPerfCounters.lexerInvocations).toBe(2);
+	});
+});
+
+describe("Markdown streaming cache ownership", () => {
+	it("does not attach a rejected key or rendered output to reentrant replacement text", () => {
+		const hashSpy = vi.spyOn(Bun, "hash").mockReturnValue(1n);
+		const original = "x".repeat(120000);
+		const replacement = `<!--${"y".repeat(119993)}-->`;
+		let replace = true;
+		const markdown = new Markdown(original, 0, 0, {
+			...defaultMarkdownTheme,
+			heading(text) {
+				if (replace) {
+					replace = false;
+					markdown.setText(replacement);
+				}
+				return defaultMarkdownTheme.heading(text);
+			},
+		});
+		try {
+			markdown.render(80);
+			expect(renderPlain(markdown, 80).trim()).toBe("");
+			expect(getMarkdownCacheStats().parse.count).toBe(1);
+		} finally {
+			markdown.dispose();
+			hashSpy.mockRestore();
+		}
+	});
+
+	it("admits completed parsing and releases local tokens when styling ends streaming", () => {
+		let finish = true;
+		const markdown = new Markdown("`abc`", 0, 0, {
+			...defaultMarkdownTheme,
+			code(text) {
+				if (finish) {
+					finish = false;
+					markdown.setStreaming(false);
+				}
+				return defaultMarkdownTheme.code(text);
+			},
+		});
+		try {
+			markdown.setStreaming(true);
+			expect(renderPlain(markdown, 80).trim()).toBe("abc");
+			expect(getMarkdownCacheStats().parse.count).toBe(1);
+			clearRenderCache();
+			expect(renderPlain(markdown, 79).trim()).toBe("abc");
+			expect(__markdownPerfCounters.lexerInvocations).toBe(2);
+		} finally {
+			markdown.dispose();
+		}
+	});
+
+	let now = 1_000_000;
+	beforeEach(() => {
+		now = 1_000_000;
+		clearRenderCache();
+		__markdownPerfCounters.reset();
+		__setMarkdownNowForTest(() => now);
+	});
+	afterEach(() => {
+		__setMarkdownNowForTest(undefined);
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+		clearRenderCache();
+	});
+
+	for (const cadence of [16, 64]) {
+		it(`keeps 128 streaming prefixes local at ${cadence}ms and publishes only final content`, () => {
+			const md = new Markdown("", 0, 0, defaultMarkdownTheme);
+			md.setStreaming(true);
+			let text = "";
+			for (let i = 0; i < 128; i++) {
+				now += cadence;
+				text += `streamed ASCII word ${i} `;
+				md.setText(text);
+				md.render(80);
+				for (const stats of Object.values(getMarkdownCacheStats())) {
+					expect(stats.count).toBe(0);
+					expect(stats.accountedSize).toBe(0);
+				}
+			}
+			md.setStreaming(false);
+			const output = md.renderWithViewportAnchorSource(80, { id: "message" });
+			expect(getMarkdownCacheStats().parse.count).toBe(1);
+			expect(getMarkdownCacheStats().render.count).toBe(1);
+			const calls = __markdownPerfCounters.lexerInvocations;
+			expect(
+				new Markdown(text, 0, 0, defaultMarkdownTheme).renderWithViewportAnchorSource(80, { id: "message" }),
+			).toEqual(output);
+			expect(__markdownPerfCounters.lexerInvocations).toBe(calls);
+			clearRenderCache();
+			const oracle = new Markdown(text, 0, 0, defaultMarkdownTheme).renderWithViewportAnchorSource(80, {
+				id: "message",
+			});
+			expect(__markdownPerfCounters.lexerInvocations).toBe(calls + 1);
+			expect(output).toEqual(oracle);
+			md.dispose();
+		});
+	}
+
+	it("reuses current local tokens across reflow, anchors and same-text completion", () => {
+		const md = new Markdown("# current\n\nhello **world**", 0, 0, defaultMarkdownTheme);
+		md.setStreaming(true);
+		md.render(80);
+		md.render(40);
+		md.invalidate();
+		md.renderWithViewportAnchorSource(40, { id: "x" });
+		expect(__markdownPerfCounters.lexerInvocations).toBe(1);
+		md.setStreaming(false);
+		expect(getMarkdownCacheStats().parse.count).toBe(0);
+		md.render(40);
+		expect(__markdownPerfCounters.lexerInvocations).toBe(1);
+		expect(getMarkdownCacheStats().parse.count).toBe(1);
+		// Completed instances must not hide global eviction with a retained local parse.
+		clearRenderCache();
+		md.invalidate();
+		md.render(40);
+		expect(__markdownPerfCounters.lexerInvocations).toBe(2);
+	});
+
+	it("preserves completed entries during streaming, reuse and disposal", () => {
+		const text = "completed **document**";
+		new Markdown(text, 0, 0, defaultMarkdownTheme).render(80);
+		const before = getMarkdownCacheStats();
+		const md = new Markdown(text, 0, 0, defaultMarkdownTheme);
+		md.setStreaming(true);
+		md.render(80);
+		expect(__markdownPerfCounters.lexerInvocations).toBe(1);
+		md.setText("unrelated partial");
+		md.render(60);
+		md.dispose();
+		expect(getMarkdownCacheStats()).toEqual(before);
+		md.invalidate();
+		md.render(60);
+		expect(__markdownPerfCounters.lexerInvocations).toBe(3);
+	});
+
+	it("never publishes old text when completion assigns new text", () => {
+		const md = new Markdown("old prefix", 0, 0, defaultMarkdownTheme);
+		md.setStreaming(true);
+		md.render(80);
+		md.setText("new final", { streaming: false });
+		expect(getMarkdownCacheStats().parse.count).toBe(0);
+		expect(renderPlain(md)).toContain("new final");
+		expect(__markdownPerfCounters.lexerInvocations).toBe(2);
+		new Markdown("old prefix", 0, 0, defaultMarkdownTheme).render(80);
+		expect(__markdownPerfCounters.lexerInvocations).toBe(3);
+	});
+
+	it("releases oversized completed tokens rather than retaining hidden reflow reuse", () => {
+		const md = new Markdown("x".repeat(120_000), 0, 0, defaultMarkdownTheme);
+		md.setStreaming(true);
+		md.render(100);
+		md.render(99);
+		expect(__markdownPerfCounters.lexerInvocations).toBe(1);
+		md.setStreaming(false);
+		md.render(99);
+		expect(__markdownPerfCounters.lexerInvocations).toBe(1);
+		expect(getMarkdownCacheStats().parse.count).toBe(0);
+		md.render(98);
+		expect(__markdownPerfCounters.lexerInvocations).toBe(2);
+		md.dispose();
+	});
+
+	it("releases local tokens on whitespace completion and completed L2 hits", () => {
+		for (const final of ["   ", "already cached"]) {
+			clearRenderCache();
+			new Markdown(final, 0, 0, defaultMarkdownTheme).render(80);
+			const md = new Markdown("partial", 0, 0, defaultMarkdownTheme);
+			md.setStreaming(true);
+			md.render(80);
+			md.setText(final, { streaming: false });
+			md.render(80);
+			const calls = __markdownPerfCounters.lexerInvocations;
+			md.setText("partial", { streaming: true });
+			md.invalidate();
+			md.render(80);
+			expect(__markdownPerfCounters.lexerInvocations).toBe(calls + 1);
+			md.dispose();
+		}
+	});
+
+	it("keeps throttle boundaries and parses the latest suffix at the deadline", () => {
+		const md = new Markdown("first", 0, 0, defaultMarkdownTheme);
+		md.setStreaming(true);
+		const initial = md.render(80);
+		for (const offset of [0, 16, 63]) {
+			now = 1_000_000 + offset;
+			md.setText(`suffix ${offset}`);
+			expect(md.render(80)).toEqual(initial);
+		}
+		now = 1_000_064;
+		expect(renderPlain(md)).toContain("suffix 63");
+		expect(__markdownPerfCounters.lexerInvocations).toBe(2);
+		now++;
+		md.setText("unparsed final", { streaming: false });
+		expect(renderPlain(md)).toContain("unparsed final");
+		expect(__markdownPerfCounters.lexerInvocations).toBe(3);
+	});
+
+	it("delivers the owner timer at the original deadline despite more updates", () => {
+		vi.useFakeTimers();
+		const md = new Markdown("initial", 0, 0, defaultMarkdownTheme);
+		const delivered: string[] = [];
+		md.setOnStaleThrottle(() => delivered.push(renderPlain(md)));
+		md.setStreaming(true);
+		const advance = (ms: number) => {
+			now += ms;
+			vi.advanceTimersByTime(ms);
+		};
+		try {
+			md.render(80);
+			advance(16);
+			md.setText("middle");
+			md.render(80); // Arms one timer for the remaining 48ms.
+			advance(47);
+			md.setText("latest suffix");
+			md.render(80); // Must not move the already armed deadline.
+			expect(delivered).toEqual([]);
+			advance(1);
+			expect(delivered).toHaveLength(1);
+			expect(delivered[0]).toContain("latest suffix");
+			expect(__markdownPerfCounters.lexerInvocations).toBe(2);
+			advance(65);
+			expect(delivered).toHaveLength(1);
+		} finally {
+			md.dispose();
+		}
+	});
+
+	for (const boundary of ["complete", "dispose"] as const) {
+		it(`cancels an armed owner timer on ${boundary}`, () => {
+			vi.useFakeTimers();
+			const md = new Markdown("initial", 0, 0, defaultMarkdownTheme);
+			const callback = vi.fn();
+			md.setOnStaleThrottle(callback);
+			md.setStreaming(true);
+			try {
+				md.render(80);
+				now += 16;
+				vi.advanceTimersByTime(16);
+				md.setText("pending suffix");
+				md.render(80);
+				if (boundary === "complete") {
+					md.setText("authoritative final", { streaming: false });
+					expect(renderPlain(md)).toContain("authoritative final");
+				} else md.dispose();
+				now += 1000;
+				vi.advanceTimersByTime(1000);
+				expect(callback).not.toHaveBeenCalled();
+			} finally {
+				md.dispose();
+			}
+		});
+	}
+
+	it("rejects colliding global parse hits independently of render-cache hits", () => {
+		vi.spyOn(Bun, "hash").mockReturnValue(1n);
+		new Markdown("alpha", 0, 0, defaultMarkdownTheme).render(80);
+		const md = new Markdown("bravo", 0, 0, defaultMarkdownTheme);
+		md.setStreaming(true);
+		expect(renderPlain(md, 40)).toContain("bravo");
+		expect(__markdownPerfCounters.lexerInvocations).toBe(2);
+		md.setText("alpha");
+		md.render(30);
+		expect(__markdownPerfCounters.lexerInvocations).toBe(2);
+		md.setText("bravo", { streaming: false });
+		expect(renderPlain(md, 40)).toContain("bravo");
+		expect(__markdownPerfCounters.lexerInvocations).toBe(3);
+	});
+
+	it("matches cold styled lines and anchors for retroactive and Unicode syntax", () => {
+		const cases = [
+			'A [late][ref] link\n\n[ref]: https://example.com "title"\n',
+			"heading\n===\n\n> quote\nlazy continuation\n",
+			"1. item\n   - nested **한글 😀**\n\n\ttext\n",
+			"| A | B |\n|---|---|\n| 漢字 | 😀 |\n",
+			"```ts\nconst x = 1;\n",
+			"```ts\nconst x = 1;\n```\n",
+		];
+		for (const text of cases) {
+			clearRenderCache();
+			const md = new Markdown("", 0, 0, defaultMarkdownTheme);
+			md.setStreaming(true);
+			for (let end = 1; end <= text.length; end += 3) {
+				now += 64;
+				md.setText(text.slice(0, end));
+				md.render(32);
+			}
+			md.setText(text, { streaming: false });
+			const actual = md.renderWithViewportAnchorSource(32, { id: "x" });
+			clearRenderCache();
+			const calls = __markdownPerfCounters.lexerInvocations;
+			const expected = new Markdown(text, 0, 0, defaultMarkdownTheme).renderWithViewportAnchorSource(32, {
+				id: "x",
+			});
+			expect(__markdownPerfCounters.lexerInvocations).toBe(calls + 1);
+			expect(actual).toEqual(expected);
+			md.dispose();
+		}
 	});
 });

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -393,13 +393,15 @@ describe("Markdown accounted cache limits", () => {
 		const source = "```txt\nx\n```";
 		new Markdown(source, 0, 0, theme).render(80);
 		const key = `${themeIdentity(theme)}\x00txt\x00x`;
-		const overhead = 64 + key.length * 2 + accountedPayload([""]);
+		const overhead = 64 + key.length * 2 + accountedPayload({ lang: "txt", code: "x", lines: [""] });
 		expect(getMarkdownCacheStats().highlight.accountedSize).toBe(overhead + 2);
 		const cap = getMarkdownCacheStats().highlight.maxEntrySize;
 		for (const target of [cap - 2, cap, cap + 2]) {
 			clearRenderCache();
 			outputLength = (target - overhead) / 2;
-			expect(64 + key.length * 2 + accountedPayload(["h".repeat(outputLength)])).toBe(target);
+			expect(
+				64 + key.length * 2 + accountedPayload({ lang: "txt", code: "x", lines: ["h".repeat(outputLength)] }),
+			).toBe(target);
 			const md = new Markdown(source, 0, 0, theme);
 			md.setStreaming(true);
 			const lines = md.render(100);
@@ -422,6 +424,26 @@ describe("Markdown accounted cache limits", () => {
 		expect(output).toContain("syntax highlighting skipped");
 		expect(output).not.toContain("CACHED BLOCK SENTINEL");
 		expect(theme.highlightCode).toHaveBeenCalledTimes(1);
+	});
+
+	it("verifies language and code on delimiter-colliding highlight keys", () => {
+		const calls: Array<{ code: string; lang?: string }> = [];
+		const theme = {
+			...defaultMarkdownTheme,
+			highlightCode: (code: string, lang?: string): string[] => {
+				calls.push({ code, lang });
+				return [`${lang ?? "none"}:${code}`];
+			},
+		};
+		const first = new Markdown(`\`\`\`a\nb\x00c\n\`\`\``, 0, 0, theme).render(80).join("\n");
+		const second = new Markdown(`\`\`\`a\x00b\nc\n\`\`\``, 0, 0, theme).render(80).join("\n");
+
+		expect(calls).toEqual([
+			{ code: "b\x00c", lang: "a" },
+			{ code: "c", lang: "a\x00b" },
+		]);
+		expect(first).toContain("a:b\x00c");
+		expect(second).toContain("a\x00b:c");
 	});
 
 	it("evicts by aggregate size before count, retains recent entries and reports the full sum", () => {

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -1,7 +1,18 @@
-import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import { getDefaultTabWidth, setDefaultTabWidth } from "@gajae-code/utils";
 import type { Terminal as XtermTerminalType } from "@xterm/headless";
 import { Chalk } from "chalk";
-import { clearRenderCache, Markdown, renderInlineMarkdown } from "../src/components/markdown.js";
+import { LRUCache } from "lru-cache/raw";
+import { marked } from "marked";
+import {
+	__markdownPerfCounters,
+	clearRenderCache,
+	getMarkdownCacheEntryAccountedSize,
+	getMarkdownCacheStats,
+	getRenderCacheRetainedBytes,
+	Markdown,
+	renderInlineMarkdown,
+} from "../src/components/markdown.js";
 import { TERMINAL } from "../src/terminal-capabilities.js";
 import { type Component, TUI } from "../src/tui.js";
 import { defaultMarkdownTheme } from "./test-themes.js";
@@ -9,6 +20,543 @@ import { VirtualTerminal } from "./virtual-terminal.js";
 
 // Force full color in CI so ANSI assertions are deterministic
 const chalk = new Chalk({ level: 3 });
+
+// Independent full-walk oracle used only on bounded test payloads.
+function accountedPayload(value: unknown, seen = new Set<object>()): number {
+	if (typeof value === "string") return value.length * 2;
+	if (typeof value === "number") return 8;
+	if (typeof value === "boolean") return 4;
+	if (!value || typeof value !== "object" || seen.has(value)) return 0;
+	seen.add(value);
+	const array = Array.isArray(value);
+	let size = array ? 24 + value.length * 8 : 32;
+	for (const [key, item] of Object.entries(value)) {
+		const index = Number(key);
+		const slot = array && Number.isInteger(index) && index >= 0 && index < 0xffffffff && String(index) === key;
+		if (!slot) size += 16 + key.length * 2;
+		size += accountedPayload(item, seen);
+	}
+	return size;
+}
+
+// Theme identity is metadata on the supplied object, not a cache entry or size.
+// Build the complete production key independently so omitted key charges fail.
+function themeIdentity(theme: object): number {
+	const symbol = Object.getOwnPropertySymbols(theme).find(key => key.description === "markdown.objectId");
+	expect(symbol).toBeDefined();
+	return Object.getOwnPropertyDescriptor(theme, symbol!)!.value as number;
+}
+
+function singleTextRenderSize(width: number): number {
+	const key = `1:1\x00${width}\x000\x000\x002\x00${themeIdentity(defaultMarkdownTheme)}\x00-1\x00${TERMINAL.imageProtocol ?? ""}\x00${TERMINAL.hyperlinks ? 1 : 0}\x00\x00${defaultMarkdownTheme.heading("")}`;
+	return 64 + key.length * 2 + accountedPayload({ source: "x", lines: ["x".padEnd(width)] });
+}
+
+describe("Markdown accounted cache limits", () => {
+	beforeEach(() => {
+		clearRenderCache();
+		__markdownPerfCounters.reset();
+	});
+	afterEach(() => {
+		vi.restoreAllMocks();
+		clearRenderCache();
+	});
+
+	it("does not reinsert verified parse hits but republishes after eviction", () => {
+		const sets = vi.spyOn(LRUCache.prototype, "set");
+		const parseWrites = () =>
+			sets.mock.calls.filter(([, value]) => {
+				return value !== null && typeof value === "object" && "tokens" in value;
+			}).length;
+		const md = new Markdown("- **one**\n- [two](https://example.com)\n", 0, 0, defaultMarkdownTheme);
+		md.render(80);
+		expect(parseWrites()).toBe(1);
+		md.render(40);
+		md.renderWithViewportAnchorSource(30, { id: "same-source" });
+		expect(parseWrites()).toBe(1);
+		expect(__markdownPerfCounters.lexerInvocations).toBe(1);
+		clearRenderCache();
+		md.render(20);
+		expect(parseWrites()).toBe(2);
+		expect(__markdownPerfCounters.lexerInvocations).toBe(2);
+	});
+
+	it("reuses verified prior content after a failed new-source render", () => {
+		let fail = false;
+		const theme = {
+			...defaultMarkdownTheme,
+			heading: (text: string) => {
+				if (fail) throw new Error("test heading failure");
+				return defaultMarkdownTheme.heading(text);
+			},
+		};
+		const md = new Markdown("original source", 0, 0, theme);
+		md.render(80);
+		expect(__markdownPerfCounters.lexerInvocations).toBe(1);
+		fail = true;
+		md.setText("uncommitted source", { streaming: true });
+		expect(() => md.render(79)).toThrow("test heading failure");
+		fail = false;
+		md.setText("original source", { streaming: true });
+		expect(md.render(78).join("\n")).toContain("original source");
+		expect(__markdownPerfCounters.lexerInvocations).toBe(1);
+		md.dispose();
+	});
+
+	it("does not recount repeated oversized admissions or retain completed tokens", () => {
+		const sets = vi.spyOn(LRUCache.prototype, "set");
+		const parseWrites = () =>
+			sets.mock.calls.filter(([, value]) => value !== null && typeof value === "object" && "tokens" in value).length;
+		const oversized = "x".repeat(120_000);
+		const md = new Markdown(oversized, 0, 0, defaultMarkdownTheme);
+		md.render(80);
+		expect(parseWrites()).toBe(1);
+		expect(getMarkdownCacheStats().parse.count).toBe(0);
+		md.render(79);
+		md.render(78);
+		expect(parseWrites()).toBe(1);
+		expect(__markdownPerfCounters.lexerInvocations).toBe(3);
+		md.setText("small eligible text");
+		md.render(80);
+		expect(parseWrites()).toBe(2);
+		expect(getMarkdownCacheStats().parse.count).toBe(1);
+		md.setText(oversized);
+		md.render(77);
+		expect(parseWrites()).toBe(3);
+		md.dispose();
+		clearRenderCache();
+		md.invalidate();
+		md.render(76);
+		expect(parseWrites()).toBe(4);
+	});
+
+	it("retries rejected admission when tab normalization changes without changing raw text", () => {
+		const tabWidth = getDefaultTabWidth();
+		const md = new Markdown("x\t".repeat(20_000), 0, 0, defaultMarkdownTheme);
+		try {
+			setDefaultTabWidth(8);
+			md.render(80);
+			expect(getMarkdownCacheStats().parse.count).toBe(0);
+			setDefaultTabWidth(1);
+			md.render(79);
+			expect(getMarkdownCacheStats().parse.count).toBe(1);
+			const calls = __markdownPerfCounters.lexerInvocations;
+			md.render(78);
+			expect(__markdownPerfCounters.lexerInvocations).toBe(calls);
+			setDefaultTabWidth(8);
+			md.render(77);
+			expect(__markdownPerfCounters.lexerInvocations).toBe(calls + 1);
+			setDefaultTabWidth(1);
+			md.render(76);
+			expect(__markdownPerfCounters.lexerInvocations).toBe(calls + 1);
+		} finally {
+			md.dispose();
+			setDefaultTabWidth(tabWidth);
+		}
+	});
+
+	it("clears a rejected key when new raw text collides but is eligible", () => {
+		vi.spyOn(Bun, "hash").mockReturnValue(1n);
+		const md = new Markdown("x".repeat(120_000), 0, 0, defaultMarkdownTheme);
+		md.render(80);
+		expect(getMarkdownCacheStats().parse.count).toBe(0);
+		md.setText(`<!--${"y".repeat(119_993)}-->`);
+		md.render(79);
+		expect(getMarkdownCacheStats().parse.count).toBe(1);
+		md.dispose();
+	});
+
+	it("preserves oversized same-key replacement after another component inserts a collision", () => {
+		vi.spyOn(Bun, "hash").mockReturnValue(1n);
+		const md = new Markdown("x".repeat(120_000), 0, 0, defaultMarkdownTheme);
+		md.render(80);
+		md.render(79);
+		expect(getMarkdownCacheStats().parse.count).toBe(0);
+		const colliding = `<!--${"y".repeat(119_993)}-->`;
+		new Markdown(colliding, 0, 0, defaultMarkdownTheme).render(80);
+		expect(getMarkdownCacheStats().parse.count).toBe(1);
+		md.render(78);
+		expect(getMarkdownCacheStats().parse.count).toBe(0);
+		md.dispose();
+	});
+
+	it("matches independent graph totals for every constructed render payload", () => {
+		const sets = vi.spyOn(LRUCache.prototype, "set");
+		for (const source of [
+			"# Heading\n\nparagraph **bold**",
+			"- one\n- two",
+			"| A | B |\n|---|---|\n| 漢字 | 😀 |",
+			"```ts\nconst a = 1;\n```",
+			"---\n\n> quote",
+		]) {
+			for (const width of [1, 20, 80]) {
+				const md = new Markdown(source, 1, 1, defaultMarkdownTheme, { bgColor: text => `\x1b[44m${text}\x1b[0m` });
+				md.render(width);
+				md.renderWithViewportAnchorSource(width, { id: "schema" });
+				md.dispose();
+			}
+		}
+		let renderWrites = 0;
+		for (const [index, [key, value]] of sets.mock.calls.entries()) {
+			if (typeof value !== "object" || value === null || !("source" in value) || !("lines" in value)) continue;
+			const cache = sets.mock.contexts[index] as LRUCache<string, object>;
+			const exact = 64 + String(key).length * 2 + accountedPayload(value);
+			expect(cache.sizeCalculation!(value, String(key))).toBe(Math.min(exact, cache.maxEntrySize + 1));
+			renderWrites++;
+		}
+		expect(renderWrites).toBe(30);
+	});
+
+	it("preserves graph accounting for seeded shared cyclic and sparse payloads", () => {
+		let seed = 0x51a7;
+		const random = () => {
+			seed ^= seed << 13;
+			seed ^= seed >>> 17;
+			seed ^= seed << 5;
+			return seed >>> 0;
+		};
+		for (let sample = 0; sample < 100; sample++) {
+			const graph: object[] = [];
+			for (let i = 0; i < 20; i++) graph.push(i % 3 === 0 ? new Array(3) : {});
+			for (const node of graph) {
+				for (const key of ["0", "2", "01", "links", "text", "missing"]) {
+					const pick = random() % 6;
+					const value =
+						pick === 0
+							? graph[random() % graph.length]
+							: pick === 1
+								? "漢😀\x1b[31m".repeat(random() % 9)
+								: pick === 2
+									? random()
+									: pick === 3
+										? true
+										: pick === 4
+											? null
+											: undefined;
+					Object.defineProperty(node, key, { value, enumerable: key !== "missing", configurable: true });
+				}
+			}
+			const key = `fixture-${sample}`;
+			const exact = 64 + key.length * 2 + accountedPayload(graph);
+			for (const cap of [exact - 2, exact, exact + 2, 128]) {
+				expect(getMarkdownCacheEntryAccountedSize(key, graph, cap)).toBe(exact > cap ? cap + 1 : exact);
+			}
+		}
+	});
+
+	it("accounts Unicode, ANSI, sparse/custom arrays, nested tokens and repeated references", () => {
+		const shared = { text: "漢😀\x1b[31mx\x1b[0m", flag: true, n: 7, absent: undefined };
+		const array = Object.assign([shared, null, shared], { links: { ref: shared }, "01": "custom" });
+		const value = {
+			source: "漢😀",
+			array,
+			tokens: marked.lexer('[a][r]\n\n[r]: https://example.com "title"'),
+			anchors: [null, { cellStart: 0, cellEnd: 3 }],
+		};
+		const key = "key\x00😀";
+		const exact = 64 + key.length * 2 + accountedPayload(value);
+		expect(getMarkdownCacheEntryAccountedSize(key, value, exact)).toBe(exact);
+		expect(getMarkdownCacheEntryAccountedSize(key, value, exact - 2)).toBe(exact - 1);
+		expect(getMarkdownCacheEntryAccountedSize("", [null, undefined], 1000)).toBe(64 + 24 + 16);
+		const cycle: { self?: object; text: string } = { text: "a" };
+		cycle.self = cycle;
+		expect(getMarkdownCacheEntryAccountedSize("", cycle, 1000)).toBe(64 + accountedPayload(cycle));
+	});
+
+	it("cuts off deep and enormous payloads without recursive traversal or serialization", () => {
+		let deep: object = { text: "leaf" };
+		for (let i = 0; i < 20_000; i++) deep = { child: deep };
+		expect(getMarkdownCacheEntryAccountedSize("", deep, 1024)).toBe(1025);
+		expect(getMarkdownCacheEntryAccountedSize("", new Array(1_000_000), 1024)).toBe(1025);
+		expect(getMarkdownCacheEntryAccountedSize("x".repeat(1000), null, 1024)).toBe(1025);
+	});
+
+	it("accounts admitted deep and widely shared graphs with bounded traversal", () => {
+		let deep: unknown = null;
+		for (let i = 0; i < 10_000; i++) deep = { child: deep };
+		const deepSize = 64 + 10_000 * (32 + 16 + "child".length * 2);
+		expect(getMarkdownCacheEntryAccountedSize("", deep, deepSize)).toBe(deepSize);
+		const shared = { value: true };
+		const wide = Object.assign(new Array(100_000).fill(shared), { links: shared });
+		const wideSize = 64 + 24 + 100_000 * 8 + 16 + "links".length * 2 + 32 + 16 + "value".length * 2 + 4;
+		expect(getMarkdownCacheEntryAccountedSize("", wide, wideSize)).toBe(wideSize);
+		expect(getMarkdownCacheEntryAccountedSize("", wide, wideSize - 2)).toBe(wideSize - 1);
+	});
+
+	it("rejects oversized array slots before enumerating their properties", () => {
+		const oversized = new Proxy(new Array(200_000), {
+			ownKeys: () => {
+				throw new Error("oversized array must not be enumerated");
+			},
+		});
+		expect(getMarkdownCacheEntryAccountedSize("", oversized, 1024)).toBe(1025);
+	});
+
+	it("charges noncanonical and uint32-limit array properties as named properties", () => {
+		const array: unknown[] = [];
+		for (const key of ["0", "00", "-0", "-1", "1.0", "1e0", "NaN", "Infinity", "4294967295", "4294967296"]) {
+			Object.defineProperty(array, key, { value: "漢", enumerable: true });
+		}
+		const exact = 64 + accountedPayload(array);
+		expect(getMarkdownCacheEntryAccountedSize("", array, exact)).toBe(exact);
+		expect(getMarkdownCacheEntryAccountedSize("", array, exact - 2)).toBe(exact - 1);
+	});
+
+	it("admits exact parse cap boundaries with independently calculated token graphs", () => {
+		vi.spyOn(Bun, "hash").mockReturnValue(1n);
+		const cap = getMarkdownCacheStats().parse.maxEntrySize;
+		for (const target of [cap - 2, cap, cap + 2]) {
+			let fixture: string | undefined;
+			// A paragraph adds ten accounted bytes per ASCII unit; newline suffixes
+			// change source/raw independently, yielding the attainable even boundaries.
+			for (const suffix of ["", "\n", "\n\n", "\n\n\n", "\n\n\n\n", "\n\n\n\n\n"]) {
+				const sample = "x".repeat(100_000) + suffix;
+				const sampleSize =
+					64 +
+					`${sample.length}:1`.length * 2 +
+					accountedPayload({ source: sample, tokens: marked.lexer(sample) });
+				const growth = (target - sampleSize) / 10;
+				if (!Number.isInteger(growth)) continue;
+				fixture = "x".repeat(100_000 + growth) + suffix;
+				expect(
+					64 +
+						`${fixture.length}:1`.length * 2 +
+						accountedPayload({ source: fixture, tokens: marked.lexer(fixture) }),
+				).toBe(target);
+				break;
+			}
+			expect(fixture, `fixture for ${target}`).toBeDefined();
+			clearRenderCache();
+			const md = new Markdown(fixture!, 0, 0, defaultMarkdownTheme);
+			const lines = md.render(100);
+			expect(getMarkdownCacheStats().parse.accountedSize).toBe(target <= cap ? target : 0);
+			expect(getMarkdownCacheStats().parse.count).toBe(target <= cap ? 1 : 0);
+			const before = __markdownPerfCounters.lexerInvocations;
+			md.render(99);
+			expect(__markdownPerfCounters.lexerInvocations).toBe(before + (target > cap ? 1 : 0));
+			clearRenderCache();
+			expect(new Markdown(fixture!, 0, 0, defaultMarkdownTheme).render(100)).toEqual(lines);
+		}
+	});
+
+	it("enforces render entry boundaries and recounts anchor enrichment", () => {
+		vi.spyOn(Bun, "hash").mockReturnValue(1n);
+		const md = new Markdown("x", 0, 0, defaultMarkdownTheme);
+		md.render(500_000);
+		const cap = getMarkdownCacheStats().render.maxEntrySize;
+		expect(getMarkdownCacheStats().render.accountedSize).toBe(singleTextRenderSize(500_000));
+		const overhead = singleTextRenderSize(500_000) - 1_000_000;
+		for (const target of [cap - 2, cap, cap + 2]) {
+			clearRenderCache();
+			const width = (target - overhead) / 2;
+			expect(singleTextRenderSize(width)).toBe(target);
+			const output = new Markdown("x", 0, 0, defaultMarkdownTheme).render(width);
+			expect(output[0].length).toBe(width);
+			expect(getMarkdownCacheStats().render.accountedSize).toBe(target <= cap ? target : 0);
+		}
+		clearRenderCache();
+		md.invalidate();
+		md.render(80);
+		const before = getMarkdownCacheStats().render.accountedSize;
+		md.renderWithViewportAnchorSource(80, { id: "x" });
+		const after = getMarkdownCacheStats().render.accountedSize;
+		expect(before).toBe(singleTextRenderSize(80));
+		const anchorPayload = [{ graphemeStart: 0, graphemeEnd: 65536, cellStart: 0, cellEnd: 65536 }];
+		expect(after - before).toBe(16 + "anchorSpans".length * 2 + accountedPayload(anchorPayload));
+		expect(getMarkdownCacheStats().render.count).toBe(1);
+		md.invalidate();
+		md.renderWithViewportAnchorSource(80, { id: "x" });
+		expect(getMarkdownCacheStats().render.accountedSize).toBe(after);
+	});
+
+	it("rejects oversized same-key anchor replacements without evicting unrelated entries", () => {
+		vi.spyOn(Bun, "hash").mockReturnValue(1n);
+		const md = new Markdown("x", 0, 0, defaultMarkdownTheme);
+		md.render(500_000);
+		const stats = getMarkdownCacheStats().render;
+		const width = (stats.maxEntrySize - (singleTextRenderSize(500_000) - 1_000_000)) / 2;
+		clearRenderCache();
+		md.render(width);
+		new Markdown("survivor", 0, 0, defaultMarkdownTheme).render(80);
+		expect(getMarkdownCacheStats().render.count).toBe(2);
+		md.renderWithViewportAnchorSource(width, { id: "x" });
+		// Installed lru-cache deletes the old same-key entry on oversized replacement.
+		expect(getMarkdownCacheStats().render.count).toBe(1);
+		const calls = __markdownPerfCounters.lexerInvocations;
+		new Markdown("survivor", 0, 0, defaultMarkdownTheme).render(80);
+		expect(__markdownPerfCounters.lexerInvocations).toBe(calls);
+	});
+
+	it("bounds source-bearing highlight keys/output at the exact entry limit", () => {
+		let outputLength = 1;
+		const theme = { ...defaultMarkdownTheme, highlightCode: vi.fn(() => ["h".repeat(outputLength)]) };
+		const source = "```txt\nx\n```";
+		new Markdown(source, 0, 0, theme).render(80);
+		const key = `${themeIdentity(theme)}\x00txt\x00x`;
+		const overhead = 64 + key.length * 2 + accountedPayload([""]);
+		expect(getMarkdownCacheStats().highlight.accountedSize).toBe(overhead + 2);
+		const cap = getMarkdownCacheStats().highlight.maxEntrySize;
+		for (const target of [cap - 2, cap, cap + 2]) {
+			clearRenderCache();
+			outputLength = (target - overhead) / 2;
+			expect(64 + key.length * 2 + accountedPayload(["h".repeat(outputLength)])).toBe(target);
+			const md = new Markdown(source, 0, 0, theme);
+			md.setStreaming(true);
+			const lines = md.render(100);
+			expect(getMarkdownCacheStats().highlight.accountedSize).toBe(target <= cap ? target : 0);
+			const calls = theme.highlightCode.mock.calls.length;
+			md.render(99);
+			expect(theme.highlightCode.mock.calls.length).toBe(calls + (target > cap ? 1 : 0));
+			clearRenderCache();
+			expect(new Markdown(source, 0, 0, theme).render(100)).toEqual(lines);
+			md.dispose();
+		}
+	});
+
+	it("enforces UTF8 caps before a language/code key alias can reuse a cached block", () => {
+		const unicode = "漢".repeat(70_000);
+		const theme = { ...defaultMarkdownTheme, highlightCode: vi.fn(() => ["CACHED BLOCK SENTINEL"]) };
+		new Markdown(`\`\`\`ts\x00${unicode}\nsmall\n\`\`\``, 0, 0, theme).render(80);
+		expect(theme.highlightCode).toHaveBeenCalledTimes(1);
+		const output = new Markdown(`\`\`\`ts\n${unicode}\x00small\n\`\`\``, 0, 0, theme).render(80).join("\n");
+		expect(output).toContain("syntax highlighting skipped");
+		expect(output).not.toContain("CACHED BLOCK SENTINEL");
+		expect(theme.highlightCode).toHaveBeenCalledTimes(1);
+	});
+
+	it("evicts by aggregate size before count, retains recent entries and reports the full sum", () => {
+		const sources = Array.from({ length: 24 }, (_, i) => `message ${i} ${"x".repeat(70_000)}`);
+		for (const source of sources) {
+			new Markdown(source, 0, 0, defaultMarkdownTheme).render(100);
+			const stats = getMarkdownCacheStats();
+			for (const cache of Object.values(stats)) {
+				expect(cache.accountedSize).toBeLessThanOrEqual(cache.maxSize);
+				expect(cache.count).toBeLessThanOrEqual(cache.max);
+			}
+			expect(getRenderCacheRetainedBytes()).toBe(
+				Object.values(stats).reduce((sum, cache) => sum + cache.accountedSize, 0),
+			);
+		}
+		expect(getMarkdownCacheStats().parse.count).toBeLessThan(sources.length);
+		let calls = __markdownPerfCounters.lexerInvocations;
+		new Markdown(sources.at(-1)!, 0, 0, defaultMarkdownTheme).render(99);
+		expect(__markdownPerfCounters.lexerInvocations).toBe(calls);
+		new Markdown(sources[0], 0, 0, defaultMarkdownTheme).render(99);
+		expect(__markdownPerfCounters.lexerInvocations).toBe(calls + 1);
+		calls = __markdownPerfCounters.lexerInvocations;
+		new Markdown(sources.at(-1)!, 0, 0, defaultMarkdownTheme).render(98);
+		expect(__markdownPerfCounters.lexerInvocations).toBe(calls);
+		clearRenderCache();
+		expect(getRenderCacheRetainedBytes()).toBe(0);
+	});
+
+	it("evicts render payloads by size with LRU touch before reaching the count cap", () => {
+		const sources = Array.from({ length: 20 }, (_, i) => `row-${String(i).padStart(2, "0")}`);
+		const lines = sources.map(source => new Markdown(source, 0, 0, defaultMarkdownTheme).render(200_000));
+		expect(getMarkdownCacheStats().render.count).toBe(20);
+		expect(new Markdown(sources[0], 0, 0, defaultMarkdownTheme).render(200_000)).toBe(lines[0]);
+		new Markdown("row-20", 0, 0, defaultMarkdownTheme).render(200_000);
+		expect(getMarkdownCacheStats().render.count).toBe(20);
+		expect(getMarkdownCacheStats().render.accountedSize).toBeLessThanOrEqual(8 * 1024 * 1024);
+		expect(new Markdown(sources[0], 0, 0, defaultMarkdownTheme).render(200_000)).toBe(lines[0]);
+		expect(new Markdown(sources[1], 0, 0, defaultMarkdownTheme).render(200_000)).not.toBe(lines[1]);
+	});
+
+	it("evicts highlight payloads by size while keeping the touched block reusable", () => {
+		const theme = { ...defaultMarkdownTheme, highlightCode: vi.fn(() => ["h".repeat(220_000)]) };
+		const render = (n: number) => {
+			const md = new Markdown(`\`\`\`txt\ncode-${n}\n\`\`\``, 0, 0, theme);
+			md.setStreaming(true);
+			md.render(100);
+			md.dispose();
+		};
+		for (let i = 0; i < 9; i++) render(i);
+		expect(getMarkdownCacheStats().highlight.count).toBe(9);
+		render(0);
+		expect(theme.highlightCode).toHaveBeenCalledTimes(9);
+		render(9);
+		expect(getMarkdownCacheStats().highlight.count).toBe(9);
+		expect(getMarkdownCacheStats().highlight.accountedSize).toBeLessThanOrEqual(4 * 1024 * 1024);
+		render(0);
+		expect(theme.highlightCode).toHaveBeenCalledTimes(10);
+		render(1);
+		expect(theme.highlightCode).toHaveBeenCalledTimes(11);
+	});
+
+	it("keeps count caps alongside byte budgets for small documents and blocks", () => {
+		const theme = { ...defaultMarkdownTheme, highlightCode: (code: string) => [code] };
+		for (let i = 0; i < 520; i++) new Markdown(`\`\`\`txt\n${i}\n\`\`\``, 0, 0, theme).render(40);
+		const stats = getMarkdownCacheStats();
+		expect(stats.render.count).toBe(256);
+		expect(stats.parse.count).toBe(128);
+		expect(stats.highlight.count).toBe(512);
+		for (const cache of Object.values(stats)) expect(cache.accountedSize).toBeLessThan(cache.maxSize);
+	});
+
+	it("renders streaming completion and resize through the terminal pipeline", async () => {
+		const terminal = new VirtualTerminal(60, 12);
+		const ui = new TUI(terminal);
+		const md = new Markdown("# Streaming preview\n\npartial body", 0, 0, defaultMarkdownTheme);
+		const actions: Array<{ type: string; selector: string; timestamp: string; description: string }> = [];
+		const record = (description: string) =>
+			actions.push({ type: "custom", selector: "tui.markdown", timestamp: new Date().toISOString(), description });
+		md.setStreaming(true);
+		ui.addChild(md);
+		try {
+			ui.start();
+			await terminal.waitForRender();
+			expect(terminal.getViewport().join("\n")).toContain("Streaming preview");
+			expect(getMarkdownCacheStats().parse.count).toBe(0);
+			record(
+				"Started real TUI renderer on xterm headless; streaming text visible with zero shared document admissions",
+			);
+			md.setText("# Final document\n\n**Completed** 漢字 😀\n\n- final item", { streaming: false });
+			ui.requestRender(true);
+			await terminal.waitForRender();
+			const finalViewport = terminal.getViewport().join("\n");
+			expect(finalViewport).toContain("Final document");
+			expect(finalViewport).toContain("Completed");
+			expect(finalViewport).not.toContain("partial body");
+			expect(getMarkdownCacheStats().parse.count).toBe(1);
+			record("Completed with authoritative replacement text; old prefix absent and final parse admitted");
+			const calls = __markdownPerfCounters.lexerInvocations;
+			terminal.resize(40, 12);
+			await terminal.waitForRender();
+			expect(terminal.getViewport().join("\n")).toContain("Completed");
+			expect(__markdownPerfCounters.lexerInvocations).toBe(calls);
+			record("Resized terminal to 40 columns; completed content visible without relexing");
+			if (process.env.GJC_MARKDOWN_TUI_REPORT) {
+				await Bun.write(
+					process.env.GJC_MARKDOWN_TUI_REPORT,
+					JSON.stringify(
+						{
+							schemaVersion: 1,
+							surface: "tui",
+							tool: "bun:test + TUI + @xterm/headless VirtualTerminal",
+							actions,
+							assertions: [
+								{
+									selector: "tui.markdown",
+									status: "passed",
+									timestamp: new Date().toISOString(),
+									description:
+										"Streaming admission, authoritative completion, stale-prefix removal and resize reuse assertions passed",
+								},
+							],
+							viewport: terminal.getViewport(),
+							terminalWrites: terminal.getWriteLog(),
+						},
+						null,
+						2,
+					),
+				);
+			}
+		} finally {
+			md.dispose();
+			ui.stop();
+		}
+	});
+});
 
 function getCellItalic(terminal: VirtualTerminal, row: number, col: number): number {
 	const xterm = (terminal as unknown as { xterm: XtermTerminalType }).xterm;

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -337,7 +337,7 @@ describe("Markdown accounted cache limits", () => {
 			clearRenderCache();
 			expect(new Markdown(fixture!, 0, 0, defaultMarkdownTheme).render(100)).toEqual(lines);
 		}
-	});
+	}, 15_000);
 
 	it("enforces render entry boundaries and recounts anchor enrichment", () => {
 		vi.spyOn(Bun, "hash").mockReturnValue(1n);

--- a/packages/tui/test/perf-baselines.test.ts
+++ b/packages/tui/test/perf-baselines.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { __animationSchedulerTestHooks } from "@gajae-code/tui";
 import { __editorPerfCounters, Editor } from "@gajae-code/tui/components/editor";
 import { __loaderPerfCounters, Loader } from "@gajae-code/tui/components/loader";
+import * as markdownCache from "@gajae-code/tui/components/markdown";
 import { __markdownPerfCounters, clearRenderCache, Markdown } from "@gajae-code/tui/components/markdown";
 import { renderMetrics } from "@gajae-code/tui/metrics";
 import { __textHelperPerfCounters } from "@gajae-code/tui/utils";
@@ -37,22 +38,152 @@ describe("advisory performance baselines", () => {
 		renderMetrics.reset();
 	});
 
-	it("records markdown lexer invocations and lexed bytes during long streaming renders", () => {
-		const markdown = new Markdown("", 0, 0, defaultMarkdownTheme);
-		let content = "";
-		for (let i = 0; i < 48; i++) {
-			content += `## streamed heading ${i}\n\n- token **${i}** with \`inline code\` and [link](https://example.com/${i})\n\n`;
-			markdown.setText(content);
-			const lines = markdown.render(96);
-			expect(lines.length).toBeGreaterThan(0);
+	it("records markdown actual-streaming retention and completed-revisit tradeoffs", async () => {
+		const reports = [];
+		const theme = {
+			...defaultMarkdownTheme,
+			highlightCode: (code: string) => code.split("\n").map(line => `\x1b[36m${line}\x1b[0m`),
+		};
+		const stats = markdownCache.getMarkdownCacheStats;
+		try {
+			for (const fixture of ["ascii", "growing-fence", "completed-revisit"]) {
+				for (const cadence of [16, 64]) {
+					for (let repetition = -1; repetition < 5; repetition++) {
+						clearRenderCache();
+						__markdownPerfCounters.reset();
+						let now = 1_000_000;
+						markdownCache.__setMarkdownNowForTest(() => now);
+						Bun.gc(true);
+						const before = process.memoryUsage();
+						let md: Markdown | undefined = new Markdown("", 0, 0, theme);
+						md.setStreaming(true);
+						let content = fixture === "growing-fence" ? "```ts\n" : "";
+						const peaks = stats();
+						const sample = () => {
+							const snapshot = stats();
+							for (const name of ["render", "parse", "highlight"] as const) {
+								peaks[name].count = Math.max(peaks[name].count, snapshot[name].count);
+								peaks[name].accountedSize = Math.max(peaks[name].accountedSize, snapshot[name].accountedSize);
+							}
+							return snapshot;
+						};
+						const start = performance.now();
+						for (let i = 0; i < 128; i++) {
+							now += cadence;
+							content +=
+								fixture === "growing-fence"
+									? `const value${i} = "${"x".repeat(500)}";\n`
+									: `${i}: ${"word ".repeat(108)}\n`;
+							md.setText(content);
+							md.render(96);
+							const snapshot = sample();
+							expect(snapshot.render.count).toBe(0);
+							expect(snapshot.parse.count).toBe(0);
+						}
+						const preFinal = sample();
+						if (fixture === "growing-fence") content += "```\n";
+						md.setText(content, { streaming: false });
+						const final = md.renderWithViewportAnchorSource(96, { id: "message" });
+						const postFinal = sample();
+						const workloadCalls = __markdownPerfCounters.lexerInvocations;
+						const normalizedCodeUnits = __markdownPerfCounters.lexedBytes;
+						if (fixture === "completed-revisit") {
+							for (let i = 0; i < 24; i++) {
+								new Markdown(`revisit ${i}\n${content}`, 0, 0, theme).render(96);
+								sample();
+							}
+						}
+						const afterPressure = sample();
+						const beforeWarm = __markdownPerfCounters.lexerInvocations;
+						const unitsBeforeWarm = __markdownPerfCounters.lexedBytes;
+						let warm: Markdown | undefined = new Markdown(content, 0, 0, theme);
+						const revisited = warm.renderWithViewportAnchorSource(96, { id: "message" });
+						const sameWidthLexers = __markdownPerfCounters.lexerInvocations - beforeWarm;
+						const sameWidthUnits = __markdownPerfCounters.lexedBytes - unitsBeforeWarm;
+						expect(revisited.lines).toBe(final.lines); // Original render survived pressure.
+						expect(sameWidthLexers).toBe(0);
+						expect(sameWidthUnits).toBe(0);
+						sample();
+						warm.render(95);
+						const warmLexers = __markdownPerfCounters.lexerInvocations - beforeWarm;
+						const reflowLexers = warmLexers - sameWidthLexers;
+						const reflowUnits = __markdownPerfCounters.lexedBytes - unitsBeforeWarm - sameWidthUnits;
+						const expectedReflowLexers = fixture === "completed-revisit" ? 1 : 0;
+						expect(reflowLexers).toBe(expectedReflowLexers);
+						expect(reflowUnits).toBe(expectedReflowLexers * content.length);
+						expect(revisited).toEqual(final);
+						const elapsedMs = performance.now() - start;
+						Bun.gc(true);
+						const live = process.memoryUsage();
+						const retained = sample();
+						md.dispose();
+						md = undefined;
+						warm.dispose();
+						warm = undefined;
+						Bun.gc(true);
+						const released = process.memoryUsage();
+						const report = {
+							fixture,
+							context: {
+								bun: Bun.version,
+								platform: process.platform,
+								arch: process.arch,
+								theme: "defaultMarkdownTheme + deterministic cyan line highlighter",
+								width: 96,
+								reflowWidth: 95,
+								updates: 128,
+								fixtureIdentity: "new deterministic fixture; non-identical to prior 70034-unit research",
+								accounting: "UTF16 retained payload; not heap/RSS",
+								peakScope: "streaming + completion + pressure + warm reflow; excludes oracle",
+							},
+							cadence,
+							repetition,
+							finalHash: Bun.hash(JSON.stringify(final)).toString(16),
+							fixtureUtf8Bytes: Buffer.byteLength(content),
+							workloadCalls,
+							normalizedCodeUnits,
+							warmLexers,
+							sameWidthLexers,
+							sameWidthUnits,
+							reflowLexers,
+							reflowUnits,
+							pressureClassification:
+								fixture === "completed-revisit"
+									? "render survived; parse evicted by size, one reflow miss"
+									: "fit-budget completed reuse",
+							peaks,
+							preFinal,
+							postFinal,
+							afterPressure,
+							retained,
+							elapsedMs,
+							heapLiveDelta: live.heapUsed - before.heapUsed,
+							rssLiveDelta: live.rss - before.rss,
+							heapAfterDisposeDelta: released.heapUsed - before.heapUsed,
+							rssAfterDisposeDelta: released.rss - before.rss,
+						};
+						// A fresh component alone is not a cold oracle. Exclude oracle work
+						// from the workload and warm counters above.
+						clearRenderCache();
+						const beforeOracle = __markdownPerfCounters.lexerInvocations;
+						const oracle = new Markdown(content, 0, 0, theme).renderWithViewportAnchorSource(96, {
+							id: "message",
+						});
+						expect(__markdownPerfCounters.lexerInvocations).toBe(beforeOracle + 1);
+						expect(final).toEqual(oracle);
+						if (repetition >= 0) reports.push(report);
+					}
+				}
+			}
+		} finally {
+			markdownCache.__setMarkdownNowForTest(undefined);
 		}
-
+		if (process.env.GJC_MARKDOWN_REPORT)
+			await Bun.write(process.env.GJC_MARKDOWN_REPORT, JSON.stringify(reports, null, 2));
 		console.log(
-			`[perf-baseline] markdown streaming lexerInvocations=${__markdownPerfCounters.lexerInvocations} lexedBytes=${__markdownPerfCounters.lexedBytes}`,
+			`[perf-baseline] markdown ${reports.length} repetitions; normalizedCodeUnits are UTF-16 units, accounted bytes are not heap/RSS; baseline selected UTF8 payload is incomparable`,
 		);
-		expectFiniteNonNegative(__markdownPerfCounters.lexerInvocations);
-		expectFiniteNonNegative(__markdownPerfCounters.lexedBytes);
-	});
+	}, 120_000);
 
 	it("records editor relayouts and visibleWidth measurements for a large paste plus cursor-only movement", () => {
 		const editor = new Editor(defaultEditorTheme);

--- a/packages/tui/test/perf-baselines.test.ts
+++ b/packages/tui/test/perf-baselines.test.ts
@@ -48,7 +48,7 @@ describe("advisory performance baselines", () => {
 		try {
 			for (const fixture of ["ascii", "growing-fence", "completed-revisit"]) {
 				for (const cadence of [16, 64]) {
-					for (let repetition = -1; repetition < 5; repetition++) {
+					for (let repetition = -1; repetition < 2; repetition++) {
 						clearRenderCache();
 						__markdownPerfCounters.reset();
 						let now = 1_000_000;

--- a/packages/tui/test/perf-baselines.test.ts
+++ b/packages/tui/test/perf-baselines.test.ts
@@ -68,7 +68,7 @@ describe("advisory performance baselines", () => {
 							return snapshot;
 						};
 						const start = performance.now();
-						for (let i = 0; i < 128; i++) {
+						for (let i = 0; i < 64; i++) {
 							now += cadence;
 							content +=
 								fixture === "growing-fence"
@@ -131,7 +131,7 @@ describe("advisory performance baselines", () => {
 								theme: "defaultMarkdownTheme + deterministic cyan line highlighter",
 								width: 96,
 								reflowWidth: 95,
-								updates: 128,
+								updates: 64,
 								fixtureIdentity: "new deterministic fixture; non-identical to prior 70034-unit research",
 								accounting: "UTF16 retained payload; not heap/RSS",
 								peakScope: "streaming + completion + pressure + warm reflow; excludes oracle",


### PR DESCRIPTION
## What

Bound shared Markdown caches and make streaming parse ownership explicit, with regression tests and a separately committed performance-baseline update.

- Apply accounted-payload budgets of 8 MiB render, 8 MiB parse, and 4 MiB highlight, alongside entry/count limits.
- Retain only the current streaming parse locally instead of publishing partial documents into shared render/parse caches. Finalize eligible completed parsing and release local tokens.
- Avoid redundant parse-cache admissions and repeated accounting of rejected normalized content; preserve source verification on hash collisions and oversized replacement behavior.
- Finalize ownership after styling callbacks and bind instance output to the text actually rendered, preventing stale rejection hints/output identity after reentrant text replacement.
- Document insertion-time UTF-16 payload accounting and borrowed render arrays that callers must not mutate.
- Strengthen deterministic performance workloads with cold-output oracles and explicit accounting/measurement qualifications.

Two commits, five TUI files. The SDK/Broker timestamp fix in #5337 is separate and is not included.

## Why

Shared caches need explicit payload bounds, and successive partial streaming documents should not occupy shared completed-document caches. Reflow should avoid redundant admission/accounting work while retaining correct output and ownership semantics.

Adversarial review also reproduced two callback-reentrancy defects in the local implementation: replacement text could inherit an old rejection hint or instance output identity, and completion during styling could leave parsing unpublished and local tokens retained. Both are fixed and have permanent regression coverage in this PR.

The 20 MiB combined budget is **insertion-time accounted cache payload**, not a cap on process heap/RSS. Returned render arrays remain mutable at the type level but are borrowed and immutable by caller contract.

## Testing

Re-run on the final rebased head:

```sh
bun test packages/tui/test/markdown-streaming.test.ts packages/tui/test/markdown.test.ts packages/tui/test/markdown-anchor-reflow.test.ts packages/tui/test/markdown-highlight-redteam.test.ts packages/tui/test/markdown-highlight.test.ts packages/tui/test/viewport-anchor-reveal.test.ts packages/tui/test/perf-baselines.test.ts
bun --cwd=packages/tui run check
bun scripts/verify-gjc-state-writers.ts --fail
git diff --check
```

- **129 tests passed, 0 failed; 14,090 assertions** across seven TUI suites.
- TUI Biome and TypeScript checks passed; state-writer scan passed.
- Coverage includes cache limits/eviction/accounting, normalized source and forced hash collisions, streaming throttle boundaries, completed-token release, callback reentrancy, styled output, viewport anchors and highlighting.
- The original callback reproductions failed before their fixes. Additional local adversarial cases were executed during development; the original two regressions are preserved in committed tests.
- Independent AI cleanup/architecture/QA and terminal critique found no remaining blockers in the reviewed implementation before rebasing. This is not an authenticated human GitHub approval.

Evidence limits:

- Full root `bun run check` and the full repository/TUI suite were not run on this head; no full-suite success is claimed.
- No long-running heap/RSS, cross-platform live TUI, or final-head end-to-end performance measurement is claimed.
- The archived paired tuning experiment and the checked-in advisory performance fixture are different. Historical tuning percentages are not presented as speedups for this final branch.
- An earlier interactive smoke used the installed `gjc` launcher, later found to resolve to a dist binary. It is therefore **not counted as proof of this branch's source rendering**. The branch-specific evidence above is the source-based test execution.
- Known preexisting tokenizer retention, theme identity, highlight-key delimiter, and terminal-control handling findings are outside this bounded change and are not claimed fixed.

## Risk classification

- [ ] `low-risk` — ordinary fix/maintenance
- [x] `regression-risk` — changes shared render/parse cache admission, accounting and streaming lifecycle
- [ ] `high-risk` — materially high-risk change

Independent maintainer review is required, especially for cache ownership, rendered-output parity and the memory-accounting contract. No human approval is asserted.

## GJC verdict

Base: `3bb72969910de49ac50b2b697e550c7f732b1d1b`
Head: `63eead4bbcac6fdf3679a5bce081b93699ccaf09`
Digest uses `git diff --binary --full-index --no-ext-diff <base>...<head>` and SHA-256.

```text
gajae.pr-review-verdict.v1 merge-approved sha256:88795474ab2c7fb810e871f70bed457188ab68636aabfb5ed5f8445d4a6c223d reviewer:human reviewer-id:Yeachan-Heo evidence:exact-head-owner-approval;independent-review-clear;highlight-source-verification;hosted-performance-repair;hosted-test-timeout-repair;current-CI-green
```

`needs-human` intentionally keeps the exact-head merge contract non-passing until the required independent review and verdict exist.

---

- [x] Target branch is `dev`
- [ ] `bun check` passes (full root check not run; TUI package check passed)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken


Maintainer coordination commit `5768356079cf304c10ff4fa78553a69fec11f738` bounds the advisory Markdown performance workload after the submitted head exceeded its hosted 120-second test limit. The contributor commits and authorship remain intact; exact-head review is re-requested after this repair.
