### PR TITLE
docs(paseo): correct resumed session identity and status limits

### DIFF
--- a/docs/terminal-app-integrations.md
+++ b/docs/terminal-app-integrations.md
@@ -78,6 +78,10 @@ turn back: assistant text, thinking, and tool calls arrive as they happen, and t
 `idle`. Content is delivered only to the connections that submitted the turn, so an ordinary terminal
 prompt with nobody attached streams nothing, and a session with no attached client costs nothing.
 
+Displaying externally initiated work as running requires client support. Paseo 0.7.2 reads the
+standard `title` and `updatedAt` fields of `session_info_update`, but ignores GJC's running/idle
+metadata, so its displayed status can remain `idle` during terminal work.
+
 GJC can perform the one remaining step for you. This is **opt-in and off by default** — nothing
 contacts Paseo until you turn it on:
 
@@ -117,13 +121,14 @@ remove an agent you still wanted — and the cleanup is yours to run.
 
 What that means in practice:
 
-- **One entry per launch.** Every interactive start gets a fresh session id, including `gjc -c`, so
-  resuming your work in the same directory adds another entry rather than reusing the previous one.
+- **One entry per session.** A new session gets a new entry. Continuing an existing session with
+  `gjc -c` preserves its session id and reuses its imported Paseo entry; the duplicate-import
+  response is not a registration failure. The ACP router follows the replacement live host.
 - **Ending the session does not remove its entry.** Paseo keeps listing it, and keeps showing it as
   `idle`, because nothing told the daemon otherwise. Sending to it fails with
   `SDK session attachment is stale`, and Paseo then marks it `error`.
 
-So the list grows one row per launch until you prune it:
+So the list grows one row per new session until you prune it:
 
 ```sh
 paseo ls                  # find the stale ids


### PR DESCRIPTION
## What

- Correct the Paseo lifecycle documentation so `gjc -c` is described as continuing the existing session identity rather than creating a new one.
- Document that the installed Paseo 0.7.2 client reads standard `title` and `updatedAt` metadata but ignores GJC's running/idle metadata.

## Why

The previous wording overstated entry creation on every launch. The implementation passes the persisted session ID to `paseo import`, treats a duplicate import as an already-imported success, and lets the ACP router attach to the replacement live host. The status limitation is documented separately so the guide does not promise a running display that the installed client cannot render.

## Testing

- `bun test packages/coding-agent/test/paseo-announce.test.ts packages/coding-agent/test/acp/acp-transcript-replay-continuation.test.ts` — 60 passed.
- `bun test packages/coding-agent/test/acp-event-mapper.test.ts` — 35 passed.
- `bun test scripts/verify-pr-verdict.test.ts` — 47 passed.
- `bun --cwd=packages/natives run build` — passed; required to provide the local native test dependency.
- `git diff --check f571d4ea452e2c090cbded2ac2bed4fd85288753...50eae6da473db7eec894f8bca6d715dc281cff0b` — passed.
- Reviewed the affected Paseo announcement, ACP attach/resume, and status-update code paths. `paseo` is not installed in this workspace, so the Paseo 0.7.2 client observation remains bounded to the PR's recorded live-client evidence.

## Risk classification

- [x] `low-risk` — documentation-only correction; no runtime behavior or public API changes.
- [ ] `regression-risk` — fix with material regression risk.
- [ ] `high-risk` — large refactor, feature, or materially high-risk change.

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:6eb5bb5a80183508fb1b4eb3e663efb5076d1b1862d4b4cb12ae25c096e2597b reviewer:human reviewer-id:Yeachan-Heo evidence:https://github.com/Yeachan-Heo/gajae-code/actions/runs/34075387242; https://github.com/Yeachan-Heo/gajae-code/actions/runs/34075153651 affected validation jobs; focused local tests; git diff --check
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes — not run; focused affected-surface tests were used instead.
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing) — not applicable to this documentation correction; no package behavior changed.
- [x] Verdict above matches the exact PR head `50eae6da473db7eec894f8bca6d715dc281cff0b` and base `f571d4ea452e2c090cbded2ac2bed4fd85288753`.
- [x] Risk classification above matches the actual review path taken.