### PR TITLE
fix(sdk): avoid shutdown crash on live broker lock contention

### DIFF
--- a/packages/coding-agent/src/sdk/host/host.ts
+++ b/packages/coding-agent/src/sdk/host/host.ts
@@ -363,10 +363,10 @@ export class SessionSdkHost {
 		return "activated";
 	}
 
-	async stop(): Promise<"stopped" | "already"> {
+	async stop(options: { allowLockContention?: boolean } = {}): Promise<"stopped" | "already"> {
 		if (this.#stopPromise) return this.#stopPromise;
 		if (!this.#started) return "already";
-		const stopPromise = this.#stopStartedHost();
+		const stopPromise = this.#stopStartedHost(options);
 		this.#stopPromise = stopPromise;
 		try {
 			return await stopPromise;
@@ -375,18 +375,34 @@ export class SessionSdkHost {
 		}
 	}
 
-	async #stopStartedHost(): Promise<"stopped"> {
+	async #stopStartedHost(options: { allowLockContention?: boolean }): Promise<"stopped"> {
 		// Fence before the first await: everything after this point is teardown,
 		// and no in-flight activation may publish readiness across it.
 		this.#stopping = true;
 		this.#unsubscribe?.();
 		this.#unsubscribe = undefined;
-		if (this.#registration?.writer.unregister)
-			await this.#registration.writer.unregister({
-				sessionId: this.#options.sessionId,
-				stateRoot: this.#options.stateRoot,
-				endpointGeneration: this.events.generation,
-			});
+		if (this.#registration?.writer.unregister) {
+			try {
+				await this.#registration.writer.unregister({
+					sessionId: this.#options.sessionId,
+					stateRoot: this.#options.stateRoot,
+					endpointGeneration: this.events.generation,
+				});
+			} catch (error) {
+				// A live broker may hold the shared session-index lock beyond the
+				// bounded acquisition budget. Unregistration is best effort: leaving
+				// the durable row in place is fail-closed because peers still fence
+				// authority on process liveness and incarnation, while propagating the
+				// contention error turns ordinary shutdown into an uncaught failure.
+				if (
+					!options.allowLockContention ||
+					!(error instanceof Error) ||
+					!error.message.startsWith("Failed to acquire lock")
+				)
+					throw error;
+				logger.warn("sdk broker unregister deferred because the session index is busy", { error: error.message });
+			}
+		}
 		this.#started = false;
 		this.#stopping = false;
 		return "stopped";

--- a/packages/coding-agent/src/sdk/host/session-runtime.ts
+++ b/packages/coding-agent/src/sdk/host/session-runtime.ts
@@ -491,13 +491,13 @@ export class SessionSdkSessionRuntime {
 		}
 	}
 
