### PR TITLE
fix(utils): redact the credential shapes the import scrubber already lists

### DIFF
--- a/packages/coding-agent/src/crash/sanitize.ts
+++ b/packages/coding-agent/src/crash/sanitize.ts
@@ -40,7 +40,7 @@ const INVISIBLE_PATTERN = new RegExp(INVISIBLE_CLASS, "g");
 // residual scanner that silently alternates verdicts is worse than none.
 const CONTROL_PROBE = new RegExp(CONTROL_CLASS);
 const INVISIBLE_PROBE = new RegExp(INVISIBLE_CLASS);
-const URL_PATTERN = /\b[a-zA-Z][a-zA-Z0-9+.-]*:\/\/[^\s<>"'`)\]]+/g;
+const URL_PATTERN = /(?<![A-Za-z0-9+.-])[a-zA-Z][a-zA-Z0-9+.-]*:\/\/[^\s<>"'`)\]]+/g;
 /** Anything still matching these after sanitization means the scanner is not certain. */
 const RESIDUAL_PATTERNS: readonly RegExp[] = [
 	/\bsk-[A-Za-z0-9_-]{8,}/,

--- a/packages/coding-agent/test/crash-sanitize.test.ts
+++ b/packages/coding-agent/test/crash-sanitize.test.ts
@@ -81,6 +81,49 @@ describe("sanitizeExternalCrashV1 — hostile inputs", () => {
 		expect(Buffer.byteLength(output, "utf8")).toBeLessThan(CRASH_BODY_MAX_BYTES);
 		expect(output.endsWith("…[truncated]")).toBe(true);
 	});
+
+	it("drops the credential shapes the import scrubber already recognizes", () => {
+		// All synthetic. These four survived into outbound text because the shared
+		// credential layer did not name them, while session-import/redact.ts —
+		// which faces strictly less exposure — already listed every one.
+		const googleApiKey = `AIza${"S".repeat(35)}`;
+		const pemBody = "MIIEowIBAAKCAQEAxGZ0000abcdefgHIJKLmnop";
+		const output = sanitized(
+			[
+				`google: ${googleApiKey}`,
+				"principal one: ABIAIOSFODNN7EXAMPLE",
+				"principal two: ACCAIOSFODNN7EXAMPLE",
+				// Control: already covered before this change.
+				"principal three: ASIAIOSFODNN7EXAMPLE",
+				`-----BEGIN RSA PRIVATE KEY-----\n${pemBody}\n-----END RSA PRIVATE KEY-----`,
+			].join("\n"),
+		);
+
+		expect(output).not.toContain(googleApiKey);
+		expect(output).not.toContain("ABIAIOSFODNN7EXAMPLE");
+		expect(output).not.toContain("ACCAIOSFODNN7EXAMPLE");
+		expect(output).not.toContain("ASIAIOSFODNN7EXAMPLE");
+		expect(output).not.toContain(pemBody);
+		// The surrounding diagnostic text still survives.
+		expect(output).toContain("principal one");
+		expect(output).toContain("principal two");
+	});
+
+	it("keeps url userinfo out of outbound text without hiding the host", () => {
+		const output = sanitized("clone failed: https://deploy:s3cr3tvalue@git.example.com/x.git");
+		expect(output).not.toContain("s3cr3tvalue");
+		expect(output).toContain("clone failed");
+	});
+
+	it("scans a large credential-free body in linear time", () => {
+		// The url-credential rule bounds its scheme repetition. An unbounded one
+		// re-tries every prefix of a long alphabetic run before failing on `://`,
+		// which is quadratic: a 200 KB crash body cost ~10s and blew the 5s test
+		// timeout in packages/utils/test/crash-journal.test.ts.
+		const startedAt = performance.now();
+		sanitized("x".repeat(200_000));
+		expect(performance.now() - startedAt).toBeLessThan(1_000);
+	});
 });
 
 describe("fenceCrashText", () => {

--- a/packages/coding-agent/test/crash-sanitize.test.ts
+++ b/packages/coding-agent/test/crash-sanitize.test.ts
@@ -110,9 +110,13 @@ describe("sanitizeExternalCrashV1 — hostile inputs", () => {
 	});
 
 	it("keeps url userinfo out of outbound text without hiding the host", () => {
-		const output = sanitized("clone failed: https://deploy:s3cr3tvalue@git.example.com/x.git");
+		const output = sanitized(
+			"clone failed: https://deploy:s3cr3tvalue@git.example.com/x.git and _https://deploy:wrapped-s3cr3t@git.example.com/x.git_",
+		);
 		expect(output).not.toContain("s3cr3tvalue");
+		expect(output).not.toContain("wrapped-s3cr3t");
 		expect(output).toContain("clone failed");
+		expect(output).toContain("git.example.com");
 	});
 
 	it("scans a large credential-free body in linear time", () => {

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- `redactCrashSecrets` now covers the credential shapes the session-import scrubber already listed: Google API keys, PEM private-key blocks, the `ABIA`/`ACCA` AWS access-key prefixes, and basic-auth credentials embedded in a URL. All four previously survived into the persisted crash log and into outbound crash text, because `sanitizeExternalCrashV1` uses this function as its credential layer and its later URL/hex/path passes do not recognize them. The URL rule bounds its scheme repetition so scanning stays linear; an unbounded one re-tried every prefix of a long alphabetic run and cost roughly ten seconds on a 200 KB crash body.
 
 ## [0.16.4] - 2026-09-05
 

--- a/packages/utils/src/crash-redaction.ts
+++ b/packages/utils/src/crash-redaction.ts
@@ -25,13 +25,34 @@ export function redactCrashSecrets(text: string): string {
 	redacted = redacted.replace(/\bgh[opsur]_[A-Za-z0-9]{16,}\b/g, "«redacted-github-token»");
 	redacted = redacted.replace(/\bgithub_pat_[A-Za-z0-9_]{20,}\b/g, "«redacted-github-token»");
 	redacted = redacted.replace(/\bxox[baprs]-[A-Za-z0-9-]{8,}\b/g, "«redacted-slack-token»");
+	// A PEM block carries the key material itself, so it is redacted whole rather
+	// than line by line. It runs before the narrower rules because they would
+	// otherwise chew on the base64 body and leave a truncated key behind.
+	redacted = redacted.replace(
+		/-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z0-9 ]*PRIVATE KEY-----/g,
+		"«redacted-private-key»",
+	);
+	// Google API keys are a fixed 39-character shape that carries no label of its
+	// own, so the labeled-value rule below never sees one.
+	redacted = redacted.replace(/\bAIza[0-9A-Za-z_-]{35}\b/g, "«redacted-google-api-key»");
+	// Basic-auth credentials embedded in a URL. Scheme and host stay readable
+	// because they are the diagnostic value; only the userinfo is dropped. The
+	// scheme repetition is bounded: an unbounded `[a-z0-9+.-]*` in front of the
+	// literal `://` re-tries every prefix of a long alphabetic run, which is
+	// quadratic in input length and costs ~10s on a 200 KB crash body.
+	redacted = redacted.replace(
+		/\b([a-z][a-z0-9+.-]{0,15}:\/\/)[^/\s:@]{1,256}:[^/\s@]{1,256}@/gi,
+		"$1«redacted-url-credential»@",
+	);
 	// AKIA is the long-term access key id; ASIA is the temporary/STS one, which is
-	// the shape that actually shows up in a crashed request. The id alone is not
+	// the shape that actually shows up in a crashed request. ABIA (bearer) and
+	// ACCA (context) complete the set the session-import scrubber already lists.
+	// The id alone is not
 	// the credential: an STS payload carries `SecretAccessKey` and `SessionToken`
 	// alongside it, so the labeled-value rule below must name both. `secret_key`
 	// does not match `SecretAccessKey` (the canonical field has `Access` in the
 	// middle), and `access_token` does not match `SessionToken`.
-	redacted = redacted.replace(/\b(?:AKIA|ASIA)[0-9A-Z]{16}\b/g, "«redacted-aws-key»");
+	redacted = redacted.replace(/\b(?:AKIA|ASIA|ABIA|ACCA)[0-9A-Z]{16}\b/g, "«redacted-aws-key»");
 	redacted = redacted.replace(
 		/(?<![A-Za-z0-9_])(["']?(?:api[_-]?key|apikey|access[_-]?token|refresh[_-]?token|id[_-]?token|session[_-]?token|client[_-]?secret|secret[_-]?key|secret[_-]?access[_-]?key|password|passwd|authorization)["']?\s*[=:]\s*["']?)[^\s"',;}\]]{8,}/gi,
 		"$1«redacted»",
@@ -47,5 +68,8 @@ export const CRASH_REDACTION_MARKERS: readonly string[] = [
 	"«redacted-github-token»",
 	"«redacted-slack-token»",
 	"«redacted-aws-key»",
+	"«redacted-private-key»",
+	"«redacted-google-api-key»",
+	"«redacted-url-credential»",
 	"«redacted»",
 ];

--- a/packages/utils/src/crash-redaction.ts
+++ b/packages/utils/src/crash-redaction.ts
@@ -34,14 +34,17 @@ export function redactCrashSecrets(text: string): string {
 	);
 	// Google API keys are a fixed 39-character shape that carries no label of its
 	// own, so the labeled-value rule below never sees one.
-	redacted = redacted.replace(/\bAIza[0-9A-Za-z_-]{35}\b/g, "«redacted-google-api-key»");
+	redacted = redacted.replace(
+		/(?<![A-Za-z0-9_-])AIza[0-9A-Za-z_-]{35}(?![A-Za-z0-9_-])/g,
+		"«redacted-google-api-key»",
+	);
 	// Basic-auth credentials embedded in a URL. Scheme and host stay readable
 	// because they are the diagnostic value; only the userinfo is dropped. The
 	// scheme repetition is bounded: an unbounded `[a-z0-9+.-]*` in front of the
 	// literal `://` re-tries every prefix of a long alphabetic run, which is
 	// quadratic in input length and costs ~10s on a 200 KB crash body.
 	redacted = redacted.replace(
-		/\b([a-z][a-z0-9+.-]{0,15}:\/\/)[^/\s:@]{1,256}:[^/\s@]{1,256}@/gi,
+		/(?<![A-Za-z0-9+.-])([a-z][a-z0-9+.-]{0,15}:\/\/)[^/\s:@]{1,256}:[^/\s@]{1,256}@/gi,
 		"$1«redacted-url-credential»@",
 	);
 	// AKIA is the long-term access key id; ASIA is the temporary/STS one, which is

--- a/packages/utils/test/postmortem-crash-log.test.ts
+++ b/packages/utils/test/postmortem-crash-log.test.ts
@@ -218,6 +218,52 @@ describe("recordFatalCrash", () => {
 		expect(contents).toContain("SessionToken");
 	});
 
+	it("redacts the credential shapes the session-import scrubber already lists", () => {
+		const target = tempCrashLog();
+		// All synthetic. Each shape is already catalogued by
+		// packages/coding-agent/src/session-import/redact.ts; the persisted crash
+		// log kept them verbatim because this scrubber never named them.
+		const googleApiKey = `AIza${"S".repeat(35)}`;
+		const pemBody = "MIIEowIBAAKCAQEAxGZ0000abcdefgHIJKLmnop";
+		// ABIA is the bearer access key id and ACCA the context one; both sit
+		// alongside AKIA/ASIA in AWS's own identifier prefix table.
+		const bearerAws = "ABIAIOSFODNN7EXAMPLE";
+		const contextAws = "ACCAIOSFODNN7EXAMPLE";
+		const urlSecret = "s3cr3tvalue";
+		const err = new Error(
+			[
+				`fetch failed: ${googleApiKey}`,
+				`${bearerAws} ${contextAws}`,
+				`clone: https://deploy:${urlSecret}@git.example.com/x.git`,
+				`-----BEGIN RSA PRIVATE KEY-----\n${pemBody}\n-----END RSA PRIVATE KEY-----`,
+			].join(" "),
+		);
+
+		recordFatalCrash("Uncaught Exception", err, { path: target });
+
+		const contents = fs.readFileSync(target, "utf8");
+		expect(contents).toContain("fetch failed");
+		expect(contents).not.toContain(googleApiKey);
+		expect(contents).not.toContain(bearerAws);
+		expect(contents).not.toContain(contextAws);
+		expect(contents).not.toContain(urlSecret);
+		expect(contents).not.toContain(pemBody);
+		expect(contents).toContain("«redacted-google-api-key»");
+		expect(contents).toContain("«redacted-private-key»");
+		// Scheme and host stay readable so the record still says which remote failed.
+		expect(contents).toContain("https://«redacted-url-credential»@git.example.com");
+	});
+
+	it("scans a large credential-free crash body in linear time", () => {
+		// The url-credential rule bounds its scheme repetition. Unbounded, it
+		// re-tries every prefix of a long alphabetic run before failing on `://`,
+		// which is quadratic in body length and cost ~10s on 200 KB.
+		const target = tempCrashLog();
+		const startedAt = performance.now();
+		recordFatalCrash("Uncaught Exception", new Error("x".repeat(200_000)), { path: target });
+		expect(performance.now() - startedAt).toBeLessThan(1_000);
+	});
+
 	it("enforces owner-only permissions on a pre-existing file", () => {
 		if (process.platform === "win32") return;
 		const target = tempCrashLog();

--- a/packages/utils/test/postmortem-crash-log.test.ts
+++ b/packages/utils/test/postmortem-crash-log.test.ts
@@ -218,40 +218,46 @@ describe("recordFatalCrash", () => {
 		expect(contents).toContain("SessionToken");
 	});
 
-	it("redacts the credential shapes the session-import scrubber already lists", () => {
+	it("redacts the credential shapes the session-import scrubber already lists", async () => {
 		const target = tempCrashLog();
 		// All synthetic. Each shape is already catalogued by
 		// packages/coding-agent/src/session-import/redact.ts; the persisted crash
 		// log kept them verbatim because this scrubber never named them.
 		const googleApiKey = `AIza${"S".repeat(35)}`;
+		const trailingHyphenGoogleApiKey = `AIza${"S".repeat(34)}-`;
 		const pemBody = "MIIEowIBAAKCAQEAxGZ0000abcdefgHIJKLmnop";
 		// ABIA is the bearer access key id and ACCA the context one; both sit
 		// alongside AKIA/ASIA in AWS's own identifier prefix table.
 		const bearerAws = "ABIAIOSFODNN7EXAMPLE";
 		const contextAws = "ACCAIOSFODNN7EXAMPLE";
 		const urlSecret = "s3cr3tvalue";
+		const wrappedUrlSecret = "wrapped-s3cr3t";
 		const err = new Error(
 			[
-				`fetch failed: ${googleApiKey}`,
+				`fetch failed: ${googleApiKey} ${trailingHyphenGoogleApiKey}`,
 				`${bearerAws} ${contextAws}`,
 				`clone: https://deploy:${urlSecret}@git.example.com/x.git`,
+				`wrapped: _https://deploy:${wrappedUrlSecret}@git.example.com/x.git_`,
 				`-----BEGIN RSA PRIVATE KEY-----\n${pemBody}\n-----END RSA PRIVATE KEY-----`,
 			].join(" "),
 		);
 
 		recordFatalCrash("Uncaught Exception", err, { path: target });
 
-		const contents = fs.readFileSync(target, "utf8");
+		const contents = await Bun.file(target).text();
 		expect(contents).toContain("fetch failed");
 		expect(contents).not.toContain(googleApiKey);
+		expect(contents).not.toContain(trailingHyphenGoogleApiKey);
 		expect(contents).not.toContain(bearerAws);
 		expect(contents).not.toContain(contextAws);
 		expect(contents).not.toContain(urlSecret);
+		expect(contents).not.toContain(wrappedUrlSecret);
 		expect(contents).not.toContain(pemBody);
 		expect(contents).toContain("«redacted-google-api-key»");
 		expect(contents).toContain("«redacted-private-key»");
 		// Scheme and host stay readable so the record still says which remote failed.
 		expect(contents).toContain("https://«redacted-url-credential»@git.example.com");
+		expect(contents).toContain("_https://«redacted-url-credential»@git.example.com/x.git_");
 	});
 
 	it("scans a large credential-free crash body in linear time", () => {


### PR DESCRIPTION
## What

Teach `redactCrashSecrets` (`packages/utils/src/crash-redaction.ts`) the four credential shapes that `packages/coding-agent/src/session-import/redact.ts` already lists:

- Google API keys (`AIza` + 35)
- PEM `PRIVATE KEY` blocks, redacted whole
- the `ABIA` and `ACCA` AWS access-key id prefixes, alongside the existing `AKIA`/`ASIA`
- basic-auth credentials embedded in a URL (userinfo dropped, scheme and host kept)

## Why

`redactCrashSecrets` is the credential layer for **two** paths, not one:

1. `packages/utils/src/postmortem.ts` — the crash log GJC keeps indefinitely.
2. `packages/coding-agent/src/crash/sanitize.ts` — `sanitizeExternalCrashV1`, which gates text **leaving the machine** through `gjc crash report` and the opt-in Sentry relay.

The module docstring points outbound text at `sanitizeExternalCrashV1` as the stronger guarantee, but that function calls this one, so a gap here is an outbound gap. Its later URL/hex/uuid/path passes do not recognize any of these four shapes.

The URL rule bounds the scheme to 16 characters. An unbounded scheme repetition retries every prefix of a long alphabetic run before the literal `://`, which makes scanning quadratic on credential-free crash text.

Long hex runs (64+) remain out of scope. Both egress paths already collapse them, and adding a marker here would shift the fingerprints of already-recorded crashes and move their deduplication buckets.

## Testing

Executed after rebasing onto current `origin/dev`:

```
bun install --frozen-lockfile
bun test packages/utils/test/postmortem-crash-log.test.ts
  19 pass, 0 fail, 92 expect() calls
bun test packages/coding-agent/test/crash-sanitize.test.ts \
         packages/utils/test/crash-journal.test.ts \
         packages/utils/test/crash-fingerprint.test.ts
  39 pass, 0 fail, 91 expect() calls
bun --cwd=packages/utils run check
bun --cwd=packages/coding-agent run check
```

The focused tests cover both persisted and outbound paths, the `ASIA` control, URL userinfo removal, and the large credential-free linear-time guard. The full root `bun check` was not run; the two affected package checks passed end to end.

## Risk classification

- [ ] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [x] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`). This changes a credential-redaction boundary for crash text that can leave the machine and land in a public issue body. The implementation only widens redaction, but under-redaction leaks credentials and over-redaction can degrade diagnosability, so an independent review is required.

## GJC verdict

<!-- Paste one exact-head verdict. reviewer-id is the reviewer's GitHub login. merge-approved requires an authenticated exact-head APPROVED review from an identity distinct from the PR author — the author can never reach it. The repository owner may instead use merge-self-approved, the explicitly named solo force path for a low-risk change with a valid risk-record comment; its name records that no independent human reviewed. Otherwise write needs-human and stop. -->

```text
gajae.pr-review-verdict.v1 merge-approved sha256:0b218aa815cbd66022267ad32766e2a339b98412df8a6a5d607479838e5e5a33 reviewer:critic reviewer-id:Yeachan-Heo evidence:exact-head a2ced659c79abe99dda498355e8267c7fc33b8a0; base 918bdfb2b10b3fb97501c0efec594d9f0dfd37b7; review https://github.com/Yeachan-Heo/gajae-code/pull/5347#pullrequestreview-5127633802; focused tests and affected package checks
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken
