### PR TITLE
fix(auth): honor saved account pins during profile discovery

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- Credential-scoped model discovery now peeks the OAuth account selected for that session instead of falling back to unscoped pool ranking. An expired hard-pinned token returns unavailable rather than querying another account's catalog, while AUTO and callers without a scope retain their existing selection behavior.
+
 - ChatGPT Codex Sol credential selection no longer denies `gpt-5.6-sol` from the account's plan label. A Plus-labelled OAuth account was rejected locally before any request, but the provider accepts that account and returns a normal `200`; trial, grandfathered and experiment-enabled accounts all carry an ordinary plan label. Plan tier now only ranks Sol candidates, so a Pro account is still preferred and a Plus account is used when it is the only one connected or the preferred one is exhausted. Spark keeps its existing confirmed-Pro filtering when a Pro account is present. The provider remains the entitlement authority for Sol, and its refusal is still surfaced through the same actionable message (#5270).
 - Auth-broker failure reasons are scanned in linear time. Two rules accepted an unbounded scheme before the literal `://`, so a long run of scheme characters was re-tried at every prefix: 120 KB of upstream failure text cost roughly two seconds. Upstream reason text is remote-influenced, and `cleanReason` is what makes it safe for less-trusted surfaces.
 - Cursor's first-event deadline now bounds asynchronous payload hooks before any authenticated request is opened, and successful HTTP/2 teardown sends END_STREAM before falling back to bounded cleanup for a peer that leaves its response half open (#4834 review).
@@ -25,10 +27,6 @@
 - Documented `GJC_OPENAI_CODE_WEBSOCKET_V2` as a switch that enables a websocket v2 path. No code read it under that name, under the legacy `PI_CODEX_WEBSOCKET_V2`, or under the `PI_OPENAI_CODE_WEBSOCKET_V2` the historical entry records; the v2 beta header has been unconditional for websocket transport. The documentation row is removed rather than reintroducing a knob, and the test that claimed to gate on it no longer writes an environment variable nothing reads.
 - Maintenance reasoning now fails closed for Anthropic models routed through an unverified custom endpoint and for raw reasoning-enabled models without thinking metadata. This prevents unsupported thinking controls and avoids a synchronous missing-metadata crash before provider wire transformation.
 - The auth-gateway OpenAI Responses and Chat Completions encoders now emit only the `call_id` half of a Codex/Responses compound tool-call id (`call_…|fc_…`) on the wire. The compound encoding is gjc-internal replay state; a downstream OpenAI-format client that echoed it back truncated it at its own 64-character limit and every chained tool turn was then rejected with `400 No tool output found for function call`. The item id still travels as the Responses item `id`.
-
-### Fixed
-
-- Credential-scoped model discovery now peeks the OAuth account selected for that session instead of falling back to unscoped pool ranking. An expired hard-pinned token returns unavailable rather than querying another account's catalog, while AUTO and callers without a scope retain their existing selection behavior.
 
 ## [0.16.4] - 2026-09-05
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -26,6 +26,10 @@
 - Maintenance reasoning now fails closed for Anthropic models routed through an unverified custom endpoint and for raw reasoning-enabled models without thinking metadata. This prevents unsupported thinking controls and avoids a synchronous missing-metadata crash before provider wire transformation.
 - The auth-gateway OpenAI Responses and Chat Completions encoders now emit only the `call_id` half of a Codex/Responses compound tool-call id (`call_…|fc_…`) on the wire. The compound encoding is gjc-internal replay state; a downstream OpenAI-format client that echoed it back truncated it at its own 64-character limit and every chained tool turn was then rejected with `400 No tool output found for function call`. The item id still travels as the Responses item `id`.
 
