### PR TITLE
perf(tui): skip width scans on unchanged-width frames

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Performance
 
+- Skip full-transcript resize-width scans on unchanged-width render frames while preserving the existing resize and forced-redraw checks.
 - Avoid copying unchanged terminal-control spans, reuse retained row widths, consume only the first grapheme for cursor operations, stop select-list width scans at their bounds, and avoid redundant background-row padding.
 
 ### Fixed

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -818,6 +818,7 @@ type TuiRenderCounterSnapshot = {
 	debugRedrawEnvReads: number;
 	debugRedrawAppendWrites: number;
 	differentialGuardVisibleWidthCalls: number;
+	widthReflowScanRows: number;
 };
 type RenderCommitWaiter = {
 	resolve: (committed: boolean) => void;
@@ -1181,6 +1182,7 @@ export class TUI extends Container {
 		debugRedrawEnvReads: 0,
 		debugRedrawAppendWrites: 0,
 		differentialGuardVisibleWidthCalls: 0,
+		widthReflowScanRows: 0,
 	};
 
 	static resetRenderCountersForTest(): void {
@@ -1188,6 +1190,7 @@ export class TUI extends Container {
 			debugRedrawEnvReads: 0,
 			debugRedrawAppendWrites: 0,
 			differentialGuardVisibleWidthCalls: 0,
+			widthReflowScanRows: 0,
 		};
 	}
 
@@ -5084,10 +5087,12 @@ export class TUI extends Container {
 		}
 		const useViewportRepaintPath = this.#viewportRepaintHost();
 		const widthReflowRequired =
+			widthChanged &&
 			this.#previousWidth > 0 &&
-			rawLines.some(
-				line => !TERMINAL.isImageLine(line) && visibleWidth(line) > Math.min(this.#previousWidth, width),
-			);
+			rawLines.some(line => {
+				TUI.#renderCounters.widthReflowScanRows += 1;
+				return !TERMINAL.isImageLine(line) && visibleWidth(line) > Math.min(this.#previousWidth, width);
+			});
 		if (
 			widthChanged &&
 			!this.#legacyMultiplexerFullRender &&

--- a/packages/tui/test/perf-baselines.test.ts
+++ b/packages/tui/test/perf-baselines.test.ts
@@ -1,15 +1,16 @@
 // Advisory perf baselines: recording only; hard gating deferred to perf-gates.test.ts.
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { __animationSchedulerTestHooks } from "@gajae-code/tui";
+import { __animationSchedulerTestHooks, type Component, CURSOR_MARKER, TUI } from "@gajae-code/tui";
 import { __editorPerfCounters, Editor } from "@gajae-code/tui/components/editor";
 import { __loaderPerfCounters, Loader } from "@gajae-code/tui/components/loader";
 import * as markdownCache from "@gajae-code/tui/components/markdown";
 import { __markdownPerfCounters, clearRenderCache, Markdown } from "@gajae-code/tui/components/markdown";
-import { renderMetrics } from "@gajae-code/tui/metrics";
-import { __textHelperPerfCounters } from "@gajae-code/tui/utils";
+import { type RenderMetricsSnapshot, renderMetrics } from "@gajae-code/tui/metrics";
+import { __textHelperPerfCounters, visibleWidth } from "@gajae-code/tui/utils";
 import { $flag } from "@gajae-code/utils";
 import { makeRecordedSession, type ReplayFixture, runReplay } from "./replay-harness";
 import { defaultEditorTheme, defaultMarkdownTheme } from "./test-themes";
+import { VirtualTerminal } from "./virtual-terminal";
 
 function expectFiniteNonNegative(value: number): void {
 	expect(Number.isFinite(value)).toBe(true);
@@ -262,8 +263,212 @@ describe("advisory performance baselines", () => {
 		it("records line normalization/diff baselines for a 100k-line transcript append", async () => {
 			await runTranscriptAppendBaseline(100_000, "100k");
 		}, 120000);
+
+		it("records width-scan CPU, fresh input, and actual-resize evidence", async () => {
+			// A comparison checkout must not accidentally import the candidate through workspace links.
+			expect(import.meta.resolve("@gajae-code/tui")).toBe(new URL("../src/index.ts", import.meta.url).href);
+			const reports = [];
+			for (const metrics of [false, true]) {
+				for (const count of [64, 8_000, 40_000]) {
+					for (const phase of ["normal", "input"] as const)
+						reports.push(await runWidthScanWorkload(count, phase, metrics));
+				}
+				reports.push(await runWidthScanWorkload(40_000, "resize", metrics));
+			}
+			const report = {
+				schemaVersion: 1,
+				bun: Bun.version,
+				platform: process.platform,
+				arch: process.arch,
+				runtime: process.execPath,
+				tuiEntry: import.meta.resolve("@gajae-code/tui"),
+				sourceSha256: sha256(await Bun.file(new URL("../src/tui.ts", import.meta.url)).arrayBuffer()),
+				fixtureSourceSha256: sha256(await Bun.file(new URL(import.meta.url)).arrayBuffer()),
+				nativeSha256: process.env.GJC_WIDTH_SCAN_NATIVE_SHA ?? null,
+				flags: {
+					virtualViewport: process.env.PI_TUI_VIRTUAL_VIEWPORT ?? null,
+					tmux: process.env.TMUX ?? null,
+					screen: process.env.STY ?? null,
+				},
+				reports,
+			};
+			if (process.env.GJC_WIDTH_SCAN_REPORT)
+				await Bun.write(process.env.GJC_WIDTH_SCAN_REPORT, JSON.stringify(report, null, 2));
+			console.log(
+				`[width-scan] ${reports.length} workloads; 5 warmups + 20 samples; CPU/frame/input scopes separate`,
+			);
+		}, 120000);
 	}
 });
+
+type WidthScanPhase = "normal" | "input" | "resize";
+
+class WidthScanTranscript implements Component {
+	tail = "tail-setup";
+
+	constructor(readonly lines: string[]) {}
+
+	invalidate(): void {}
+
+	render(): string[] {
+		return [...this.lines, this.tail];
+	}
+}
+
+function sha256(value: string | ArrayBuffer): string {
+	return new Bun.CryptoHasher("sha256").update(value).digest("hex");
+}
+
+function widthScanDigest(value: unknown): string {
+	return sha256(JSON.stringify(value, (_key, item) => (typeof item === "bigint" ? item.toString() : item)));
+}
+
+async function runWidthScanWorkload(count: number, phase: WidthScanPhase, metrics: boolean) {
+	const lines = Array.from({ length: count }, (_value, index) => {
+		const text = `${index.toString().padStart(6, "0")} :: stable transcript 한글 wide 界 payload`;
+		return index % 3 === 0 ? `\x1b[36m${text}\x1b[0m` : text;
+	});
+	const fixtureHash = widthScanDigest(lines);
+	const terminal = new VirtualTerminal(100, 30, { isProcessTerminal: true });
+	const tui = new TUI(terminal, false, { widthSettleMs: 0 });
+	const transcript = new WidthScanTranscript(lines);
+	let editor: Editor | undefined;
+	let initialRawRows: string[];
+	const samples: Array<{
+		observedMs: number;
+		cpuUserMicros: number;
+		cpuSystemMicros: number;
+		bytes: number;
+		writes: number;
+		stateHash: string;
+	}> = [];
+	let warmMemory: NodeJS.MemoryUsage | undefined;
+	let liveMemory: NodeJS.MemoryUsage | undefined;
+	let frameMetrics: RenderMetricsSnapshot;
+	let measuredFrames = 0;
+	let startupBytes = 0;
+	let teardownBytes = 0;
+	try {
+		tui.addChild(transcript);
+		// The resize control has no width-padded editor/suffix: every raw row fits
+		// both 99 and 100 columns, so it must visit the full history.
+		if (phase !== "resize") {
+			editor = new Editor(defaultEditorTheme);
+			tui.addChild(editor);
+			editor.setBorderVisible(false);
+			editor.setText("input");
+			tui.setBottomPinnedComponent(editor);
+			tui.setFocus(editor);
+		}
+		initialRawRows = tui.render(100);
+		// TUI extracts this marker before forming the rows scanned for reflow.
+		expect(
+			initialRawRows.every(line => visibleWidth(line.replace(CURSOR_MARKER, "")) <= (phase === "resize" ? 99 : 100)),
+		).toBe(true);
+		tui.start();
+		const setup = tui.requestRenderWithGeneration(false, "width-scan.setup");
+		expect(await tui.waitForRenderCommit(setup, 5_000)).toBe(true);
+		await terminal.flush();
+		startupBytes = terminal.getWriteLog().reduce((sum, text) => sum + Buffer.byteLength(text), 0);
+		if (metrics) renderMetrics.enable();
+		else renderMetrics.disable();
+		for (let sample = 0; sample < 25; sample++) {
+			terminal.clearWriteLog();
+			if (sample === 5) {
+				Bun.gc(true);
+				warmMemory = process.memoryUsage();
+				renderMetrics.reset();
+			}
+			const cpuStart = process.cpuUsage();
+			let started = performance.now();
+			let generation: number;
+			if (phase === "resize") {
+				terminal.resize(terminal.columns === 100 ? 99 : 100, 30);
+				// Obtain a waiter without turning this real resize into a semantic mutation.
+				generation = tui.requestRenderWithGeneration(false, "resize");
+			} else {
+				transcript.tail = `tail-${sample.toString().padStart(2, "0")}`;
+				generation = tui.requestRenderWithGeneration(false, "width-scan.normal");
+				if (phase === "input") {
+					started = performance.now();
+					terminal.sendInput(String.fromCharCode(65 + sample));
+				}
+			}
+			expect(await tui.waitForRenderCommit(generation, 5_000)).toBe(true);
+			await terminal.flush();
+			const viewport = terminal.getViewport();
+			expect(viewport.some(line => line.trim() === transcript.tail)).toBe(true);
+			if (editor) {
+				const expected = phase === "input" ? `input${"ABCDEFGHIJKLMNOPQRSTUVWXY".slice(0, sample + 1)}` : "input";
+				expect(editor.getText()).toBe(expected);
+				expect(viewport.map(line => line.trim())).toContain(`${expected}${defaultEditorTheme.symbols.inputCursor}`);
+			}
+			const observedMs = performance.now() - started;
+			const cpu = process.cpuUsage(cpuStart);
+			if (sample >= 5) {
+				measuredFrames++;
+				const writes = terminal.getWriteLog();
+				samples.push({
+					observedMs,
+					cpuUserMicros: cpu.user,
+					cpuSystemMicros: cpu.system,
+					bytes: writes.reduce((sum, text) => sum + Buffer.byteLength(text), 0),
+					writes: writes.length,
+					stateHash: widthScanDigest({
+						writes,
+						viewport,
+						scrollback: terminal.getScrollBuffer(),
+						observation: tui.getViewportObservation(),
+						anchors: tui.getViewportAnchorSnapshot(),
+					}),
+				});
+			}
+		}
+		frameMetrics = renderMetrics.snapshot();
+		expect(measuredFrames).toBe(20);
+		if (metrics) expect(frameMetrics.renderCount).toBe(20);
+		Bun.gc(true);
+		liveMemory = process.memoryUsage();
+	} finally {
+		terminal.clearWriteLog();
+		tui.stop();
+		tui.dispose();
+		await terminal.flush();
+		teardownBytes = terminal.getWriteLog().reduce((sum, text) => sum + Buffer.byteLength(text), 0);
+		terminal.reset();
+		terminal.clearWriteLog();
+		renderMetrics.disable();
+		renderMetrics.reset();
+	}
+	Bun.gc(true);
+	return {
+		count,
+		phase,
+		metrics,
+		fixtureHash,
+		actualRawRows: initialRawRows.length,
+		fixtureUtf8Bytes: lines.reduce((sum, line) => sum + Buffer.byteLength(line), 0),
+		widths: phase === "resize" ? [100, 99] : [100],
+		rows: 30,
+		warmups: 5,
+		measuredFrames,
+		startupBytes,
+		teardownBytes,
+		frame: metrics ? frameMetrics.renderDurations : null,
+		lineCounts: metrics ? frameMetrics.lineCounts : null,
+		memory: { warm: warmMemory, live: liveMemory, afterDispose: process.memoryUsage() },
+		memoryScope: "Forced-GC samples; fixture and disposed harness remain referenced; not a leak/reclaim proof",
+		latencyScope:
+			phase === "input"
+				? "Dispatch through verified fresh emulator content"
+				: "Request through verified emulator content; includes scheduling",
+		frameScope:
+			"Synchronous render/immediate commit after preparations; excludes deferred terminal/emulator completion",
+		cpuScope:
+			"Process CPU for mutation/resize/input through fresh observation, including queued normal work; excludes state hashing and memory samples",
+		samples,
+	};
+}
 
 async function runTranscriptAppendBaseline(lineCount: number, label: string): Promise<void> {
 	const fixture: ReplayFixture = {

--- a/packages/tui/test/render-helper-counts.test.ts
+++ b/packages/tui/test/render-helper-counts.test.ts
@@ -1,6 +1,8 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
-import { type Component, TUI } from "@gajae-code/tui";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { type Component, Container, Editor, Text, TUI } from "@gajae-code/tui";
+import { ImageProtocol, setTerminalImageProtocol, TERMINAL } from "@gajae-code/tui/terminal-capabilities";
 import { visibleWidth } from "@gajae-code/tui/utils";
+import { defaultEditorTheme } from "./test-themes";
 import { VirtualTerminal } from "./virtual-terminal";
 
 class MutableLinesComponent implements Component {
@@ -34,10 +36,17 @@ function visible(term: VirtualTerminal): string[] {
 describe("TUI render helper counters", () => {
 	let previousDebugRedraw: string | undefined;
 	let monotonicNow = 0;
+	const previousEnvironment = new Map<string, string | undefined>();
+	const behaviorTraces: Array<{ scenario: string; frames: unknown[] }> = [];
 
 	beforeEach(() => {
 		previousDebugRedraw = Bun.env.PI_DEBUG_REDRAW;
 		delete Bun.env.PI_DEBUG_REDRAW;
+		for (const key of ["TMUX", "STY", "WT_SESSION", "PI_TUI_VIRTUAL_VIEWPORT", "GJC_TUI_IME_CURSOR"]) {
+			previousEnvironment.set(key, Bun.env[key]);
+			delete Bun.env[key];
+		}
+		Bun.env.GJC_TUI_IME_CURSOR = "0";
 		monotonicNow = 0;
 		TUI.resetRenderCountersForTest();
 		vi.spyOn(performance, "now").mockImplementation(() => {
@@ -49,11 +58,21 @@ describe("TUI render helper counters", () => {
 	afterEach(() => {
 		vi.restoreAllMocks();
 		TUI.resetRenderCountersForTest();
+		for (const [key, value] of previousEnvironment) {
+			if (value === undefined) delete Bun.env[key];
+			else Bun.env[key] = value;
+		}
+		previousEnvironment.clear();
 		if (previousDebugRedraw === undefined) {
 			delete Bun.env.PI_DEBUG_REDRAW;
 		} else {
 			Bun.env.PI_DEBUG_REDRAW = previousDebugRedraw;
 		}
+	});
+
+	afterAll(async () => {
+		if (behaviorTraces.length && Bun.env.GJC_WIDTH_SCAN_BEHAVIOR_REPORT)
+			await Bun.write(Bun.env.GJC_WIDTH_SCAN_BEHAVIOR_REPORT, JSON.stringify(behaviorTraces, null, 2));
 	});
 
 	it("caches PI_DEBUG_REDRAW and does not append debug logs when disabled", async () => {
@@ -126,4 +145,209 @@ describe("TUI render helper counters", () => {
 			tui.stop();
 		}
 	});
+
+	it("skips width-scan row visits on established non-forced live frames", async () => {
+		const term = new VirtualTerminal(40, 8);
+		const lines = Array.from({ length: 40 }, (_value, index) => `row-${index}`);
+		const component = new MutableLinesComponent(lines);
+		const editor = new Editor(defaultEditorTheme);
+		editor.setBorderVisible(false);
+		editor.setText("input");
+		const tui = new TUI(term, false, { widthSettleMs: 0 });
+		tui.addChild(component);
+		tui.addChild(editor);
+		tui.setFocus(editor);
+		try {
+			tui.start();
+			await committedFrame(tui, term, "setup");
+			for (const action of ["mutate", "append", "input", "same-size", "forced", "after-forced"]) {
+				TUI.resetRenderCountersForTest();
+				const marker = `tail-${action}`;
+				if (action === "append") lines.push(marker);
+				else lines[lines.length - 1] = marker;
+				component.setLines(lines);
+				if (action === "input") term.sendInput("A");
+				if (action === "same-size") term.resize(40, 8);
+				await committedFrame(tui, term, action, action === "forced");
+				expect(visible(term)).toContain(marker);
+				if (action === "input") {
+					expect(editor.getText()).toBe("inputA");
+					expect(visible(term)).toContain(`inputA${defaultEditorTheme.symbols.inputCursor}`);
+				}
+				expect(TUI.getRenderCountersForTest().widthReflowScanRows).toBe(0);
+			}
+		} finally {
+			tui.stop();
+			tui.dispose();
+			term.reset();
+		}
+	});
+
+	for (const virtual of ["0", "1"]) {
+		for (const overwide of [false, true]) {
+			it(`preserves width-scan resize visits and image exclusion: virtual=${virtual} overwide=${overwide}`, async () => {
+				Bun.env.PI_TUI_VIRTUAL_VIEWPORT = virtual;
+				const previousProtocol = TERMINAL.imageProtocol;
+				const image = `\x1b_Ga=T,f=32,s=1,v=1;AAAAAA==\x1b\\${"界".repeat(20)}`;
+				const equal = `\x1b[31m${"界".repeat(6)}\x1b[0m`;
+				const lines = [image, equal, overwide ? "界".repeat(7) : "fitting", "last"];
+				const term = new VirtualTerminal(12, 12);
+				const tui = new TUI(term, false, { widthSettleMs: 0 });
+				try {
+					setTerminalImageProtocol(ImageProtocol.Kitty);
+					expect(TERMINAL.isImageLine(image)).toBe(true);
+					expect(visibleWidth(image)).toBeGreaterThan(12);
+					expect(visibleWidth(equal)).toBe(12);
+					tui.addChild(new MutableLinesComponent(lines));
+					tui.start();
+					await committedFrame(tui, term, "setup");
+					TUI.resetRenderCountersForTest();
+					term.resize(14, 12);
+					await committedFrame(tui, term, "resize");
+					expect(TUI.getRenderCountersForTest().widthReflowScanRows).toBe(overwide ? 3 : lines.length);
+					TUI.resetRenderCountersForTest();
+					await committedFrame(tui, term, "forced", true);
+					expect(TUI.getRenderCountersForTest().widthReflowScanRows).toBe(0);
+				} finally {
+					try {
+						tui.stop();
+						tui.dispose();
+						term.reset();
+					} finally {
+						setTerminalImageProtocol(previousProtocol);
+					}
+				}
+			});
+		}
+
+		for (const processHost of [false, true]) {
+			it(`preserves width-scan behavior: virtual=${virtual} viewportHost=${processHost}`, async () => {
+				Bun.env.PI_TUI_VIRTUAL_VIEWPORT = virtual;
+				const term = new VirtualTerminal(40, 8, { isProcessTerminal: processHost });
+				const lines = Array.from({ length: 60 }, (_value, index) => `row-${index.toString().padStart(2, "0")}`);
+				const component = new MutableLinesComponent(lines);
+				const tui = new TUI(term, false, { widthSettleMs: 0 });
+				tui.addChild(component);
+				const frames: unknown[] = [];
+				const capture = async (label: string, force = false, resizeOnly = false) => {
+					await committedFrame(tui, term, resizeOnly ? "resize" : label, force);
+					frames.push(frameObservation(label, tui, term));
+					term.clearWriteLog();
+				};
+				try {
+					tui.start();
+					await capture("setup");
+					for (const label of ["mutation", "append", "same-size", "forced", "after-forced"]) {
+						if (label === "append") lines.push(label);
+						else lines[lines.length - 1] = label;
+						component.setLines(lines);
+						if (label === "same-size") term.resize(40, 8);
+						await capture(label, label === "forced");
+						expect(visible(term)).toContain(label);
+					}
+					for (const [width, height] of [
+						[40, 10],
+						[24, 10],
+						[40, 10],
+					] as const) {
+						term.resize(width, height);
+						await capture(`resize-${width}-${height}`, false, true);
+						expect(visible(term)).toContain("after-forced");
+					}
+					for (const resizeFirst of [true, false]) {
+						const marker = resizeFirst ? "once-resize-first" : "once-mutation-first";
+						if (resizeFirst) term.resize(30, 10);
+						lines.push(marker);
+						component.setLines(lines);
+						tui.requestRender(false, "mutation");
+						if (!resizeFirst) term.resize(40, 10);
+						await capture(marker);
+						expect(term.getScrollBuffer().filter(line => line.trimEnd() === marker)).toHaveLength(1);
+					}
+					lines[0] = "界".repeat(30);
+					lines.push("unproven-append");
+					component.setLines(lines);
+					term.resize(24, 10);
+					await capture("unproven-reflow");
+					expect(visible(term)).toContain("unproven-append");
+					behaviorTraces.push({ scenario: `virtual=${virtual},viewportHost=${processHost}`, frames });
+				} finally {
+					tui.stop();
+					tui.dispose();
+					term.reset();
+				}
+			});
+		}
+	}
+
+	it("preserves width-scan behavior for renderer-owned anchors and manual history", async () => {
+		const term = new VirtualTerminal(40, 8, { isProcessTerminal: true });
+		const tui = new TUI(term, false, { widthSettleMs: 0 });
+		const transcript = new Container();
+		const texts = Array.from(
+			{ length: 60 },
+			(_value, index) => new Text(`row-${index} alpha beta gamma delta`, 0, 0),
+		);
+		for (const [index, text] of texts.entries()) {
+			transcript.addChild(text);
+			transcript.setViewportAnchorSource(text, { id: `message-${index}` });
+		}
+		tui.addChild(transcript);
+		tui.setViewportAnchorComponent(transcript);
+		tui.setViewportOutputSource({ identity: "width-scan", revision: 0n });
+		const frames: unknown[] = [];
+		const capture = async (label: string, directPaint = false) => {
+			if (directPaint) await term.flush();
+			else await committedFrame(tui, term, label);
+			frames.push({ directPaint, ...frameObservation(label, tui, term) });
+			term.clearWriteLog();
+		};
+		try {
+			tui.start();
+			await capture("setup");
+			expect(tui.getViewportAnchorSnapshot()?.anchors.some(anchor => anchor?.id === "message-59")).toBe(true);
+			// Edge pinning makes the first-visible semantic observation the retained anchor.
+			expect(tui.scrollViewportBy(-12, { pin: "edge" })).toBe(true);
+			await capture("manual", true);
+			const anchored = tui.getViewportObservation()?.semanticAnchor;
+			expect(anchored).toMatchObject({ id: "message-40", graphemeStart: 0, cellStart: 0 });
+			expect(tui.getViewportObservation()?.manualHistory).toBe(true);
+			texts[59]!.setText("hidden live mutation");
+			tui.setViewportOutputSource({ identity: "width-scan", revision: 1n });
+			await capture("manual-mutation");
+			expect(tui.getViewportObservation()?.semanticAnchor?.id).toBe(anchored?.id);
+			term.resize(24, 8);
+			await capture("manual-resize");
+			const reflowed = tui.getViewportObservation()?.semanticAnchor;
+			expect(reflowed?.id).toBe(anchored?.id);
+			expect(reflowed!.graphemeStart).toBeLessThanOrEqual(anchored!.graphemeStart);
+			expect(reflowed!.graphemeEnd).toBeGreaterThan(anchored!.graphemeStart);
+			expect(tui.followLiveViewport()).toBe(true);
+			await capture("follow-live", true);
+			expect(tui.getViewportObservation()?.manualHistory).toBe(false);
+			expect(visible(term)).toContain("hidden live mutation");
+			behaviorTraces.push({ scenario: "semantic-anchors", frames });
+		} finally {
+			tui.stop();
+			tui.dispose();
+			term.reset();
+		}
+	});
 });
+
+async function committedFrame(tui: TUI, term: VirtualTerminal, source: string, force = false): Promise<void> {
+	const generation = tui.requestRenderWithGeneration(force, source);
+	expect(await tui.waitForRenderCommit(generation, 1_000)).toBe(true);
+	await term.flush();
+}
+
+function frameObservation(label: string, tui: TUI, term: VirtualTerminal) {
+	return {
+		label,
+		writes: term.getWriteLog(),
+		viewport: term.getViewport(),
+		scrollback: term.getScrollBuffer(),
+		observation: tui.getViewportObservation(),
+		anchors: tui.getViewportAnchorSnapshot(),
+	};
+}


### PR DESCRIPTION
## What

- Short-circuit the existing `widthReflowRequired` calculation with `widthChanged`, before the existing positive-previous-width guard.
- Preserve the initializer position, image exclusion, strict width comparison, `.some` early exit, and resize-only consumer.
- Add `widthReflowScanRows` through the existing test-counter snapshot/reset surface, plus live-render structural and behavioral regressions.
- Add an opt-in advisory width-scan workload in the existing performance suite and close fixture setup-failure cleanup gaps.
- Update the existing TUI changelog.

No new production feature API, setting, dependency, cache, timer, render-frequency limit, or Markdown cache redesign.

## Why

The reflow predicate was scanning the entire rendered transcript on ordinary fixed-width frames even though its only consumer is guarded by `widthChanged && !coalescedWidthAppend`. Skipping that unused calculation removes linear work without dropping updates or changing resize decisions. The existing `previousWidth > 0` check still preserves initial/forced-render sentinel behavior.

## Testing

Rebased onto current `dev` at `f571d4ea452e2c090cbded2ac2bed4fd85288753`; refreshed head is `95591f0228e8`. The patch remains unchanged in the touched production logic.

Re-run on the rebased branch:

```sh
bun --cwd=packages/tui run check
bun test packages/tui/test/render-helper-counts.test.ts packages/tui/test/resize-width-settle.test.ts packages/tui/test/render-commit.test.ts
PI_TUI_PERF_GATES=1 GJC_WIDTH_SCAN_REPORT=/tmp/width-scan-report.json bun test packages/tui/test/perf-baselines.test.ts -t width-scan
git diff origin/dev...HEAD --check
```

- Package Biome and TypeScript checks pass.
- Focused regressions: **42 passed, 0 failed, 10,817 assertions**.
- Advisory fixture: **1 passed, 14 workloads, 1,350 assertions**.
- Rebased behavior trace is byte-identical to the unchanged-runtime oracle, including writes, viewport, scrollback, observations, and anchors.
- Structural red/green was demonstrated before adding the guard: an established, non-forced fixed-width frame visited 41 rows; the guarded case visits zero. Actual resizes retain positive/full/early-exit visits, including image and exact-width controls.
- Before/after setup-failure injection confirms protocol restoration and TUI disposal without swallowing the intentionally failing tests.
- Retained same-runtime native OS PTY smoke covers streaming with Unicode input, narrowing/widening, manual history, follow-live, and graceful exit. Its 71,662-byte ANSI capture contains actual terminal controls.

### Advisory measurements

Five fresh-process A/B pairs with alternating order, five warmups and twenty measured samples per workload; deterministic 64/8,000/40,000-row fixtures on Bun 1.4.2, darwin-arm64. CPU measurements have helper metrics disabled; synchronous frame timing is measured separately with metrics enabled.

| Transcript rows | Phase | CPU ms / verified frame, baseline → candidate |
| --- | --- | --- |
| 8,000 | normal | 7.4159 → 1.6125 |
| 8,000 | input | 7.08105 → 1.1687 |
| 40,000 | normal | 33.4425 → 5.8792 |
| 40,000 | input | 33.7665 → 3.9205 |

CPU entries are medians of five per-run means. Input-to-fresh-emulator-content p95 (median of five run-p95s) is **8.3243 → 2.4767 ms** at 8,000 rows and **34.3457 → 5.2160 ms** at 40,000 rows. All **1,400 paired measured observations** match output byte counts, write counts, and state digests; startup/teardown observations also match.

Timing pairs used identical original fixture source on baseline/candidate. The runtime implementation is unchanged through the later cleanup repair and rebase. Repaired/rebased fixture validation runs are separate correctness evidence, not additional timing pairs. These reconstructed workloads are not the earlier real-assistant research projection, and isolated scan timings were not subtracted from whole-frame p95.

### Limitations and tradeoffs

- **No zero-overhead resize claim.** The separate 40,000-row actual `100↔99` resize control has median paired CPU changes of **+0.6225%** with metrics off and **+0.1711%** with metrics on, with mixed-sign ranges. Metrics-on observed resize p95 increased **0.2703–1.1431 ms** across the five pairs; synchronous frame-p95 deltas are mixed. All pairs/order groups were investigated, and the possible small cost of the accepted per-visited-row test counter is retained as an explicit tradeoff.
- **No memory-saving claim.** Sampled 40,000-row input RSS was about **285.6 → 314.1 MB**, heap used **34.17 → 34.39 MB**. Fixtures/disposed harnesses remain referenced at sampling; allocator/JIT/GC explanations are hypotheses, not causal or leak/reclamation proof.
- Normal observed latency can remain scheduler-bound. OS PTY/emulator observations do not establish physical-display latency or subjective smoothness. Twenty samples and five pairs limit tail precision.
- The separate unchanged `node-pty` matrix had **1 pass / 5 empty-output timeouts**; a standalone output probe also returned no data. Successful native `PtySession` validation does not erase those failures.
- Full repository checks and hosted CI are not claimed. Local raw QA artifacts remain in ignored `artifacts/`; committed fixtures/regressions are reproducible with the commands above.

## Risk classification

- [ ] `low-risk`
- [x] `regression-risk` — this changes the core TUI render path, where a regression can affect redraw, resize, viewport, and scrollback behavior. The counter accessor is test-facing, but its per-visited-row increment also executes during real runtime resize scans. The possible resize cost and limited terminal/platform coverage remain disclosed.
- [ ] `high-risk`

The guard has a narrow sole-consumer equivalence argument, and the focused structural/parity tests substantially reduce risk. Those facts do not qualify the entire PR for the owner-only low-risk merge path. This is not a large redesign or public-feature/API migration.

Merge requires one assigned independent TUI/domain reviewer and an authenticated exact-head `APPROVED` review, as required by the repository's `regression-risk` policy. The current head is `95591f0228e8`. AI reviews and local test passes do not substitute for that independent approval; the verdict remains `needs-human`.

## GJC verdict

Independent owner review completed on the exact head; merge is authorized.

```text
gajae.pr-review-verdict.v1 merge-approved sha256:6647db99738b0f4c09828efda2d5eeec3b086e99ef5cd065a535b3affcf8dac7 reviewer:human reviewer-id:Yeachan-Heo evidence:bun test packages/tui/test/render-helper-counts.test.ts packages/tui/test/perf-baselines.test.ts packages/tui/test/resize-width-settle.test.ts packages/tui/test/render-commit.test.ts (47 passed); bun --cwd=packages/tui run check (passed); authenticated exact-head approval
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes — full repository gate not run; targeted package check passed
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken