### PR TITLE
docs(ai): drop the phantom GJC_OPENAI_CODE_WEBSOCKET_V2 knob

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -373,7 +373,6 @@ OAuth host chain: `KIMI_CODE_OAUTH_HOST` → `KIMI_OAUTH_HOST` → `https://auth
 | `GJC_OPENAI_CODE_DEBUG`                     | `1`/`true` enables OpenAI code provider debug logging      |
 | `GJC_NO_STRICT`                       | Global bypass for OpenAI-style strict schema enforcement (`adaptSchemaForStrict`); legacy alias `PI_NO_STRICT` |
 | `GJC_OPENAI_CODE_WEBSOCKET`                 | `1`/`true` enables websocket transport preference    |
-| `GJC_OPENAI_CODE_WEBSOCKET_V2`              | `1`/`true` enables websocket v2 path                 |
 | `GJC_OPENAI_CODE_WEBSOCKET_IDLE_TIMEOUT_MS` | Positive integer override (default 300000)           |
 | `GJC_OPENAI_CODE_WEBSOCKET_RETRY_BUDGET`    | Non-negative integer override (default 5)            |
 | `GJC_OPENAI_CODE_WEBSOCKET_RETRY_DELAY_MS`  | Positive integer base backoff override (default 500) |

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Documented `GJC_OPENAI_CODE_WEBSOCKET_V2` as a switch that enables a websocket v2 path. No code read it under that name, under the legacy `PI_CODEX_WEBSOCKET_V2`, or under the `PI_OPENAI_CODE_WEBSOCKET_V2` the historical entry records; the v2 beta header has been unconditional for websocket transport. The documentation row is removed rather than reintroducing a knob, and the test that claimed to gate on it no longer writes an environment variable nothing reads.
 - Maintenance reasoning now fails closed for Anthropic models routed through an unverified custom endpoint and for raw reasoning-enabled models without thinking metadata. This prevents unsupported thinking controls and avoids a synchronous missing-metadata crash before provider wire transformation.
 
 ## [0.16.4] - 2026-09-05

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -19,7 +19,6 @@ const originalWebSocket = global.WebSocket;
 const originalCodexWebSocketRetryBudget = Bun.env.PI_CODEX_WEBSOCKET_RETRY_BUDGET;
 const originalCodexWebSocketRetryDelayMs = Bun.env.PI_CODEX_WEBSOCKET_RETRY_DELAY_MS;
 const originalCodexWebSocketIdleTimeoutMs = Bun.env.PI_CODEX_WEBSOCKET_IDLE_TIMEOUT_MS;
-const originalCodexWebSocketV2 = Bun.env.PI_CODEX_WEBSOCKET_V2;
 
 function restoreEnv(name: string, value: string | undefined): void {
 	if (value === undefined) {
@@ -36,7 +35,6 @@ afterEach(() => {
 	restoreEnv("PI_CODEX_WEBSOCKET_RETRY_BUDGET", originalCodexWebSocketRetryBudget);
 	restoreEnv("PI_CODEX_WEBSOCKET_RETRY_DELAY_MS", originalCodexWebSocketRetryDelayMs);
 	restoreEnv("PI_CODEX_WEBSOCKET_IDLE_TIMEOUT_MS", originalCodexWebSocketIdleTimeoutMs);
-	restoreEnv("PI_CODEX_WEBSOCKET_V2", originalCodexWebSocketV2);
 	vi.restoreAllMocks();
 });
 
@@ -2915,10 +2913,9 @@ describe("openai-codex streaming", () => {
 		expect((capturedBodies[1]?.text as { verbosity?: string } | undefined)?.verbosity).toBe("high");
 	});
 
-	it("uses websocket v2 beta header when v2 mode is enabled", async () => {
+	it("sends the websocket v2 beta header on every websocket transport", async () => {
 		const tempDir = TempDir.createSync("@pi-codex-stream-");
 		setAgentDir(tempDir.path());
-		Bun.env.PI_CODEX_WEBSOCKET_V2 = "1";
 
 		const payload = Buffer.from(
 			JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: "acc_test" } }),


### PR DESCRIPTION
## What

- Remove the `GJC_OPENAI_CODE_WEBSOCKET_V2` row from `docs/environment-variables.md`.
- Stop the codex stream test from writing `PI_CODEX_WEBSOCKET_V2`, and rename it to state the gate that actually exists.

## Why

The doc row reads:

```
| `GJC_OPENAI_CODE_WEBSOCKET_V2` | `1`/`true` enables websocket v2 path |
```

Nothing reads it. Not that name, not the legacy `PI_CODEX_WEBSOCKET_V2`, and not the `PI_OPENAI_CODE_WEBSOCKET_V2` recorded at `packages/ai/CHANGELOG.md:2390`. On `dev` (`2a5f8dd7`), `grep -rn WEBSOCKET_V2 packages scripts docs` returns the doc row, three lines in one test file, and that historical changelog entry — no source read.

`createCodexHeaders` picks the header from the transport alone (`openai-codex-responses.ts:2913-2916`):

```ts
const betaHeader =
    transport === "websocket"
        ? OPENAI_HEADER_VALUES.BETA_RESPONSES_WEBSOCKETS_V2
        : OPENAI_HEADER_VALUES.BETA_RESPONSES;
```

The test `uses websocket v2 beta header when v2 mode is enabled` set `PI_CODEX_WEBSOCKET_V2 = "1"` as its precondition. On unmodified `dev`:

- delete that line → **still passes**
- set `PI_CODEX_WEBSOCKET_V2=0` **and** `GJC_OPENAI_CODE_WEBSOCKET_V2=0` → **still passes**

So the precondition was inert and the test name described a gate that does not exist. Same class as #3284, where the env trust suites masked only the inherited source.

Every other member of the family resolves through a real `GJC_`/`PI_` pair — `GJC_OPENAI_CODE_DEBUG`, `_WEBSOCKET`, `_WEBSOCKET_RETRY_BUDGET`, `_WEBSOCKET_RETRY_DELAY_MS`, `_WEBSOCKET_IDLE_TIMEOUT_MS`. V2 is the one leftover from when the header stopped being optional, which is what #3245 was cleaning up.

I removed the row rather than implementing the knob: the v2 beta header is not optional for websocket transport, and reintroducing a switch would mean shipping a path that can request the older beta on a transport that requires the newer one. Say so if you'd rather have the knob back and I'll send that instead.

## Testing

```
bunx biome check packages/ai/test/openai-codex-stream.test.ts   # clean
bun test packages/ai/test/openai-codex-stream.test.ts
  76 pass, 0 fail, 428 expect() calls
```

No runtime source changes; the assertion on the `OpenAI-Beta: responses_websockets=2026-02-06` header is unchanged and still runs.

## Risk classification

- [x] `low-risk` — documentation and test-only. No runtime code path changes; the removed environment write had no reader.
- [ ] `regression-risk`
- [ ] `high-risk`

## GJC verdict

```text
gajae.pr-review-verdict.v1 needs-human sha256:f11097863c56a422c06541b4f33cdc53854cbba2ba8ba9f3a10c513d2e168eb2 reviewer:human reviewer-id:10kH evidence:bun test packages/ai/test/openai-codex-stream.test.ts
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes (biome clean on the touched file; the full multi-workspace gate exceeded my local time budget)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken

