### PR TITLE
test(coding-agent): restore presentation reset in resume reentrancy red-team fixture

### DIFF
--- a/packages/coding-agent/test/resume-session-reentrancy.redteam.test.ts
+++ b/packages/coding-agent/test/resume-session-reentrancy.redteam.test.ts
@@ -118,6 +118,7 @@ function createResumeHarness(options: ResumeHarnessOptions = {}): {
 		rebuildInitialMessages: options.rebuildInitialMessages ?? vi.fn(),
 		reloadTodos: options.reloadTodos ?? vi.fn(async () => undefined),
 		showStatus,
+		resetAssistantTextPresentation: vi.fn(),
 	} as unknown as InteractiveModeContext;
 
 	return {


### PR DESCRIPTION
## What

Restore the required presentation-reset callback in the resume re-entrancy red-team harness.

## Why

The fixture omitted `resetAssistantTextPresentation`, so committed resume paths failed with a `TypeError` before their adversarial assertions ran. This fixes #5328 without weakening the required production callback contract.

## Testing

- Reproduced the issue on `origin/dev`: 5 passing / 16 failing cases in `packages/coding-agent/test/resume-session-reentrancy.redteam.test.ts`.
- Verified the repaired red-team fixture: 21 passing / 0 failing.
- Verified both resume fixtures: 28 passing / 0 failing.
- `bunx biome check packages/coding-agent/test/resume-session-reentrancy.redteam.test.ts`

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:0fea2e714b5424fc4097fcc57aa3329a15557e94e0dcc2997906c752217703b4 reviewer:human reviewer-id:Yeachan-Heo evidence:local exact-file reproduction and paired fixture verification
```

---

- [ ] Target branch is `dev`
- [ ] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (not user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*