### PR TITLE
fix(natives): honor the documented GJC_NATIVE_VARIANT override

### DIFF
--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- The addon loader now honors `GJC_NATIVE_VARIANT`, the x64 variant override named in `docs/natives-architecture.md`, `docs/natives-addon-loader-runtime.md`, and `docs/natives-build-release-debugging.md`. Only the pre-rebrand `PI_NATIVE_VARIANT` was read, so the documented remedy for a machine that loads the wrong variant — including the troubleshooting row that prescribes `GJC_NATIVE_VARIANT=baseline` — silently kept the auto-detected variant. The legacy name still works, the canonical name wins when both are set, an empty canonical value falls through to the alias, and invalid values are still ignored.
+
 ## [0.16.4] - 2026-09-05
 
 ### Fixed

--- a/packages/natives/native/loader-state.d.ts
+++ b/packages/natives/native/loader-state.d.ts
@@ -30,6 +30,8 @@ export function detectWin32Avx2Support(
 	report?: (diagnostic: Win32Avx2ProbeDiagnostic) => void,
 ): boolean;
 
+export function getVariantOverride(env?: Record<string, string | undefined>): "modern" | "baseline" | null;
+
 export interface GetAddonFilenamesInput {
 	tag: string;
 	arch: string;

--- a/packages/natives/native/loader-state.js
+++ b/packages/natives/native/loader-state.js
@@ -484,10 +484,14 @@ export function detectWin32Avx2Support(
 	return probeWin32Avx2ViaPowerShell(run, report);
 }
 
-function getVariantOverride() {
-	const value = process.env.PI_NATIVE_VARIANT;
-	if (!value) return null;
-	if (value === "modern" || value === "baseline") return value;
+export function getVariantOverride(env = process.env) {
+	// `GJC_NATIVE_VARIANT` is the documented name (docs/natives-architecture.md,
+	// docs/natives-addon-loader-runtime.md, docs/natives-build-release-debugging.md);
+	// `PI_NATIVE_VARIANT` is the pre-rebrand name kept as a fallback. An empty or
+	// blank canonical value falls through rather than masking the legacy one.
+	const raw = env.GJC_NATIVE_VARIANT?.trim() || env.PI_NATIVE_VARIANT?.trim();
+	if (!raw) return null;
+	if (raw === "modern" || raw === "baseline") return raw;
 	return null;
 }
 

--- a/packages/natives/test/variant-override.test.ts
+++ b/packages/natives/test/variant-override.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "bun:test";
+import { getVariantOverride } from "../native/loader-state.js";
+
+describe("getVariantOverride", () => {
+	it("honors the documented GJC_NATIVE_VARIANT name", () => {
+		// The three natives docs name `GJC_NATIVE_VARIANT`, and
+		// docs/natives-build-release-debugging.md prescribes it as the remedy when
+		// an x64 machine loads the wrong variant. Only `PI_NATIVE_VARIANT` was
+		// read, so following that remedy silently kept the auto-detected variant.
+		expect(getVariantOverride({ GJC_NATIVE_VARIANT: "baseline" })).toBe("baseline");
+		expect(getVariantOverride({ GJC_NATIVE_VARIANT: "modern" })).toBe("modern");
+	});
+
+	it("keeps honoring the pre-rebrand PI_NATIVE_VARIANT name", () => {
+		expect(getVariantOverride({ PI_NATIVE_VARIANT: "baseline" })).toBe("baseline");
+		expect(getVariantOverride({ PI_NATIVE_VARIANT: "modern" })).toBe("modern");
+	});
+
+	it("prefers the canonical name over the legacy alias", () => {
+		expect(getVariantOverride({ GJC_NATIVE_VARIANT: "modern", PI_NATIVE_VARIANT: "baseline" })).toBe("modern");
+	});
+
+	it("treats an empty or blank canonical value as absent", () => {
+		expect(getVariantOverride({ GJC_NATIVE_VARIANT: "", PI_NATIVE_VARIANT: "baseline" })).toBe("baseline");
+		expect(getVariantOverride({ GJC_NATIVE_VARIANT: "   ", PI_NATIVE_VARIANT: "baseline" })).toBe("baseline");
+		expect(getVariantOverride({ GJC_NATIVE_VARIANT: "" })).toBeNull();
+	});
+
+	it("ignores invalid values under either name", () => {
+		// docs/natives-architecture.md: "invalid values are ignored".
+		expect(getVariantOverride({ GJC_NATIVE_VARIANT: "bogus" })).toBeNull();
+		expect(getVariantOverride({ PI_NATIVE_VARIANT: "Modern" })).toBeNull();
+		expect(getVariantOverride({})).toBeNull();
+	});
+});


### PR DESCRIPTION
## What

Make the addon loader honor the documented `GJC_NATIVE_VARIANT` x64 override while retaining the pre-rebrand `PI_NATIVE_VARIANT` alias.

## Why

The runtime docs prescribe `GJC_NATIVE_VARIANT=modern|baseline`, including as the remediation for an x64 machine that loads the wrong native variant. Before this change, `packages/natives/native/loader-state.js` read only `PI_NATIVE_VARIANT`, so the documented override silently had no effect. The canonical name now takes precedence when present, blank canonical input falls through to the legacy alias, and invalid values remain ignored.

## Testing

- `bun --cwd=packages/natives run check` — passed (Biome and TypeScript).
- `bun test packages/natives/test/variant-override.test.ts` — 5 passed, 0 failed, 11 expectations.
- `bun scripts/verify-gjc-state-writers.ts --fail` — passed.
- `bun test packages/natives/test` — 82 passed, 8 skipped, 6 failed, 5 errors in this checkout because the Linux native addon artifacts are absent/stale; the focused override test and package check pass.

## Risk classification

- [x] `low-risk` — narrow native-loader maintenance change: it adds the documented environment name, preserves the existing alias, and covers precedence, blank input, invalid input, and no-override behavior with focused tests.
- [ ] `regression-risk`
- [ ] `high-risk`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:b233f864b114b2575eb6f4865a17851efd1238b9bc36cd84b00c351fd0a3f050 reviewer:human reviewer-id:Yeachan-Heo evidence:bun --cwd=packages/natives run check; bun test packages/natives/test/variant-override.test.ts; bun scripts/verify-gjc-state-writers.ts --fail
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes (package-scoped `bun --cwd=packages/natives run check` passes; full workspace check was not required for this focused native-loader change)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head `5597cb6cc9c2266090cc02988d7d57dcb4d90a29` and live base `f571d4ea452e2c090cbded2ac2bed4fd85288753`
- [x] Risk classification above matches the actual review path taken