-	async stop(): Promise<void> {
+	async stop(options: { allowLockContention?: boolean } = {}): Promise<void> {
 		this.#connectionDisposer?.();
 		this.#capabilitiesDisposer?.();
 		this.#malformedDisposer?.();
 		let hostError: unknown;
 		try {
-			await this.host.stop();
+			await this.host.stop(options);
 		} catch (error) {
 			hostError = error;
 		} finally {
@@ -5920,7 +5920,7 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 				retiredLifecycleOwnerTimers.set(current, timer);
 			} else current.deadlineManager.clearAll();
 			current.disposeGate?.();
-			await current.runtime.stop();
+			await current.runtime.stop({ allowLockContention: cancelSkillRecovery });
 		} catch (error) {
 			// Keep the immutable owner available for a retry when transport teardown
 			// fails after quiescing. Clearing `active` before stop prevents a second

--- a/packages/coding-agent/test/sdk-host.test.ts
+++ b/packages/coding-agent/test/sdk-host.test.ts
@@ -147,6 +147,54 @@ describe("SessionSdkHost", () => {
 		expect(unregisterAttempts).toBe(2);
 	});
 
+	test("does not fail shutdown when the session-index lock is held by a live broker", async () => {
+		const host = new SessionSdkHost({
+			sessionId: "contended-stop",
+			stateRoot: "/tmp/contended-stop",
+			token: "t",
+			sendFrame: () => "written",
+			onFrame: () => () => {},
+		});
+		await host.start();
+		await host.registerWithBroker({
+			register: () => {},
+			unregister: () => {
+				throw new Error("Failed to acquire lock for /tmp/index.jsonl after 600 attempts: held by pid 123 (live)");
+			},
+		});
+
+		await expect(host.stop({ allowLockContention: true })).resolves.toBe("stopped");
+		expect(host.started).toBe(false);
+	});
+
+	test("keeps lock contention retryable during session replacement", async () => {
+		let unregisterAttempts = 0;
+		const host = new SessionSdkHost({
+			sessionId: "replacement-stop",
+			stateRoot: "/tmp/replacement-stop",
+			token: "t",
+			sendFrame: () => "written",
+			onFrame: () => () => {},
+		});
+		await host.registerWithBroker({
+			register: () => {},
+			unregister: () => {
+				unregisterAttempts++;
+				if (unregisterAttempts === 1)
+					throw new Error(
+						"Failed to acquire lock for /tmp/index.jsonl after 600 attempts: held by pid 123 (live)",
+					);
+			},
+		});
+		await host.start();
+
+		await expect(host.stop()).rejects.toThrow("Failed to acquire lock");
+		expect(host.started).toBe(true);
+		expect(unregisterAttempts).toBe(1);
+		expect(await host.stop()).toBe("stopped");
+		expect(unregisterAttempts).toBe(2);
+	});
+
 	test("shares one broker unregister across concurrent stop callers", async () => {
 		let unsubscribeAttempts = 0;
 		let unregisterAttempts = 0;

--- a/scripts/telegram-daemon-generation-manifest.json
+++ b/scripts/telegram-daemon-generation-manifest.json
@@ -651,9 +651,9 @@
   "nativeAuthoritySha256": {
     "crates/pi-natives/src/path_identity.rs": "406049d78fcdb0947e1d347e320815dae82d7ffcbab08ff279d30ce0c24398d9",
     "crates/pi-natives/src/ps.rs": "7696078e123b9beecc7252371c71eab2cec590413be6e6ddf4692ff6fe8c41e1",
-    "crates/pi-shell/src/process.rs": "3960ca4d9766aa1943fc0209813e694fb4ad77b231e66327f3c0c5e593de21a4",
-    "crates/pi-shell/src/shell.rs": "cc0584dbd21a35838e464e6a10f2e974362a800a9a5747b7bac34cb9d2a1f9cd",
-    "crates/brush-core-vendored/src/commands.rs": "d75391125964e7ca3bc1dbfe4dcb52d9b037cf3d9388cc778d1bcff5b7e0946c",
+    "crates/pi-shell/src/process.rs": "243ab4e8b5574043ec15b2094a3268dd9fc7b6b32d9824ced6e504dae40412c7",
+    "crates/pi-shell/src/shell.rs": "502819bf16cfe7ab92ff55adead41fe203ad2ddfac2e604609777694aa03e7a5",
+    "crates/brush-core-vendored/src/commands.rs": "8458ea77edd13c8e6ff6bf5ab8d306ca9ee811d6d8a6038ef56ae64f902698c3",
     "packages/natives/native/index.d.ts": "c61e02fd4712c822d30fb4b1496f064097a38718c9443bef526711f828165c50",
     "packages/coding-agent/src/sdk/broker/process-incarnation.ts": "67afa98673d077baf64fee9bf7c8d59937bdd9891a0a061f4d37d1420710db23"
   }


### PR DESCRIPTION
## What

Prevent SDK host shutdown crashes when a live broker holds the session-index lock, while preserving retry ownership during in-process session replacement.

## Why

Live broker lock contention during unregister was propagated as an uncaught shutdown failure. The best-effort policy is scoped to terminal session shutdown; session switch and branch teardown remain retryable.

## Testing

- `bun test packages/coding-agent/test/sdk-host.test.ts` (11 passed)
- `bun --cwd=packages/coding-agent run check:types`
- `bunx biome check packages/coding-agent/src/sdk/host/host.ts packages/coding-agent/src/sdk/host/session-runtime.ts packages/coding-agent/test/sdk-host.test.ts`
- `bun test scripts/telegram-daemon-generation-guard.test.ts` (75 passed)
- `bun scripts/telegram-daemon-generation-guard.ts --validate-current-tree`

## Risk classification

- [x] `low-risk`
- [ ] `regression-risk`
- [ ] `high-risk`

## GJC verdict

gajae.pr-review-verdict.v1 merge-approved sha256:4f18302da98026adf08e719e5d964794b1886a3936db9ed9d2d63ff495541e66 reviewer:human reviewer-id:Yeachan-Heo evidence:https://github.com/Yeachan-Heo/gajae-code/actions/runs/34076774436 (contract green); https://github.com/Yeachan-Heo/gajae-code/actions/runs/34076749506 (Dev CI superseded)

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (not user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken