### PR TITLE
fix(tools): preserve getter receiver in ultragoal ask guard

### DIFF
--- a/packages/coding-agent/src/tools/ultragoal-ask-guard.ts
+++ b/packages/coding-agent/src/tools/ultragoal-ask-guard.ts
@@ -70,9 +70,9 @@ export function guardToolForUltragoalAsk<T extends AgentTool>(
 	const candidate = tool as GuardedTool;
 	if (candidate[ULTRAGOAL_ASK_GUARD]) return tool;
 	const wrapped = new Proxy(tool, {
-		get(target, prop, receiver) {
+		get(target, prop) {
 			if (prop === ULTRAGOAL_ASK_GUARD) return true;
-			if (prop !== "execute") return Reflect.get(target, prop, receiver);
+			if (prop !== "execute") return Reflect.get(target, prop);
 			return async (...args: unknown[]): Promise<unknown> => {
 				// The wrapper runs BEFORE AskTool.execute(): resolve the nudge
 				// budget against the SESSION profile, never the process-global one.

--- a/packages/coding-agent/test/tools/ultragoal-ask-guard.test.ts
+++ b/packages/coding-agent/test/tools/ultragoal-ask-guard.test.ts
@@ -130,6 +130,28 @@ class StubExtensionWrappedAskTool {
 	}
 }
 
+class PrivateMetadataAskTool {
+	#name = "ask";
+	#description = "Ask the user a question";
+
+	label = "Ask";
+	summary = "Ask";
+	parameters = {} as never;
+	strict = true;
+
+	get name(): string {
+		return this.#name;
+	}
+
+	get description(): string {
+		return this.#description;
+	}
+
+	async execute(): Promise<{ content: { type: "text"; text: string }[]; details: object }> {
+		return { content: [{ type: "text", text: "asked" }], details: {} };
+	}
+}
+
 describe("ultragoal ask guard", () => {
 	it("allows ask when durable ultragoal state is absent without requiring ambient GJC_SESSION_ID", async () => {
 		const cwd = await tempDir();
@@ -184,6 +206,16 @@ describe("ultragoal ask guard", () => {
 
 		expect(result.content[0]).toMatchObject({ type: "text", text: "asked" });
 		expect(tool.executeArgs).toEqual(["call", { foo: 1 }, undefined, undefined, undefined]);
+	});
+
+	it("preserves private-field metadata getters and avoids double-guarding", () => {
+		const tool = new PrivateMetadataAskTool();
+		const guarded = guardToolForUltragoalAsk(tool as unknown as AgentTool, () => process.cwd());
+
+		expect(guarded.name).toBe("ask");
+		expect(guarded.description).toBe("Ask the user a question");
+		const guardedAgain = guardToolForUltragoalAsk(guarded, () => process.cwd());
+		expect(guardedAgain).toBe(guarded);
 	});
 
 	it("blocks an unwrapped AskTool before prompting while ultragoal is active", async () => {


### PR DESCRIPTION
## What
Fix the ask guard Proxy metadata getter receiver. `Reflect.get(target, prop)` invokes accessors with the original target, preserving private-field access.

## Why
Mac Studio source execution reproduced `Cannot access invalid private field (this.#tool)` at `ToolDescriptorFacade.name` during AgentSession startup. The fix is rebased onto current `dev` and includes a private-field getter regression test plus the existing prototype-method receiver coverage.

## Testing
- Exact-head focused CI: `packages/coding-agent/test/tools/ultragoal-ask-guard.test.ts` (run triggered by head `2e39dbb2dd44ead010a834267434469fb3498305`).
- Local: `git diff --check origin/dev...HEAD` passed.
- Local focused test was attempted but could not start because the checkout lacks a matching native addon (`@gajae-code/natives` loader version sentinel mismatch); CI is the authoritative runtime evidence.

## Risk classification
- [ ] `low-risk`
- [x] `regression-risk`
- [ ] `high-risk`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:6b76f41a3791f839042ff535c284d966282e53e5c91fcea558f831ea629c2a2d reviewer:human reviewer-id:Yeachan-Heo evidence:exact-head CI run for 2e39dbb2dd44ead010a834267434469fb3498305 plus git diff --check origin/dev...HEAD
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes
- [x] Tested locally or by exact-head CI
- [ ] CHANGELOG updated (not user-facing)
- [x] Verdict above matches the exact PR head
- [x] Risk classification above matches the actual review path taken