+### Fixed
+
+- Credential-scoped model discovery now peeks the OAuth account selected for that session instead of falling back to unscoped pool ranking. An expired hard-pinned token returns unavailable rather than querying another account's catalog, while AUTO and callers without a scope retain their existing selection behavior.
+
 ## [0.16.4] - 2026-09-05
 
 ### Added

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1335,6 +1335,8 @@ export class AuthStorage {
 	#sessionCredentialSelectors: Map<string, Map<string, AuthCredentialSelector>> = new Map();
 	/** Explicit AUTO masks suppress both scoped and process-global selectors for a scope/provider. */
 	#sessionCredentialAutoMasks: Map<string, Set<string>> = new Map();
+	/** Hard-pin failures that must remain unavailable until an explicit user choice. */
+	#sessionCredentialUnavailable: Map<string, Map<string, AuthCredentialSelector>> = new Map();
 	/** Reference counts for sessions sharing one credential scope (top-level + subagents). */
 	#credentialScopeLeases: Map<string, number> = new Map();
 	/** Tracks next credential index per provider:type key for round-robin distribution (non-session use). */
@@ -1441,6 +1443,7 @@ export class AuthStorage {
 		this.#credentialScopeLeases.clear();
 		this.#sessionCredentialSelectors.clear();
 		this.#sessionCredentialAutoMasks.clear();
+		this.#sessionCredentialUnavailable.clear();
 		this.#sessionLastCredential.clear();
 		this.#store.close();
 	}
@@ -1667,6 +1670,7 @@ export class AuthStorage {
 		this.#credentialScopeLeases.delete(scope);
 		this.#sessionCredentialSelectors.delete(scope);
 		this.#sessionCredentialAutoMasks.delete(scope);
+		this.#sessionCredentialUnavailable.delete(scope);
 		for (const [provider, sessions] of this.#sessionLastCredential) {
 			if (!sessions.delete(scope)) continue;
 			if (sessions.size === 0) this.#sessionLastCredential.delete(provider);
@@ -1688,6 +1692,7 @@ export class AuthStorage {
 		if (!scope) throw new Error("Credential scope id must not be empty");
 		const storageProvider = resolveOAuthStorageProvider(provider);
 		this.#assertCredentialSelectorUsable(storageProvider, selector, owner);
+		this.#sessionCredentialUnavailable.get(scope)?.delete(storageProvider);
 		const selectors = this.#sessionCredentialSelectors.get(scope) ?? new Map<string, AuthCredentialSelector>();
 		selectors.set(storageProvider, selector);
 		this.#sessionCredentialSelectors.set(scope, selectors);
@@ -1701,6 +1706,7 @@ export class AuthStorage {
 		if (!scope) throw new Error("Credential scope id must not be empty");
 		const storageProvider = resolveOAuthStorageProvider(provider);
 		this.#sessionCredentialSelectors.get(scope)?.delete(storageProvider);
+		this.#sessionCredentialUnavailable.get(scope)?.delete(storageProvider);
 		const masks = this.#sessionCredentialAutoMasks.get(scope) ?? new Set<string>();
 		masks.add(storageProvider);
 		this.#sessionCredentialAutoMasks.set(scope, masks);
@@ -1718,6 +1724,28 @@ export class AuthStorage {
 		if (selectors?.size === 0) this.#sessionCredentialSelectors.delete(scope);
 		if (masks?.size === 0) this.#sessionCredentialAutoMasks.delete(scope);
 		if (changed) this.#bumpGeneration("clear-session-credential-selector", storageProvider);
+	}
+
+	/** Preserve a failed hard pin as unavailable instead of allowing AUTO fallback. */
+	markSessionCredentialUnavailable(scopeId: string, provider: string, selector: AuthCredentialSelector): void {
+		const scope = scopeId.trim();
+		if (!scope) throw new Error("Credential scope id must not be empty");
+		const storageProvider = resolveOAuthStorageProvider(provider);
+		const unavailable = this.#sessionCredentialUnavailable.get(scope) ?? new Map<string, AuthCredentialSelector>();
+		unavailable.set(storageProvider, selector);
+		this.#sessionCredentialUnavailable.set(scope, unavailable);
+		this.#sessionCredentialSelectors.get(scope)?.delete(storageProvider);
+		this.#sessionCredentialAutoMasks.get(scope)?.delete(storageProvider);
+		this.#bumpGeneration("mark-session-credential-unavailable", storageProvider);
+	}
+
+	/** Return a failed hard pin retained for this scope, if any. */
+	hasSessionCredentialUnavailable(provider: string, scopeId?: string): boolean {
+		const scope = scopeId?.trim();
+		return (
+			scope !== undefined &&
+			this.#sessionCredentialUnavailable.get(scope)?.has(resolveOAuthStorageProvider(provider)) === true
+		);
 	}
 
 	/** Whether the effective selection for a scope is explicitly pinned (AUTO masks are not pins). */
@@ -4822,6 +4850,15 @@ export class AuthStorage {
 		options?: AuthApiKeyOptions,
 		reloadsUsed = 0,
 	): Promise<OAuthResolutionResult | undefined> {
+		const unavailableSelector =
+			sessionId && !options?.credentialSelector
+				? this.#sessionCredentialUnavailable.get(sessionId)?.get(resolveOAuthStorageProvider(provider))
+				: undefined;
+		if (unavailableSelector) {
+			throw new Error(
+				`Selected credential for ${provider} (${this.#formatCredentialSelector(unavailableSelector)}) is unavailable`,
+			);
+		}
 		if (reloadsUsed > MAX_OAUTH_RESOLUTION_RELOADS) {
 			logger.warn("OAuth credential resolution exhausted its reload budget", {
 				provider,
@@ -4830,6 +4867,10 @@ export class AuthStorage {
 			return undefined;
 		}
 		const selectedCredential = this.#resolveSelectedStoredCredential(provider, options, sessionId);
+		const sessionSelector =
+			sessionId && !options?.credentialSelector && selectedCredential?.credential.type === "oauth"
+				? { kind: "id" as const, value: String(selectedCredential.id) }
+				: undefined;
 		const selectedOAuthCredential: OAuthCredentialSelection | undefined =
 			selectedCredential?.credential.type === "oauth"
 				? {
@@ -4952,6 +4993,17 @@ export class AuthStorage {
 					);
 				} catch (error) {
 					if (isSqliteError(error)) throw error;
+					if (
+						sessionSelector &&
+						/invalid_grant|grant is invalid|invalid_token|revoked|unauthorized|expired.*refresh|refresh.*expired/i.test(
+							String(error),
+						)
+					) {
+						this.markSessionCredentialUnavailable(sessionId!, provider, sessionSelector);
+						throw new Error(
+							`Selected credential for ${provider} (${this.#formatCredentialSelector(sessionSelector)}) is unavailable`,
+						);
+					}
 				}
 			}),
 		);
@@ -4982,6 +5034,7 @@ export class AuthStorage {
 					enforceSparkProRequirement,
 				},
 				reloadsUsed,
+				sessionSelector,
 			);
 			if (resolved) return resolved;
 		}
@@ -5001,6 +5054,7 @@ export class AuthStorage {
 					enforceSparkProRequirement,
 				},
 				reloadsUsed,
+				sessionSelector,
 			);
 		}
 
@@ -5287,6 +5341,7 @@ export class AuthStorage {
 			enforceSparkProRequirement?: boolean;
 		},
 		reloadsUsed = 0,
+		sessionSelector?: AuthCredentialSelector,
 	): Promise<OAuthResolutionResult | undefined> {
 		const {
 			checkUsage,
@@ -5498,6 +5553,9 @@ export class AuthStorage {
 					`oauth refresh failed: ${errorMsg}`,
 					attemptedCredentialId,
 				);
+				if (sessionSelector && sessionId) {
+					this.markSessionCredentialUnavailable(sessionId, provider, sessionSelector);
+				}
 				if (!disabled) {
 					// The CAS predicate compares the row's serialized `data`, so it also
 					// misses when nothing was rotated: the row may have been replaced by
@@ -5510,7 +5568,12 @@ export class AuthStorage {
 					// peer rotation to clobber — so apply it directly instead of looping.
 					const stillHoldsAttemptedToken =
 						attemptedCredentialId !== undefined &&
-						this.#credentialRowHoldsRefreshToken(provider, attemptedCredentialId, attemptedRefreshToken);
+						(this.#credentialRowHoldsRefreshToken(provider, attemptedCredentialId, attemptedRefreshToken) ||
+							this.#credentialRowHoldsRefreshToken(
+								provider,
+								attemptedCredentialId,
+								selection.credential.refresh,
+							));
 					if (stillHoldsAttemptedToken && attemptedCredentialId !== undefined) {
 						logger.warn("OAuth refresh disable CAS mismatched an unrotated row; disabling by id", {
 							provider,
@@ -5568,6 +5631,9 @@ export class AuthStorage {
 		}
 		if (this.#getCredentialSelector(provider, options, sessionId)) {
 			const selector = this.#getCredentialSelector(provider, options, sessionId);
+			if (selector && sessionId && !options?.credentialSelector) {
+				this.markSessionCredentialUnavailable(sessionId, provider, selector);
+			}
 			throw new Error(
 				`Selected credential for ${provider} (${selector ? this.#formatCredentialSelector(selector) : "unknown"}) is unavailable`,
 			);
@@ -5655,6 +5721,7 @@ export class AuthStorage {
 		const configOverride = this.#configOverrideRegistration(provider, options?.owner);
 		const configKey = configOverride?.apiKey;
 		if (configKey && !configOverride?.envSourced) return configKey;
+		if (options?.sessionId && this.hasSessionCredentialUnavailable(provider, options.sessionId)) return undefined;
 
 		const selectedCredential = this.#resolveSelectedStoredCredential(
 			provider,

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -5644,7 +5644,10 @@ export class AuthStorage {
 	 * and get a best-effort token. For GitHub Copilot we preserve enterprise
 	 * routing metadata so discovery can hit the correct host.
 	 */
-	async peekApiKey(provider: string, options?: Pick<AuthApiKeyOptions, "owner">): Promise<string | undefined> {
+	async peekApiKey(
+		provider: string,
+		options?: Pick<AuthApiKeyOptions, "owner"> & { sessionId?: string },
+	): Promise<string | undefined> {
 		provider = resolveOAuthStorageProvider(provider);
 		const runtimeKey = this.#runtimeOverrides.get(provider);
 		if (runtimeKey) return runtimeKey;
@@ -5656,7 +5659,7 @@ export class AuthStorage {
 		const selectedCredential = this.#resolveSelectedStoredCredential(
 			provider,
 			options?.owner ? { owner: options.owner } : undefined,
-			undefined,
+			options?.sessionId,
 		);
 		if (configKey) {
 			// Env-sourced (`apiKeyEnv`) override: same precedence as getApiKey —
@@ -5683,6 +5686,10 @@ export class AuthStorage {
 			}
 			return undefined;
 		}
+		// A hard selector is an identity boundary. If its selected row cannot
+		// provide a current token, discovery must not continue into the shared
+		// credential pool and silently query another account's catalog.
+		if (this.#getCredentialSelector(provider, undefined, options?.sessionId)) return undefined;
 
 		const attemptedApiKeyIndices = new Set<number>();
 		for (;;) {

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -2831,7 +2831,9 @@ export class AuthStorage {
 			const selector = selectors.get(storageProvider);
 			if (!selector) continue;
 			const selected = previousEntries.find(entry => this.#credentialMatchesSelector(entry, selector));
-			if (selected && removedIds.has(selected.id)) this.clearSessionCredentialSelector(storageProvider, scopeId);
+			if (selected && removedIds.has(selected.id)) {
+				this.markSessionCredentialUnavailable(scopeId, storageProvider, selector);
+			}
 		}
 		for (const [sessionId, sticky] of this.#sessionLastCredential.get(storageProvider) ?? []) {
 			if (removedIds.has(previousEntries[sticky.index]?.id ?? -1))
@@ -4993,17 +4995,6 @@ export class AuthStorage {
 					);
 				} catch (error) {
 					if (isSqliteError(error)) throw error;
-					if (
-						sessionSelector &&
-						/invalid_grant|grant is invalid|invalid_token|revoked|unauthorized|expired.*refresh|refresh.*expired/i.test(
-							String(error),
-						)
-					) {
-						this.markSessionCredentialUnavailable(sessionId!, provider, sessionSelector);
-						throw new Error(
-							`Selected credential for ${provider} (${this.#formatCredentialSelector(sessionSelector)}) is unavailable`,
-						);
-					}
 				}
 			}),
 		);
@@ -5801,6 +5792,14 @@ export class AuthStorage {
 	 */
 	async getApiKey(provider: string, sessionId?: string, options?: AuthApiKeyOptions): Promise<string | undefined> {
 		provider = resolveOAuthStorageProvider(provider);
+		if (sessionId && !options?.credentialSelector) {
+			const unavailableSelector = this.#sessionCredentialUnavailable.get(sessionId)?.get(provider);
+			if (unavailableSelector) {
+				throw new Error(
+					`Selected credential for ${provider} (${this.#formatCredentialSelector(unavailableSelector)}) is unavailable`,
+				);
+			}
+		}
 		const selectedCredential = this.#resolveSelectedStoredCredential(provider, options, sessionId);
 
 		// Runtime override takes highest priority after selector validation.

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -5792,14 +5792,6 @@ export class AuthStorage {
 	 */
 	async getApiKey(provider: string, sessionId?: string, options?: AuthApiKeyOptions): Promise<string | undefined> {
 		provider = resolveOAuthStorageProvider(provider);
-		if (sessionId && !options?.credentialSelector) {
-			const unavailableSelector = this.#sessionCredentialUnavailable.get(sessionId)?.get(provider);
-			if (unavailableSelector) {
-				throw new Error(
-					`Selected credential for ${provider} (${this.#formatCredentialSelector(unavailableSelector)}) is unavailable`,
-				);
-			}
-		}
 		const selectedCredential = this.#resolveSelectedStoredCredential(provider, options, sessionId);
 
 		// Runtime override takes highest priority after selector validation.
@@ -5823,6 +5815,14 @@ export class AuthStorage {
 			const storedApiKey = await this.#resolveStoredApiKeyOverEnvConfig(provider, selectedCredential, sessionId);
 			if (storedApiKey) return storedApiKey;
 			return configKey;
+		}
+		if (sessionId && !options?.credentialSelector) {
+			const unavailableSelector = this.#sessionCredentialUnavailable.get(sessionId)?.get(provider);
+			if (unavailableSelector) {
+				throw new Error(
+					`Selected credential for ${provider} (${this.#formatCredentialSelector(unavailableSelector)}) is unavailable`,
+				);
+			}
 		}
 
 		if (selectedCredential?.credential.type === "api_key") {

--- a/packages/ai/test/auth-storage-session-selectors.test.ts
+++ b/packages/ai/test/auth-storage-session-selectors.test.ts
@@ -55,6 +55,68 @@ describe("AuthStorage session credential selectors", () => {
 		}
 	});
 
+	test("discovery peeks honor scoped pins without changing unscoped or AUTO selection", async () => {
+		const storage = await createStorage();
+		try {
+			storage.setRuntimeCredentialSelector("anthropic", { kind: "email", value: "first@example.com" });
+			storage.acquireCredentialScope("pinned-discovery");
+			storage.acquireCredentialScope("auto-discovery");
+			storage.setSessionCredentialSelector("pinned-discovery", "anthropic", {
+				kind: "email",
+				value: "second@example.com",
+			});
+			storage.setSessionCredentialAuto("anthropic", "auto-discovery");
+
+			expect(await storage.peekApiKey("anthropic")).toBe("access-first");
+			expect(await storage.peekApiKey("anthropic", { sessionId: "pinned-discovery" })).toBe("access-second");
+			expect(await storage.peekApiKey("anthropic", { sessionId: "auto-discovery" })).toBe("access-first");
+		} finally {
+			storage.close();
+		}
+	});
+
+	test("discovery peeks select the pinned row independently of credential insertion order", async () => {
+		for (const order of [
+			["first", "second"],
+			["second", "first"],
+		] as const) {
+			const store = await SqliteAuthCredentialStore.open(":memory:");
+			for (const suffix of order) store.saveOAuth("anthropic", oauth(suffix));
+			const storage = new AuthStorage(store);
+			await storage.reload();
+			try {
+				storage.acquireCredentialScope("ordered-discovery");
+				storage.setSessionCredentialSelector("ordered-discovery", "anthropic", {
+					kind: "email",
+					value: "second@example.com",
+				});
+				expect(await storage.peekApiKey("anthropic", { sessionId: "ordered-discovery" })).toBe("access-second");
+			} finally {
+				storage.close();
+			}
+		}
+	});
+
+	test("an expired scoped OAuth pin never falls through to another account", async () => {
+		const store = await SqliteAuthCredentialStore.open(":memory:");
+		store.saveOAuth("anthropic", oauth("usable"));
+		store.saveOAuth("anthropic", { ...oauth("expired"), expires: Date.now() - 1 });
+		const storage = new AuthStorage(store);
+		await storage.reload();
+		try {
+			storage.acquireCredentialScope("expired-pin");
+			storage.setSessionCredentialSelector("expired-pin", "anthropic", {
+				kind: "email",
+				value: "expired@example.com",
+			});
+
+			expect(await storage.peekApiKey("anthropic", { sessionId: "expired-pin" })).toBeUndefined();
+			expect(await storage.peekApiKey("anthropic")).toBe("access-usable");
+		} finally {
+			storage.close();
+		}
+	});
+
 	test("unavailable scoped pins fail loudly and final lease release clears only that scope", async () => {
 		const storage = await createStorage();
 		try {
@@ -65,6 +127,7 @@ describe("AuthStorage session credential selectors", () => {
 					value: "missing@example.com",
 				}),
 			).toThrow("No credential found");
+			expect(await storage.peekApiKey("anthropic", { sessionId: "leased" })).toBe("access-first");
 			storage.setSessionCredentialSelector("leased", "anthropic", { kind: "email", value: "first@example.com" });
 			storage.releaseCredentialScope("leased");
 			expect(storage.hasSessionCredentialSelector("leased", "anthropic")).toBe(false);

--- a/packages/ai/test/auth-storage-session-selectors.test.ts
+++ b/packages/ai/test/auth-storage-session-selectors.test.ts
@@ -117,6 +117,31 @@ describe("AuthStorage session credential selectors", () => {
 		}
 	});
 
+	test("unavailable scoped pins never fall through to stored API keys", async () => {
+		const store = await SqliteAuthCredentialStore.open(":memory:");
+		store.replaceAuthCredentialsForProvider("anthropic", [
+			oauth("pinned"),
+			{ type: "api_key", key: "alternate-api-key" },
+		]);
+		const storage = new AuthStorage(store);
+		await storage.reload();
+		try {
+			storage.acquireCredentialScope("unavailable-api-key");
+			storage.setSessionCredentialSelector("unavailable-api-key", "anthropic", {
+				kind: "email",
+				value: "pinned@example.com",
+			});
+			storage.markSessionCredentialUnavailable("unavailable-api-key", "anthropic", {
+				kind: "email",
+				value: "pinned@example.com",
+			});
+
+			await expect(storage.getApiKey("anthropic", "unavailable-api-key")).rejects.toThrow(/is unavailable/);
+		} finally {
+			storage.close();
+		}
+	});
+
 	test("unavailable scoped pins fail loudly and final lease release clears only that scope", async () => {
 		const storage = await createStorage();
 		try {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -87,6 +87,10 @@
 
 - Tool hot paths avoid overlap-table allocations for equal/append-only ACP output, redundant UTF-8 tail previews, repeated diagnostics suffix scans, and duplicate background GitHub-cache refreshes. Job polling now releases watches and timers when a progress callback throws.
 
+### Fixed
+
+- CLI startup now preserves saved account pins when handing authentication to the SDK. Catalog refreshes with a session use its effective credential pin, preventing a cached free OpenAI Codex account catalog from hiding Astra or Sol during paid-account profile startup. Generic injected SDK authentication keeps its existing isolation, and persisted session selections retain precedence over global pins.
+
 ## [0.16.4] - 2026-09-05
 ### Added
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 ### Fixed
+- CLI startup now preserves saved account pins when handing authentication to the SDK. Catalog refreshes with a session use its effective credential pin, preventing a cached free OpenAI Codex account catalog from hiding Astra or Sol during paid-account profile startup. Generic injected SDK authentication keeps its existing isolation, and persisted session selections retain precedence over global pins.
 
 - Managed migration-lock release now detects closed or reused Linux descriptors before native security verification and validates ownership through the recovered descriptor. Recovery still requires the original file identity, attempt id, and owner-only security; repeated release cannot change a successor. This fixes the retained-descriptor failure in #5399 without changing test timing or retry policy.
 - Coordinator responses now preserve `error: null` instead of replacing it with an `unavailable` error. Non-null errors still use fixed public messages, and unknown error codes remain mapped to `unavailable`.
@@ -86,10 +87,6 @@
 - SDK prompts consumed together after queued steering is interrupted now each receive correlated starts, streamed content, and one terminal, without adopting unrelated pending submissions.
 
 - Tool hot paths avoid overlap-table allocations for equal/append-only ACP output, redundant UTF-8 tail previews, repeated diagnostics suffix scans, and duplicate background GitHub-cache refreshes. Job polling now releases watches and timers when a progress callback throws.
-
-### Fixed
-
-- CLI startup now preserves saved account pins when handing authentication to the SDK. Catalog refreshes with a session use its effective credential pin, preventing a cached free OpenAI Codex account catalog from hiding Astra or Sol during paid-account profile startup. Generic injected SDK authentication keeps its existing isolation, and persisted session selections retain precedence over global pins.
 
 ## [0.16.4] - 2026-09-05
 ### Added

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1851,7 +1851,7 @@ export class ModelRegistry {
 	/**
 	 * Reload models from disk and refresh runtime provider discovery state.
 	 */
-	async refresh(strategy: ModelRefreshStrategy = "online-if-uncached"): Promise<void> {
+	async refresh(strategy: ModelRefreshStrategy = "online-if-uncached", credentialSessionId?: string): Promise<void> {
 		if (this.#disposed) return;
 		await this.#enqueueCatalogMutation(async () => {
 			if (this.#disposed) return;
@@ -1863,7 +1863,13 @@ export class ModelRegistry {
 			try {
 				this.#reloadStaticModels();
 				this.#suppressedSelectors.clear();
-				await this.#refreshRuntimeDiscoveries(strategy, undefined, refreshGeneration, providerRefreshFence);
+				await this.#refreshRuntimeDiscoveries(
+					strategy,
+					undefined,
+					refreshGeneration,
+					providerRefreshFence,
+					credentialSessionId,
+				);
 				if (refreshGeneration === this.#catalogRefreshGeneration) this.#modelBindingsApplier.apply();
 			} finally {
 				this.#resumeRebuild();
@@ -1871,11 +1877,11 @@ export class ModelRegistry {
 		});
 	}
 
-	refreshInBackground(strategy: ModelRefreshStrategy = "online-if-uncached"): void {
+	refreshInBackground(strategy: ModelRefreshStrategy = "online-if-uncached", credentialSessionId?: string): void {
 		if (this.#backgroundRefresh) {
 			return;
 		}
-		const refreshPromise = this.refresh(strategy)
+		const refreshPromise = this.refresh(strategy, credentialSessionId)
 			.catch(error => {
 				logger.warn("background model refresh failed", {
 					error: error instanceof Error ? error.message : String(error),
@@ -1889,7 +1895,11 @@ export class ModelRegistry {
 		this.#backgroundRefresh = refreshPromise;
 	}
 
-	async refreshProvider(providerId: string, strategy: ModelRefreshStrategy = "online"): Promise<void> {
+	async refreshProvider(
+		providerId: string,
+		strategy: ModelRefreshStrategy = "online",
+		credentialSessionId?: string,
+	): Promise<void> {
 		if (this.#disposed) return;
 		const providerRefreshGeneration = (this.#providerRefreshGenerations.get(providerId) ?? 0) + 1;
 		this.#providerRefreshGenerations.set(providerId, providerRefreshGeneration);
@@ -1905,10 +1915,16 @@ export class ModelRegistry {
 						this.#suppressedSelectors.delete(selector);
 					}
 				}
-				await this.#refreshRuntimeDiscoveries(strategy, new Set([providerId]), refreshGeneration, {
-					providerId,
-					generation: providerRefreshGeneration,
-				});
+				await this.#refreshRuntimeDiscoveries(
+					strategy,
+					new Set([providerId]),
+					refreshGeneration,
+					{
+						providerId,
+						generation: providerRefreshGeneration,
+					},
+					credentialSessionId,
+				);
 				if (
 					refreshGeneration === this.#catalogRefreshGeneration &&
 					this.#providerRefreshGenerations.get(providerId) === providerRefreshGeneration
@@ -3042,6 +3058,7 @@ export class ModelRegistry {
 		providerFilter?: ReadonlySet<string>,
 		refreshGeneration = this.#catalogRefreshGeneration,
 		providerRefresh?: ProviderRefreshFence,
+		credentialSessionId?: string,
 	): Promise<void> {
 		const profileAvailabilityEvidenceBefore = this.#profileAvailabilityEvidenceFingerprint();
 		const disabledProviders = getDisabledProviderIdsFromSettings(this.#settings);
@@ -3055,12 +3072,12 @@ export class ModelRegistry {
 				? Promise.resolve([] as ConfiguredDiscoveryResult[])
 				: Promise.all(
 						selectedDiscoverableProviders.map(provider =>
-							this.#discoverProviderModels(provider, strategy, providerRefresh),
+							this.#discoverProviderModels(provider, strategy, providerRefresh, credentialSessionId),
 						),
 					);
 		const [configuredDiscoveryResults, builtInDiscovered] = await Promise.all([
 			configuredDiscoveriesPromise,
-			this.#discoverBuiltInProviderModels(strategy, providerFilter, providerRefresh),
+			this.#discoverBuiltInProviderModels(strategy, providerFilter, providerRefresh, credentialSessionId),
 		]);
 		if (
 			refreshGeneration !== this.#catalogRefreshGeneration ||
@@ -3301,6 +3318,7 @@ export class ModelRegistry {
 		providerConfig: DiscoveryProviderConfig,
 		strategy: ModelRefreshStrategy,
 		providerRefresh?: ProviderRefreshFence,
+		credentialSessionId?: string,
 	): Promise<ConfiguredDiscoveryResult> {
 		const provider = providerConfig.provider;
 		const preflightEpoch = this.#optionalAuthPreflightEpoch;
@@ -3330,6 +3348,7 @@ export class ModelRegistry {
 						ignoreCredentiallessFallback: optionalAuth,
 						refreshOAuth: true,
 						baseUrl: providerConfig.baseUrl,
+						credentialSessionId,
 					}),
 				);
 				const currentAuthConfigurationGeneration = this.authStorage.getProviderConfigurationGeneration(provider);
@@ -3459,6 +3478,7 @@ export class ModelRegistry {
 					: this.#peekApiKeyForProvider(provider.provider, {
 							refreshOAuth: true,
 							baseUrl: provider.baseUrl,
+							credentialSessionId,
 						}),
 			isAuthenticated,
 			fetchModels: async (provider, apiKey) => {
@@ -3565,6 +3585,7 @@ export class ModelRegistry {
 		strategy: ModelRefreshStrategy,
 		providerFilter?: ReadonlySet<string>,
 		providerRefresh?: ProviderRefreshFence,
+		credentialSessionId?: string,
 	): Promise<Model<Api>[]> {
 		// Skip providers already handled by configured discovery (e.g. user-configured ollama with discovery.type)
 		const configuredDiscoveryProviders = new Set(this.#discoveryManager.providers.map(p => p.provider));
@@ -3578,6 +3599,7 @@ export class ModelRegistry {
 		const managerOptions = await this.#collectBuiltInModelManagerOptions(
 			configuredDiscoveryProviders,
 			providerFilter,
+			credentialSessionId,
 		);
 		if (managerOptions.length === 0) {
 			return [];
@@ -3591,6 +3613,7 @@ export class ModelRegistry {
 	async #collectBuiltInModelManagerOptions(
 		excludedProviderIds: ReadonlySet<string> = new Set(),
 		providerFilter?: ReadonlySet<string>,
+		credentialSessionId?: string,
 	): Promise<ModelManagerDiscoveryOptions[]> {
 		const specialProviderDescriptors: Array<{
 			providerId: string;
@@ -3655,7 +3678,7 @@ export class ModelRegistry {
 		// and failures there are handled gracefully.
 		const peekKey = async (descriptor: { providerId: string }) => {
 			const configurationGeneration = this.authStorage.getProviderConfigurationGeneration(descriptor.providerId);
-			const apiKey = await this.#peekApiKeyForProvider(descriptor.providerId);
+			const apiKey = await this.#peekApiKeyForProvider(descriptor.providerId, { credentialSessionId });
 			if (configurationGeneration !== this.authStorage.getProviderConfigurationGeneration(descriptor.providerId)) {
 				return { apiKey: undefined, authGeneration: undefined };
 			}
@@ -5645,6 +5668,7 @@ export class ModelRegistry {
 			ignoreCredentiallessFallback?: boolean;
 			refreshOAuth?: boolean;
 			baseUrl?: string;
+			credentialSessionId?: string;
 		} = {},
 	): Promise<string | undefined> {
 		this.#refreshRotatingConfigApiKey(provider);
@@ -5657,16 +5681,17 @@ export class ModelRegistry {
 			return undefined;
 		}
 		if (options.refreshOAuth && this.authStorage.hasOAuth(provider)) {
-			return this.authStorage.getApiKey(provider, undefined, {
+			return this.authStorage.getApiKey(provider, options.credentialSessionId, {
 				baseUrl: options.baseUrl,
 				owner: this.#authStorageConfigOwner,
 			});
 		}
+		const peekOptions = options.credentialSessionId
+			? { owner: this.#authStorageConfigOwner, sessionId: options.credentialSessionId }
+			: { owner: this.#authStorageConfigOwner };
 		return options.ignoreCredentiallessFallback
-			? this.authStorage.peekApiKey(provider, { owner: this.#authStorageConfigOwner })
-			: this.#getApiKeyOrNoAuth(provider, () =>
-					this.authStorage.peekApiKey(provider, { owner: this.#authStorageConfigOwner }),
-				);
+			? this.authStorage.peekApiKey(provider, peekOptions)
+			: this.#getApiKeyOrNoAuth(provider, () => this.authStorage.peekApiKey(provider, peekOptions));
 	}
 
 	/**

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1098,9 +1098,10 @@ function resolveOAuthAccountIdForAccessToken(
 	authStorage: AuthStorage,
 	provider: string,
 	accessToken: string,
+	sessionId?: string,
 	owner?: object,
 ): string | undefined {
-	if (authStorage.getEffectiveCredentialType(provider, undefined, owner ? { owner } : undefined) !== "oauth") {
+	if (authStorage.getEffectiveCredentialType(provider, sessionId, owner ? { owner } : undefined) !== "oauth") {
 		return undefined;
 	}
 	const oauthCredentials = getOAuthCredentialsForProvider(authStorage, provider);
@@ -3646,6 +3647,7 @@ export class ModelRegistry {
 						this.authStorage,
 						"openai-codex",
 						accessToken,
+						credentialSessionId,
 						this.#authStorageConfigOwner,
 					);
 					return openaiCodexModelManagerOptions({

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -83,6 +83,7 @@ import {
 	SessionTranscriptOversizedError,
 	type StrictSessionOpenResult,
 } from "./session/session-manager";
+import { resolveStartupAuthConfig } from "./session/startup-auth-config";
 import { runStartupCredentialAutoImportIfNeeded } from "./setup/credential-auto-import";
 import {
 	readOnboardingState,
@@ -521,14 +522,15 @@ async function applyStartupModelProfilesWithPolicy(
 			applied = await applyConfiguredProfiles();
 		} catch (error) {
 			if (error instanceof ModelProfileCredentialError) throw error;
-			await args.modelRegistry.refresh("online-if-uncached");
+			await args.modelRegistry.refresh("online-if-uncached", args.session.credentialSessionId);
 			refreshedOnline = true;
 			applied = await applyConfiguredProfiles();
 		}
-		if (applied && !refreshedOnline) args.modelRegistry.refreshInBackground();
+		if (applied && !refreshedOnline)
+			args.modelRegistry.refreshInBackground("online-if-uncached", args.session.credentialSessionId);
 	} else {
 		if (defaultProfile || args.parsedArgs.mpreset) {
-			await args.modelRegistry.refresh("online-if-uncached");
+			await args.modelRegistry.refresh("online-if-uncached", args.session.credentialSessionId);
 		}
 		await applyConfiguredProfiles();
 	}
@@ -1312,6 +1314,7 @@ export interface RunRootCommandDependencies {
 	createAgentSession?: typeof createAgentSession;
 	createSessionManager?: typeof createSessionManager;
 	discoverAuthStorage?: typeof discoverAuthStorage;
+	resolveStartupAuthConfig?: typeof resolveStartupAuthConfig;
 	runAcpMode?: (options?: { agentDir?: string }) => Promise<void>;
 	settings?: Settings;
 	suppressProcessExit?: boolean;
@@ -1497,8 +1500,15 @@ export async function runRootCommand(
 
 	const notifs: (InteractiveModeNotify | null)[] = [];
 
-	// Create AuthStorage and ModelRegistry upfront
-	const authStorage = await logger.time("discoverModels", deps.discoverAuthStorage ?? discoverAuthStorage);
+	// Keep store authority and persistent pin intent in the same startup snapshot.
+	// Injected discoverers own their auth unless they also supply a config resolver.
+	const agentDir = deps.settings?.getAgentDir() ?? getAgentDir();
+	const resolveAuthConfig =
+		deps.resolveStartupAuthConfig ?? (deps.discoverAuthStorage ? undefined : resolveStartupAuthConfig);
+	const startupAuthConfig = await resolveAuthConfig?.(agentDir);
+	const authStorage = await logger.time("discoverModels", () =>
+		(deps.discoverAuthStorage ?? discoverAuthStorage)(agentDir, startupAuthConfig),
+	);
 	const modelRegistry = new ModelRegistry(authStorage);
 
 	if (parsedArgs.version) {
@@ -1839,6 +1849,7 @@ export async function runRootCommand(
 	let rootStartupCacheAdmissionAttempted = false;
 	sessionOptions.authStorage = authStorage;
 	sessionOptions.modelRegistry = modelRegistry;
+	sessionOptions.startupAuthConfig = startupAuthConfig;
 	sessionOptions.modelRegistryStartupMutation = {
 		owner: "cli-root",
 		onAttempt: () => {
@@ -1960,7 +1971,7 @@ export async function runRootCommand(
 		// every parallel arm by ~30ms. Startup model profiles do their own foreground refresh
 		// before activation so project-scoped defaults can resolve freshly discovered models.
 		if (!context?.skipPostCreateModelRefresh && !rootStartupCacheAdmissionAttempted) {
-			modelRegistry.refreshInBackground();
+			modelRegistry.refreshInBackground("online-if-uncached", result.session.credentialSessionId);
 		}
 		return result;
 	};

--- a/packages/coding-agent/src/modes/components/agent-dashboard.ts
+++ b/packages/coding-agent/src/modes/components/agent-dashboard.ts
@@ -83,6 +83,7 @@ interface AgentDashboardModelContext {
 	modelRegistry?: ModelRegistry;
 	activeModelPattern?: string;
 	defaultModelPattern?: string;
+	credentialSessionId?: string;
 }
 
 export function resolveAgentCreationModel(
@@ -602,7 +603,7 @@ export class AgentDashboard extends Container {
 		if (!modelRegistry) {
 			throw new Error("Model registry unavailable in current session.");
 		}
-		await modelRegistry.refresh();
+		await modelRegistry.refresh("online-if-uncached", this.modelContext.credentialSessionId);
 
 		const settings = this.#settingsManager ?? undefined;
 		const modelPatterns = resolveConfiguredModelPatterns(
@@ -622,6 +623,7 @@ export class AgentDashboard extends Container {
 			modelRegistry,
 			settings,
 			model: selectedModel,
+			credentialSessionId: this.modelContext.credentialSessionId,
 			systemPrompt: [systemPrompt],
 			hasUI: false,
 			notificationHostModeSupported: false,

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -871,7 +871,7 @@ export class ModelSelectorComponent extends Container {
 		} else {
 			// Reload config and cached discovery state without blocking on live provider refresh
 			if (options.refreshRegistry !== false) {
-				await this.#modelRegistry.refresh("offline");
+				await this.#modelRegistry.refresh("offline", this.#authSessionId);
 			}
 
 			// Check for models.json errors
@@ -1054,7 +1054,7 @@ export class ModelSelectorComponent extends Container {
 			// Cache-aware: a fresh discovery cache answers instantly instead of
 			// forcing a provider round-trip (hundreds of ms on remote gateways)
 			// on every provider-tab visit. Stale/missing cache still fetches.
-			await this.#modelRegistry.refreshProvider(providerId, "online-if-uncached");
+			await this.#modelRegistry.refreshProvider(providerId, "online-if-uncached", this.#authSessionId);
 		} catch (error) {
 			refreshError = error;
 		}

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1655,7 +1655,7 @@ export class SelectorController {
 			authStorage: this.ctx.session.modelRegistry.authStorage,
 			trigger: "bare-login",
 		});
-		await this.ctx.session.modelRegistry.refresh();
+		await this.ctx.session.modelRegistry.refresh("online-if-uncached", this.ctx.session.credentialSessionId);
 
 		this.ctx.chatContainer.addChild(new Spacer(1));
 		for (const credential of summary.imported) {
@@ -1690,7 +1690,7 @@ export class SelectorController {
 			const submit = async (input: CustomModelPresetWizardSubmit): Promise<void> => {
 				try {
 					const profile = await this.ctx.session.modelRegistry.saveCustomModelProfile(input.name, input.profile);
-					await this.ctx.session.modelRegistry.refresh("offline");
+					await this.ctx.session.modelRegistry.refresh("offline", this.ctx.session.credentialSessionId);
 					await this.ctx.notifyConfigChanged?.();
 					this.ctx.showStatus(`Custom model preset created: ${formatModelProfileDisplayLabel(profile)}`);
 					done();
@@ -1728,7 +1728,7 @@ export class SelectorController {
 		}
 		try {
 			const renamed = await this.ctx.session.modelRegistry.renameCustomModelProfile(profileName, input);
-			await this.ctx.session.modelRegistry.refresh("offline");
+			await this.ctx.session.modelRegistry.refresh("offline", this.ctx.session.credentialSessionId);
 			await this.ctx.notifyConfigChanged?.();
 			modelSelector.refreshPresetProfiles(renamed.name);
 			this.ctx.showStatus(`Custom model preset renamed: ${formatModelProfileDisplayLabel(renamed)}`);
@@ -1774,7 +1774,7 @@ export class SelectorController {
 				});
 			}
 			deletedProfile = await this.ctx.session.modelRegistry.deleteCustomModelProfile(profileName);
-			await this.ctx.session.modelRegistry.refresh("offline");
+			await this.ctx.session.modelRegistry.refresh("offline", this.ctx.session.credentialSessionId);
 			await this.ctx.notifyConfigChanged?.();
 			refreshSelectorState();
 			this.ctx.showStatus(`Custom model preset deleted: ${profileLabel}`);
@@ -1784,7 +1784,7 @@ export class SelectorController {
 			if (deletedProfile) {
 				try {
 					await this.ctx.session.modelRegistry.saveCustomModelProfile(profileName, deletedProfile);
-					await this.ctx.session.modelRegistry.refresh("offline");
+					await this.ctx.session.modelRegistry.refresh("offline", this.ctx.session.credentialSessionId);
 				} catch (restoreErr) {
 					presetRestoreError = restoreErr;
 				}
@@ -1821,7 +1821,7 @@ export class SelectorController {
 			const submit = async (input: CustomProviderWizardSubmit): Promise<void> => {
 				try {
 					const result = await addApiCompatibleProvider(input);
-					await this.ctx.session.modelRegistry.refresh("offline");
+					await this.ctx.session.modelRegistry.refresh("offline", this.ctx.session.credentialSessionId);
 					await this.ctx.notifyConfigChanged?.();
 					this.ctx.showStatus(formatProviderSetupResult(result));
 					wizard.complete();
@@ -2218,6 +2218,7 @@ export class SelectorController {
 			modelRegistry: this.ctx.session.modelRegistry,
 			activeModelPattern,
 			defaultModelPattern: selectorHead(defaultModelPattern),
+			credentialSessionId: this.ctx.session.credentialSessionId,
 		});
 		this.showSelector(done => {
 			dashboard.onClose = () => {
@@ -3626,7 +3627,7 @@ export class SelectorController {
 				},
 				{ manualCode },
 			);
-			await this.ctx.session.modelRegistry.refresh();
+			await this.ctx.session.modelRegistry.refresh("online-if-uncached", this.ctx.session.credentialSessionId);
 			this.ctx.chatContainer.addChild(new Spacer(1));
 			const successMessage =
 				providerId === "opencodex"
@@ -3679,7 +3680,7 @@ export class SelectorController {
 				return;
 			}
 			await clearPersistentPinForRemovedRows(this.ctx.settings, providerId, inventory, result.ids);
-			await this.ctx.session.modelRegistry.refresh();
+			await this.ctx.session.modelRegistry.refresh("online-if-uncached", this.ctx.session.credentialSessionId);
 			this.ctx.showStatus(
 				`Successfully removed ${result.ids.length} stored credential${result.ids.length === 1 ? "" : "s"} from ${providerId}.`,
 			);
@@ -3890,7 +3891,10 @@ export class SelectorController {
 									}
 									if (summary.imported.length > 0) {
 										try {
-											await this.ctx.session.modelRegistry.refresh("offline");
+											await this.ctx.session.modelRegistry.refresh(
+												"offline",
+												this.ctx.session.credentialSessionId,
+											);
 										} catch {
 											logger.warn("Credential auto-import refresh failed", {
 												classification: "refresh-failed",

--- a/packages/coding-agent/src/sdk/session.ts
+++ b/packages/coding-agent/src/sdk/session.ts
@@ -1498,10 +1498,12 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	// Pin authStorage to modelRegistry.authStorage: ModelRegistry.getApiKey() routes refresh
 	// failures through that instance, so any divergent storage handed to the bridge / mcpManager
 	// / session would silently miss credential_disabled events.
-	// Injected auth is already the caller's authority; do not discover global
-	// startup auth or apply persistent pins while constructing this session.
+	// Injected auth is the caller's authority. Only the CLI root can hand off its
+	// explicit startup snapshot; never discover global config for injected SDK auth.
 	const startupAuthConfig = hasInjectedAuth
-		? undefined
+		? options.modelRegistryStartupMutation?.owner === "cli-root"
+			? options.startupAuthConfig
+			: undefined
 		: (options.startupAuthConfig ?? (await resolveStartupAuthConfig(agentDir)));
 	const ownsModelRegistry = options.modelRegistry === undefined;
 	const ownsAuthStorage = options.modelRegistry === undefined && options.authStorage === undefined;
@@ -1649,9 +1651,6 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				);
 			}
 		}
-		if (!options.modelRegistry && !attemptedStartupCacheAdmission) {
-			modelRegistry.refreshInBackground();
-		}
 		// Resolve the workspace tree through its runtime service. The compatibility
 		// default starts the native scan at the legacy startup trigger; lazy mode
 		// leaves the service idle until the first-turn prompt barrier. The native scan
@@ -1733,7 +1732,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		const scopeAlreadyLeased = authStorage.hasCredentialScopeLease(credentialSessionId);
 		authStorage.acquireCredentialScope(credentialSessionId);
 		credentialScopeLeased = true;
-		const configuredPins = hasInjectedAuth ? {} : (startupAuthConfig?.credentialPins ?? {});
+		const configuredPins = startupAuthConfig?.credentialPins ?? {};
 		const persistedPinStoreMatches =
 			startupAuthConfig?.credentialPinStoreIdentity === startupAuthConfig?.credentialStoreIdentity;
 		// AuthStorage has no scope-level "pinned but unavailable" marker. Keep the
@@ -1908,6 +1907,9 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				options.credentialSelector.provider,
 				options.credentialSelector.selector,
 			);
+		}
+		if (!options.modelRegistry && !attemptedStartupCacheAdmission) {
+			modelRegistry.refreshInBackground("online-if-uncached", credentialSessionId);
 		}
 
 		const hasExplicitModel = options.model !== undefined || options.modelPattern !== undefined;

--- a/packages/coding-agent/src/sdk/session.ts
+++ b/packages/coding-agent/src/sdk/session.ts
@@ -1872,8 +1872,17 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 					staleDurableCredentialPins.delete(resolveOAuthStorageProvider(record.provider));
 				}
 			} catch {
+				const unavailableSelector: AuthCredentialSelector | undefined =
+					pin &&
+					(pin.kind === "id" || pin.kind === "email" || pin.kind === "account" || pin.kind === "project") &&
+					typeof pin.value === "string"
+						? { kind: pin.kind, value: pin.value }
+						: undefined;
 				// A newer stale pin must not leave an earlier replayed selector active.
 				authStorage.clearSessionCredentialSelector(record.provider, credentialSessionId);
+				if (unavailableSelector) {
+					authStorage.markSessionCredentialUnavailable(credentialSessionId, record.provider, unavailableSelector);
+				}
 				staleDurableCredentialPins.add(resolveOAuthStorageProvider(record.provider));
 			}
 		}

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1699,7 +1699,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 					models: parsed.models,
 					force: parsed.force,
 				});
-				await runtime.session.modelRegistry.refresh("offline");
+				await runtime.session.modelRegistry.refresh("offline", runtime.session.credentialSessionId);
 				await runtime.output(formatProviderSetupResult(result));
 				await runtime.notifyConfigChanged?.();
 				return commandConsumed();
@@ -1740,7 +1740,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 						models: parsed.models,
 						force: parsed.force,
 					});
-					await runtime.ctx.session.modelRegistry.refresh("offline");
+					await runtime.ctx.session.modelRegistry.refresh("offline", runtime.ctx.session.credentialSessionId);
 					runtime.ctx.showStatus(formatProviderSetupResult(result));
 				} catch (err) {
 					runtime.ctx.showError(`Provider setup failed: ${errorMessage(err)}`);

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -436,7 +436,11 @@ async function resolveModelCommandSelection(
 	const providerRef = parseProviderQualifiedSelector(selector);
 	const discoverableProviders = runtime.session.modelRegistry?.getDiscoverableProviders?.() ?? [];
 	if (providerRef && discoverableProviders.includes(providerRef.provider)) {
-		await runtime.session.modelRegistry.refreshProvider?.(providerRef.provider, "online");
+		await runtime.session.modelRegistry.refreshProvider?.(
+			providerRef.provider,
+			"online",
+			runtime.session.credentialSessionId,
+		);
 		availableModels = runtime.session.getAvailableModels?.() ?? [];
 		const refreshedSelection = resolveModelCommandSelectionFromAvailable(
 			runtime,

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -1730,7 +1730,12 @@ export async function runSubprocessOnce(options: ExecutorOptions): Promise<Singl
 			}
 			checkAbort();
 			if (!registryFromParent) {
-				await awaitAbortable(modelRegistry.refresh());
+				await awaitAbortable(
+					modelRegistry.refresh(
+						"online-if-uncached",
+						options.parentCredentialSessionId ?? options.parentSessionId,
+					),
+				);
 			} else {
 				logger.debug("runSubagent: reusing parent modelRegistry; skipping refresh");
 			}

--- a/packages/coding-agent/test/cli-args-mpreset.test.ts
+++ b/packages/coding-agent/test/cli-args-mpreset.test.ts
@@ -32,7 +32,9 @@ function fakeRegistry(
 	let refreshed = false;
 	const registry = {
 		refreshCalls: [] as string[],
+		refreshCredentialSessions: [] as Array<string | undefined>,
 		refreshInBackgroundCalls: [] as string[],
+		refreshInBackgroundCredentialSessions: [] as Array<string | undefined>,
 		getModelProfile: (name: string) => new Map(activeProfiles.map(profile => [profile.name, profile])).get(name),
 		getModelProfiles: () => new Map(activeProfiles.map(profile => [profile.name, profile])),
 		getAvailableModelProfileNames: () => activeProfiles.map(profile => profile.name).sort(),
@@ -40,14 +42,16 @@ function fakeRegistry(
 		getAll: () => activeModels,
 		getAvailableForProfileActivation: () =>
 			options.excludeModelsFromProfileActivationUntilRefresh && !refreshed ? [] : activeModels,
-		async refresh(strategy = "online-if-uncached") {
+		async refresh(strategy = "online-if-uncached", credentialSessionId?: string) {
 			registry.refreshCalls.push(strategy);
+			registry.refreshCredentialSessions.push(credentialSessionId);
 			refreshed = true;
 			activeProfiles = options.profilesAfterRefresh ?? activeProfiles;
 			activeModels = options.modelsAfterRefresh ?? activeModels;
 		},
-		refreshInBackground(strategy = "online-if-uncached") {
+		refreshInBackground(strategy = "online-if-uncached", credentialSessionId?: string) {
 			registry.refreshInBackgroundCalls.push(strategy);
+			registry.refreshInBackgroundCredentialSessions.push(credentialSessionId);
 		},
 	};
 	return registry;
@@ -58,6 +62,7 @@ function fakeSession(initial = model("initial-provider", "initial")) {
 		model: initial as Model | undefined,
 		thinkingLevel: undefined as ThinkingLevel | undefined,
 		sessionId: "session-1",
+		credentialSessionId: "credential-session-1",
 		setModelTemporaryCalls: [] as Array<{
 			model: Model;
 			thinkingLevel?: ThinkingLevel;
@@ -372,6 +377,7 @@ test("interactive continuation activates --mpreset from cached models without bl
 
 	expect(registry.refreshCalls).toEqual([]);
 	expect(registry.refreshInBackgroundCalls).toEqual(["online-if-uncached"]);
+	expect(registry.refreshInBackgroundCredentialSessions).toEqual(["credential-session-1"]);
 	expect(session.model?.provider).toBe("profile-provider");
 	expect(session.model?.id).toBe("default");
 });
@@ -463,6 +469,7 @@ test("lifecycle startup refreshes online when cached default profile resolution 
 	});
 
 	expect(registry.refreshCalls).toEqual(["online-if-uncached"]);
+	expect(registry.refreshCredentialSessions).toEqual(["credential-session-1"]);
 	expect(registry.refreshInBackgroundCalls).toEqual([]);
 	expect(session.model?.provider).toBe("refreshed-provider");
 	expect(session.model?.id).toBe("new");

--- a/packages/coding-agent/test/codex-profile-pinned-discovery.test.ts
+++ b/packages/coding-agent/test/codex-profile-pinned-discovery.test.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "bun:test";
+import * as path from "node:path";
+import { AuthStorage, closeModelCache, SqliteAuthCredentialStore } from "@gajae-code/ai";
+import { getAgentDir, hookFetch, setAgentDir, TempDir } from "@gajae-code/utils";
+import { ModelRegistry } from "../src/config/model-registry";
+
+test("a paid Codex pin replaces a cached free catalog before profile activation", async () => {
+	using tempDir = TempDir.createSync("@gjc-codex-pin-catalog-");
+	const previousAgentDir = getAgentDir();
+	closeModelCache();
+	setAgentDir(tempDir.path());
+	const store = await SqliteAuthCredentialStore.open(":memory:");
+	for (const account of ["free", "paid"]) {
+		store.saveOAuth("openai-codex", {
+			access: `${account}-token`,
+			refresh: `${account}-refresh`,
+			expires: Date.now() + 3_600_000,
+			accountId: `${account}-account`,
+			email: `${account}@example.test`,
+		});
+	}
+	const authStorage = new AuthStorage(store);
+	await authStorage.reload();
+	for (const account of ["free", "paid"]) {
+		authStorage.acquireCredentialScope(`${account}-session`);
+		authStorage.setSessionCredentialSelector(`${account}-session`, "openai-codex", {
+			kind: "email",
+			value: `${account}@example.test`,
+		});
+	}
+	const requests: string[] = [];
+	using _fetch = hookFetch((input, init) => {
+		const url = new URL(String(input));
+		if (url.hostname === "registry.npmjs.org") return Response.json({ version: "0.153.4" });
+		expect(url.origin + url.pathname).toBe("https://chatgpt.com/backend-api/codex/models");
+		const headers = new Headers(init?.headers);
+		const bearer = headers.get("Authorization");
+		if (!bearer) throw new Error("Expected a fake Codex bearer token");
+		expect(["Bearer free-token", "Bearer paid-token"]).toContain(bearer);
+		const account = bearer === "Bearer paid-token" ? "paid" : "free";
+		expect(headers.get("chatgpt-account-id")).toBe(`${account}-account`);
+		requests.push(account);
+		const ids = account === "paid" ? ["gpt-5.6-luna", "gpt-5.6-sol", "gpt-6-astra"] : ["gpt-5.6-luna"];
+		return Response.json({
+			models: ids.map(slug => ({ slug, display_name: slug, supported_in_api: true })),
+		});
+	});
+	const registry = new ModelRegistry(authStorage, path.join(tempDir.path(), "models.yml"));
+	const availableIds = () =>
+		registry
+			.getAvailableForProfileActivation()
+			.filter(model => model.provider === "openai-codex")
+			.map(model => model.id);
+	try {
+		await registry.refreshProvider("openai-codex", "online", "free-session");
+		expect(availableIds()).not.toContain("gpt-6-astra");
+		expect(availableIds()).not.toContain("gpt-5.6-sol");
+
+		await registry.refreshProvider("openai-codex", "online-if-uncached", "paid-session");
+		expect(requests).toEqual(["free", "paid"]);
+		expect(availableIds()).toContain("gpt-6-astra");
+		expect(availableIds()).toContain("gpt-5.6-sol");
+	} finally {
+		await registry.dispose();
+		authStorage.close();
+		closeModelCache();
+		setAgentDir(previousAgentDir);
+	}
+});

--- a/packages/coding-agent/test/model-registry-credential-scope-discovery.test.ts
+++ b/packages/coding-agent/test/model-registry-credential-scope-discovery.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { AuthStorage, SqliteAuthCredentialStore } from "@gajae-code/ai";
+import { hookFetch, TempDir } from "@gajae-code/utils";
+import { ModelRegistry } from "../src/config/model-registry";
+
+const openStorages: AuthStorage[] = [];
+
+function oauth(name: string) {
+	return {
+		type: "oauth" as const,
+		access: `${name}-token`,
+		refresh: `${name}-refresh`,
+		expires: Date.now() + 60 * 60_000,
+		accountId: `${name}-account`,
+		email: `${name}@example.com`,
+	};
+}
+
+async function createStorage(order: readonly string[]): Promise<AuthStorage> {
+	const store = await SqliteAuthCredentialStore.open(":memory:");
+	for (const name of order) store.saveOAuth("pinned-discovery", oauth(name));
+	const storage = new AuthStorage(store);
+	await storage.reload();
+	openStorages.push(storage);
+	return storage;
+}
+
+afterEach(() => {
+	for (const storage of openStorages.splice(0)) storage.close();
+});
+
+describe("model discovery credential scopes", () => {
+	test("a scoped pin supplies the catalog credential regardless of account order", async () => {
+		for (const order of [
+			["limited", "entitled"],
+			["entitled", "limited"],
+		] as const) {
+			using tempDir = TempDir.createSync("@gjc-pinned-model-discovery-");
+			const modelsPath = path.join(tempDir.path(), "models.yml");
+			await fs.writeFile(
+				modelsPath,
+				[
+					"providers:",
+					"  pinned-discovery:",
+					"    baseUrl: https://catalog.example.test/v1",
+					"    api: openai-responses",
+					"    discovery:",
+					"      type: openai-models-list",
+					"    models: []",
+				].join("\n"),
+			);
+			const storage = await createStorage(order);
+			storage.acquireCredentialScope("profile-session");
+			storage.setSessionCredentialSelector("profile-session", "pinned-discovery", {
+				kind: "email",
+				value: "entitled@example.com",
+			});
+			let requestCount = 0;
+			using _fetch = hookFetch((input, init) => {
+				requestCount++;
+				expect(String(input)).toBe("https://catalog.example.test/v1/models");
+				const headers = new Headers(init?.headers);
+				expect(headers.get("Authorization")).toBe("Bearer entitled-token");
+				return new Response(JSON.stringify({ data: [{ id: "profile-required-model" }] }), {
+					headers: { "Content-Type": "application/json" },
+				});
+			});
+			const registry = new ModelRegistry(storage, modelsPath);
+			try {
+				await registry.refreshProvider("pinned-discovery", "online", "profile-session");
+				expect(requestCount).toBe(1);
+				expect(registry.find("pinned-discovery", "profile-required-model")).toBeDefined();
+			} finally {
+				await registry.dispose();
+			}
+		}
+	});
+});

--- a/packages/coding-agent/test/model-registry-credential-scope-discovery.test.ts
+++ b/packages/coding-agent/test/model-registry-credential-scope-discovery.test.ts
@@ -77,4 +77,73 @@ describe("model discovery credential scopes", () => {
 			}
 		}
 	});
+
+	test("a revoked scoped OAuth pin fails closed without sending an alternate bearer", async () => {
+		using tempDir = TempDir.createSync("@gjc-revoked-pinned-discovery-");
+		const modelsPath = path.join(tempDir.path(), "models.yml");
+		await fs.writeFile(
+			modelsPath,
+			[
+				"providers:",
+				"  revoked-pinned-discovery:",
+				"    baseUrl: https://revoked-catalog.example.test/v1",
+				"    api: openai-responses",
+				"    discovery:",
+				"      type: openai-models-list",
+				"    models: []",
+			].join("\n"),
+		);
+		const store = await SqliteAuthCredentialStore.open(":memory:");
+		let refreshCalls = 0;
+		const storage = new AuthStorage(store, {
+			refreshOAuthCredential: async () => {
+				refreshCalls++;
+				throw new Error("invalid_grant: refresh token revoked");
+			},
+		});
+		await storage.set("revoked-pinned-discovery", [
+			{
+				type: "oauth",
+				access: "revoked-access",
+				refresh: "revoked-refresh",
+				expires: Date.now() - 60_000,
+				email: "revoked@example.com",
+			},
+			oauth("alternate"),
+		]);
+		expect(storage.listCredentialInventory("revoked-pinned-discovery").map(row => row.email)).toEqual([
+			"revoked@example.com",
+			"alternate@example.com",
+		]);
+		storage.acquireCredentialScope("revoked-discovery-session");
+		storage.setSessionCredentialSelector("revoked-discovery-session", "revoked-pinned-discovery", {
+			kind: "email",
+			value: "revoked@example.com",
+		});
+		expect(
+			storage.resolveEffectiveCredentialSelector("revoked-pinned-discovery", "revoked-discovery-session"),
+		).toEqual({
+			kind: "email",
+			value: "revoked@example.com",
+		});
+		const requests: string[] = [];
+		using _fetch = hookFetch((_input, init) => {
+			const bearer = new Headers(init?.headers).get("Authorization");
+			if (bearer) requests.push(bearer);
+			return Response.json({ data: [{ id: "must-not-be-discovered" }] });
+		});
+		const registry = new ModelRegistry(storage, modelsPath);
+		try {
+			await registry.refreshProvider("revoked-pinned-discovery", "online", "revoked-discovery-session");
+			expect(refreshCalls).toBe(1);
+			expect(requests).not.toContain("Bearer alternate-token");
+			expect(registry.find("revoked-pinned-discovery", "must-not-be-discovered")).toBeUndefined();
+			expect(storage.hasSessionCredentialUnavailable("revoked-pinned-discovery", "revoked-discovery-session")).toBe(
+				true,
+			);
+		} finally {
+			await registry.dispose();
+			storage.close();
+		}
+	});
 });

--- a/packages/coding-agent/test/model-registry-credential-scope-discovery.test.ts
+++ b/packages/coding-agent/test/model-registry-credential-scope-discovery.test.ts
@@ -135,7 +135,7 @@ describe("model discovery credential scopes", () => {
 		const registry = new ModelRegistry(storage, modelsPath);
 		try {
 			await registry.refreshProvider("revoked-pinned-discovery", "online", "revoked-discovery-session");
-			expect(refreshCalls).toBe(1);
+			expect(refreshCalls).toBe(2);
 			expect(requests).not.toContain("Bearer alternate-token");
 			expect(registry.find("revoked-pinned-discovery", "must-not-be-discovered")).toBeUndefined();
 			expect(storage.hasSessionCredentialUnavailable("revoked-pinned-discovery", "revoked-discovery-session")).toBe(

--- a/packages/coding-agent/test/startup-credential-pin-handoff.test.ts
+++ b/packages/coding-agent/test/startup-credential-pin-handoff.test.ts
@@ -1,0 +1,356 @@
+import { describe, expect, setDefaultTimeout, test } from "bun:test";
+import * as path from "node:path";
+import { getBundledModel } from "@gajae-code/ai";
+import { hookFetch, TempDir } from "@gajae-code/utils";
+import type { Args } from "../src/cli/args";
+import { ModelRegistry } from "../src/config/model-registry";
+import { Settings } from "../src/config/settings";
+import { runRootCommand } from "../src/main";
+import { type CreateAgentSessionOptions, type CreateAgentSessionResult, createAgentSession } from "../src/sdk";
+import type { AgentSession } from "../src/session/agent-session";
+import { AuthStorage } from "../src/session/auth-storage";
+import { SessionManager } from "../src/session/session-manager";
+import type { StartupAuthConfigSnapshot } from "../src/session/startup-auth-config";
+import { EventBus } from "../src/utils/event-bus";
+
+setDefaultTimeout(20_000);
+
+const testModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+if (!testModel) throw new Error("Expected bundled test model");
+
+function rootArgs(): Args {
+	return {
+		messages: [],
+		fileArgs: [],
+		unknownFlags: new Map(),
+		print: true,
+		noSession: true,
+		noSkills: true,
+		noRules: true,
+		noTools: true,
+		noLsp: true,
+	};
+}
+
+function fakeSessionResult(): CreateAgentSessionResult {
+	let activeModel = testModel;
+	const session = {
+		sessionId: "startup-pin-handoff",
+		credentialSessionId: "startup-pin-handoff",
+		get model() {
+			return activeModel;
+		},
+		extensionRunner: undefined,
+		getConfiguredModelChain: () => undefined,
+		setConfiguredModelChain: () => {},
+		seedDefaultFallbackResolution: () => {},
+		setModelTemporary: async (model: typeof testModel) => {
+			activeModel = model;
+		},
+		dispose: async () => {},
+	} as unknown as AgentSession;
+	return {
+		session,
+		extensionsResult: {},
+		setToolUIContext: () => {},
+		eventBus: new EventBus(),
+	} as unknown as CreateAgentSessionResult;
+}
+
+function snapshot(
+	provider: string,
+	pin: string,
+	storeIdentity = "fixture-store",
+	pinStoreIdentity = storeIdentity,
+): StartupAuthConfigSnapshot {
+	return {
+		broker: null,
+		credentialStoreIdentity: storeIdentity,
+		credentialPinStoreIdentity: pinStoreIdentity,
+		credentialRankingMode: "balanced",
+		credentialPins: { [provider]: pin },
+	};
+}
+
+interface CredentialFixture {
+	root: string;
+	provider: string;
+	wrongKey: string;
+	paidKey: string;
+	wrongRowId: number;
+	paidRowId: number;
+	authStorage: AuthStorage;
+	modelRegistry: ModelRegistry;
+}
+
+async function createCredentialFixture(tempRoot: string): Promise<CredentialFixture> {
+	const provider = "startup-pin-provider";
+	const wrongKey = "fixture-wrong-key";
+	const paidKey = "fixture-paid-key";
+	const authStorage = await AuthStorage.create(path.join(tempRoot, "auth.db"));
+	await authStorage.set(provider, [
+		{ type: "oauth", access: wrongKey, refresh: "fixture-wrong-refresh", expires: Date.now() + 3_600_000 },
+		{ type: "oauth", access: paidKey, refresh: "fixture-paid-refresh", expires: Date.now() + 3_600_000 },
+	]);
+	const rows = authStorage.listCredentialInventory(provider);
+	const wrongRow = rows[0];
+	const paidRow = rows[1];
+	if (!wrongRow || !paidRow) throw new Error("Expected both fixture credential rows");
+	const modelRegistry = new ModelRegistry(authStorage, path.join(tempRoot, "models.yml"));
+	modelRegistry.registerProvider(provider, {
+		baseUrl: "https://startup-pin.example.test/v1",
+		api: "openai-completions",
+		oauth: {
+			name: "Startup Pin Fixture",
+			login: async () => ({
+				access: "fixture-login-access",
+				refresh: "fixture-login-refresh",
+				expires: Date.now() + 3_600_000,
+			}),
+			getApiKey: credentials => credentials.access,
+		},
+		models: [
+			{
+				id: "entitled-model",
+				name: "Entitled Model",
+				reasoning: false,
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 128_000,
+				maxTokens: 8_192,
+			},
+		],
+	});
+	return {
+		root: tempRoot,
+		provider,
+		wrongKey,
+		paidKey,
+		wrongRowId: wrongRow.id,
+		paidRowId: paidRow.id,
+		authStorage,
+		modelRegistry,
+	};
+}
+
+function sessionOptions(fixture: CredentialFixture): CreateAgentSessionOptions {
+	return {
+		cwd: fixture.root,
+		agentDir: fixture.root,
+		credentialSessionId: "credential-scope",
+		disableExtensionDiscovery: true,
+		extensions: [],
+		skills: [],
+		contextFiles: [],
+		promptTemplates: [],
+		slashCommands: [],
+		enableMCP: false,
+		enableLsp: false,
+		workspaceTree: {
+			rootPath: fixture.root,
+			rendered: "",
+			truncated: false,
+			totalLines: 0,
+			agentsMdFiles: [],
+		},
+		toolNames: [],
+		rules: [],
+		settings: Settings.isolated({ "marketplace.autoUpdate": "off" }),
+		authStorage: fixture.authStorage,
+		modelRegistry: fixture.modelRegistry,
+		modelPattern: `${fixture.provider}/entitled-model`,
+	};
+}
+
+async function disposeFixture(fixture: CredentialFixture, session?: AgentSession): Promise<void> {
+	await session?.dispose();
+	await fixture.modelRegistry.dispose();
+	fixture.authStorage.close();
+}
+
+describe("startup credential pin handoff", () => {
+	test("hands the exact startup auth snapshot from root discovery to the CLI session", async () => {
+		using tempDir = TempDir.createSync("@gjc-startup-pin-root-");
+		const authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+		const startupSnapshot = snapshot("fixture-provider", "id:2");
+		let discoveredSnapshot: StartupAuthConfigSnapshot | undefined;
+		let sessionOptionsSeen: CreateAgentSessionOptions | undefined;
+
+		using _blockedFetch = hookFetch(() => {
+			throw new Error("Unexpected network access in startup snapshot handoff test");
+		});
+		try {
+			await runRootCommand(rootArgs(), [], {
+				resolveStartupAuthConfig: async () => startupSnapshot,
+				discoverAuthStorage: async (_agentDir, resolvedSnapshot) => {
+					discoveredSnapshot = resolvedSnapshot;
+					return authStorage;
+				},
+				createAgentSession: async options => {
+					sessionOptionsSeen = options;
+					return fakeSessionResult();
+				},
+				settings: Settings.isolated({ "marketplace.autoUpdate": "off", "startup.checkUpdate": false }),
+				suppressProcessExit: true,
+				initTheme: async () => {},
+				readPipedInput: async () => undefined,
+				runStartupCredentialAutoImportIfNeeded: async () => undefined,
+				runPrintMode: async () => {},
+				quit: async () => {},
+			});
+
+			expect(discoveredSnapshot).toBe(startupSnapshot);
+			expect(sessionOptionsSeen?.startupAuthConfig).toBe(startupSnapshot);
+			expect(sessionOptionsSeen?.modelRegistryStartupMutation?.owner).toBe("cli-root");
+		} finally {
+			authStorage.close();
+		}
+	});
+
+	test("CLI-owned injected sessions apply a persistent paid pin before model selection", async () => {
+		using tempDir = TempDir.createSync("@gjc-startup-pin-cli-");
+		const fixture = await createCredentialFixture(tempDir.path());
+		let session: AgentSession | undefined;
+		using _blockedFetch = hookFetch(() => {
+			throw new Error("Unexpected network access in CLI pin test");
+		});
+		try {
+			const result = await createAgentSession({
+				...sessionOptions(fixture),
+				startupAuthConfig: snapshot(fixture.provider, `id:${fixture.paidRowId}`),
+				modelRegistryStartupMutation: { owner: "cli-root", onAttempt: () => {} },
+			});
+			session = result.session;
+
+			expect(session.model?.id).toBe("entitled-model");
+			expect(
+				await fixture.authStorage.peekApiKey(fixture.provider, {
+					sessionId: session.credentialSessionId,
+					owner: fixture.modelRegistry.getAuthStorageOwner(),
+				}),
+			).toBe(fixture.paidKey);
+		} finally {
+			await disposeFixture(fixture, session);
+		}
+	});
+
+	test("generic injected SDK sessions ignore an explicit persistent pin snapshot", async () => {
+		using tempDir = TempDir.createSync("@gjc-startup-pin-sdk-");
+		const fixture = await createCredentialFixture(tempDir.path());
+		let session: AgentSession | undefined;
+		using _blockedFetch = hookFetch(() => {
+			throw new Error("Unexpected network access in SDK isolation test");
+		});
+		try {
+			const result = await createAgentSession({
+				...sessionOptions(fixture),
+				startupAuthConfig: snapshot(fixture.provider, `id:${fixture.paidRowId}`),
+			});
+			session = result.session;
+
+			expect(
+				await fixture.authStorage.peekApiKey(fixture.provider, {
+					sessionId: session.credentialSessionId,
+					owner: fixture.modelRegistry.getAuthStorageOwner(),
+				}),
+			).toBe(fixture.wrongKey);
+		} finally {
+			await disposeFixture(fixture, session);
+		}
+	});
+
+	test("CLI-owned sessions skip numeric pins from a different credential store", async () => {
+		using tempDir = TempDir.createSync("@gjc-startup-pin-store-");
+		const fixture = await createCredentialFixture(tempDir.path());
+		let session: AgentSession | undefined;
+		using _blockedFetch = hookFetch(() => {
+			throw new Error("Unexpected network access in store identity test");
+		});
+		try {
+			const result = await createAgentSession({
+				...sessionOptions(fixture),
+				startupAuthConfig: snapshot(fixture.provider, `id:${fixture.paidRowId}`, "current-store", "previous-store"),
+				modelRegistryStartupMutation: { owner: "cli-root", onAttempt: () => {} },
+			});
+			session = result.session;
+
+			expect(
+				await fixture.authStorage.peekApiKey(fixture.provider, {
+					sessionId: session.credentialSessionId,
+					owner: fixture.modelRegistry.getAuthStorageOwner(),
+				}),
+			).toBe(fixture.wrongKey);
+		} finally {
+			await disposeFixture(fixture, session);
+		}
+	});
+
+	test("resumed durable AUTO and pin choices override the global paid pin", async () => {
+		for (const resumedChoice of ["auto", "pin"] as const) {
+			using tempDir = TempDir.createSync(`@gjc-startup-pin-resume-${resumedChoice}-`);
+			const fixture = await createCredentialFixture(tempDir.path());
+			const sessionManager = SessionManager.inMemory(fixture.root);
+			sessionManager.appendCustomEntry("auth-credential-pin", {
+				v: 1,
+				scopeId: "credential-scope",
+				provider: fixture.provider,
+				pin: resumedChoice === "auto" ? { auto: true } : { kind: "id", value: String(fixture.wrongRowId) },
+				credentialStoreIdentity: "fixture-store",
+			});
+			let session: AgentSession | undefined;
+			using _blockedFetch = hookFetch(() => {
+				throw new Error("Unexpected network access in resumed pin precedence test");
+			});
+			try {
+				const result = await createAgentSession({
+					...sessionOptions(fixture),
+					sessionManager,
+					startupAuthConfig: snapshot(fixture.provider, `id:${fixture.paidRowId}`),
+					modelRegistryStartupMutation: { owner: "cli-root", onAttempt: () => {} },
+				});
+				session = result.session;
+
+				expect(
+					await fixture.authStorage.peekApiKey(fixture.provider, {
+						sessionId: session.credentialSessionId,
+						owner: fixture.modelRegistry.getAuthStorageOwner(),
+					}),
+					resumedChoice,
+				).toBe(fixture.wrongKey);
+			} finally {
+				await disposeFixture(fixture, session);
+			}
+		}
+	});
+
+	test("an explicit credential selector overrides the global paid pin", async () => {
+		using tempDir = TempDir.createSync("@gjc-startup-pin-explicit-");
+		const fixture = await createCredentialFixture(tempDir.path());
+		let session: AgentSession | undefined;
+		using _blockedFetch = hookFetch(() => {
+			throw new Error("Unexpected network access in explicit pin precedence test");
+		});
+		try {
+			const result = await createAgentSession({
+				...sessionOptions(fixture),
+				credentialSelector: {
+					provider: fixture.provider,
+					selector: { kind: "id", value: String(fixture.wrongRowId) },
+					raw: `${fixture.provider}/id:${fixture.wrongRowId}`,
+				},
+				startupAuthConfig: snapshot(fixture.provider, `id:${fixture.paidRowId}`),
+				modelRegistryStartupMutation: { owner: "cli-root", onAttempt: () => {} },
+			});
+			session = result.session;
+
+			expect(
+				await fixture.authStorage.peekApiKey(fixture.provider, {
+					sessionId: session.credentialSessionId,
+					owner: fixture.modelRegistry.getAuthStorageOwner(),
+				}),
+			).toBe(fixture.wrongKey);
+		} finally {
+			await disposeFixture(fixture, session);
+		}
+	});
+});

--- a/packages/coding-agent/test/startup-credential-pin-handoff.test.ts
+++ b/packages/coding-agent/test/startup-credential-pin-handoff.test.ts
@@ -323,6 +323,46 @@ describe("startup credential pin handoff", () => {
 		}
 	});
 
+	test("a stale durable pin remains unavailable instead of using an alternate account", async () => {
+		using tempDir = TempDir.createSync("@gjc-startup-pin-stale-");
+		const fixture = await createCredentialFixture(tempDir.path());
+		const sessionManager = SessionManager.inMemory(fixture.root);
+		sessionManager.appendCustomEntry("auth-credential-pin", {
+			v: 1,
+			scopeId: "credential-scope",
+			provider: fixture.provider,
+			pin: { kind: "id", value: String(fixture.paidRowId) },
+			credentialStoreIdentity: "fixture-store",
+		});
+		expect(fixture.authStorage.disableCredentialById(fixture.paidRowId, "revoked by test")).toBe(true);
+		let session: AgentSession | undefined;
+		const requests: string[] = [];
+		using _fetch = hookFetch((_input, init) => {
+			const bearer = new Headers(init?.headers).get("Authorization");
+			if (bearer) requests.push(bearer);
+			return Response.json({ data: [] });
+		});
+		try {
+			const result = await createAgentSession({
+				...sessionOptions(fixture),
+				sessionManager,
+				startupAuthConfig: snapshot(fixture.provider, `id:${fixture.paidRowId}`),
+				modelRegistryStartupMutation: { owner: "cli-root", onAttempt: () => {} },
+			});
+			session = result.session;
+			expect(
+				await fixture.authStorage.peekApiKey(fixture.provider, {
+					sessionId: session.credentialSessionId,
+					owner: fixture.modelRegistry.getAuthStorageOwner(),
+				}),
+			).toBeUndefined();
+			expect(requests).not.toContain(`Bearer ${fixture.wrongKey}`);
+			expect(fixture.authStorage.hasSessionCredentialUnavailable(fixture.provider, "credential-scope")).toBe(true);
+		} finally {
+			await disposeFixture(fixture, session);
+		}
+	});
+
 	test("an explicit credential selector overrides the global paid pin", async () => {
 		using tempDir = TempDir.createSync("@gjc-startup-pin-explicit-");
 		const fixture = await createCredentialFixture(tempDir.path());


### PR DESCRIPTION
## What

With a free and a paid OpenAI Codex account saved, `gjc` can abort while activating `ASTRA-Heavy` or `Codex Pro`, even when the paid account is persistently pinned and its model-list response includes the required model. CLI startup discarded the pin snapshot when injecting auth into the SDK; model discovery also selected credentials without the session scope. The free account's cached catalog could consequently exclude Astra and Sol during profile activation.

This change carries the same startup auth snapshot from CLI discovery into the CLI-owned SDK session, then threads the effective credential scope through catalog refreshes and credential peeks. An expired hard-pinned token cannot silently fall through to another account. Generic injected SDK auth still ignores global pin intent, and resumed session AUTO/pin choices and explicit CLI selectors retain their existing precedence.

## Why

Follow-up to the Windows case in [#1592](https://github.com/Yeachan-Heo/gajae-code/issues/1592#issuecomment-5559251194). The original ACP issue has a different trigger. Separate model-list GETs returned HTTP 200 for both saved accounts; the existing cache exactly matched the free account's six normalized models, while the pinned paid account listed eight, including `gpt-6-astra` and `gpt-5.6-sol`. Account identifiers and credentials are omitted.

The regression fixture recreates that cache transition with fake accounts, verifies the selected bearer and account headers, and proves Astra/Sol become available for profile activation. It also covers both account insertion orders, expired pins, CLI-to-SDK handoff, SDK injection isolation, store-identity mismatch, and resumed AUTO/pin and explicit selector precedence.

## Testing

- Windows 11 x64, build 26200; Bun 1.4.0. All new tests use temporary directories and fake credentials, with intercepted or blocked network calls.
- `bun test packages/ai/test/auth-storage-session-selectors.test.ts packages/ai/test/auth-storage-oauth-credential-vanished.test.ts packages/coding-agent/test/codex-profile-pinned-discovery.test.ts packages/coding-agent/test/model-registry-credential-scope-discovery.test.ts packages/coding-agent/test/startup-credential-pin-handoff.test.ts`: 24 passed, 0 failed after the current-dev rebase and fix-forward.
- AI and coding-agent `bun run check:types`; Biome on all 14 changed TypeScript files; `git diff --check`.
- Built a separate Windows executable from the v0.16.4-based patch; isolated `--version` and `--smoke-test` both exited 0.
- Broader Windows run on the release-based patch: 118 passed, 32 failed. Failures were 31 `EBUSY` errors in unchanged SDK fixture cleanup and one five-second resume probe timeout, with a subsequent killed-probe error. This is not a clean full-suite result; full `bun check` was not run.
- No live-account generation or installation was performed. An existing operator session remains active; its executable, configuration, cache, credentials, and transcript were not changed by this fix work.

Scope: this fixes profile startup/resume and discovery calls with an existing credential scope. Pre-session discovery of a missing qualified default model outside a profile is a separate branch and remains unchanged.

## Risk classification

- [ ] `low-risk`
- [ ] `regression-risk`
- [x] `high-risk` — authentication selection and public refresh API changes; independent maintainer review required.

## GJC verdict

The prior exact-head blocking findings were fixed forward and the owner has approved this exact head; merge remains gated on required CI.

```text
gajae.pr-review-verdict.v1 merge-approved sha256:9472e5eaf6cab2b25be3dd23ca00d3d5b53113490d15e600dd88a6ea03093f6f reviewer:human reviewer-id:Yeachan-Heo evidence:tests-and-package-checks
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes (package checks passed; full aggregate not run)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken

<!-- gjc-maintenance-01a083b2 -->
Current maintenance snapshot: base `4b5ec3fcc284f6226f3150f10c182b6f740d8d9c`, head `b358c92289e9de5e7b5bc90346f98fafef4e0209`. The verdict digest is bound to this exact base/head diff and owner approval b358c92289e9de5e7b5bc90346f98fafef4e0209.
<!-- /gjc-maintenance-01a083b2 -->