### PR TITLE
fix(lsp): spawn trusted LSP servers by invocation path, not realpath

### DIFF
--- a/docs/tools/lsp.md
+++ b/docs/tools/lsp.md
@@ -196,7 +196,7 @@ Same as `definition`, but sends `textDocument/implementation` and reports `imple
 - Calls `detectLspmux(session.cwd)` and appends status text when a trusted `lspmux` is installed for the session trust root.
 
 **Output text**
-- `Active language servers: ...` or `No language servers configured for this project`, optionally followed by `lspmux: active (multiplexing enabled)` or `lspmux: installed but server not running`.
+- `Configured language servers: ...` or `No language servers configured for this project`, optionally followed by `lspmux: active (multiplexing enabled)` or `lspmux: installed but server not running`.
 
 ### `reload`
 **Inputs**

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 
 - Runtime state persistence now identifies contradictory `ready_for_input`/`live` fields with their lifecycle state and expected value instead of reporting only a generic invalid/unreadable marker error. Invalid markers remain untouched; this does not migrate or repair old session state.
+- LSP auto-discovery now launches trusted executable symlinks through their discovered paths instead of canonicalizing them to their targets, preserving proxy invocation names such as `rust-analyzer` when installed through rustup. The LSP status action now labels these entries as configured rather than active, since a client has not necessarily started (#5354).
 - SDK snapshot pages now read and integrity-check one contiguous span instead of rereading chunks per row. Reverse-provider disconnects discard connection-scoped registration receipts; relay shutdown releases backpressure listeners without destroying caller-owned sinks, and fragmented request frames are assembled once per newline.
 
 - The TUI working spinner and tool intent remain visible when a run continues after automatic context compaction, a compaction-hook veto, or a successful managed model retry. Temporary status replacement no longer marks the foreground run as finished; actual completion and cancellation still clear it.

--- a/packages/coding-agent/src/lsp/config.ts
+++ b/packages/coding-agent/src/lsp/config.ts
@@ -336,14 +336,21 @@ export function resolveCommand(command: string, cwd: string): string | null {
 	return piUtils.$which(command);
 }
 
-/** Resolve an LSP executable without consulting project-controlled bin directories. */
+/**
+ * Resolve an LSP executable without consulting project-controlled bin directories.
+ *
+ * Trust is evaluated on both the discovered and canonical paths, but the returned
+ * path is the discovered one: multiplexed launchers such as rustup pick the proxied
+ * tool from argv[0], so `~/.cargo/bin/rust-analyzer -> rustup` must be spawned as
+ * `rust-analyzer`, not as the resolved `rustup` binary.
+ */
 function resolveTrustedLspCommand(command: string, cwd: string): string | null {
 	if (!path.isAbsolute(command) && (command.includes("/") || command.includes("\\"))) return null;
 	const discovered = path.isAbsolute(command) ? command : piUtils.$which(command);
 	if (!discovered) return null;
 	if (isProjectControlledPath(discovered, cwd)) return null;
-	const canonical = canonicalExistingPath(discovered);
-	return canonical;
+	if (!canonicalExistingPath(discovered)) return null;
+	return discovered;
 }
 
 interface ConfigSource {

--- a/packages/coding-agent/src/lsp/index.ts
+++ b/packages/coding-agent/src/lsp/index.ts
@@ -1160,7 +1160,7 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 
 			const serverStatus =
 				servers.length > 0
-					? `Active language servers: ${servers.join(", ")}`
+					? `Configured language servers: ${servers.join(", ")}`
 					: "No language servers configured for this project";
 
 			const output = lspmuxStatus ? `${serverStatus}\n${lspmuxStatus}` : serverStatus;

--- a/packages/coding-agent/src/lsp/path-trust.ts
+++ b/packages/coding-agent/src/lsp/path-trust.ts
@@ -59,13 +59,18 @@ function findProjectTrustRoot(start: string, stopPaths: ReadonlySet<string>): st
 	}
 }
 
+function isProjectMarkerRoot(root: string): boolean {
+	return fs.existsSync(path.join(root, ".git")) || isDirectory(path.join(root, CONFIG_DIR_NAME));
+}
+
 /**
  * Spellings of `candidate` that differ only in how HOME is named: the path as
  * given, plus the same path with any ancestor that is HOME under another name
- * replaced by canonical HOME. Nothing beneath HOME is dereferenced, so a
- * project directory that merely links *into* HOME never becomes an alias.
+ * replaced by canonical HOME. The suffix beneath HOME is kept as spelled, and an
+ * alias that lives inside a project (`repo/home-link -> HOME`) is project
+ * content, not a HOME spelling, so it is never expanded.
  */
-function candidateSpellings(candidate: string, canonicalHome: string): string[] {
+function candidateSpellings(candidate: string, canonicalHome: string, projectRoot: string | undefined): string[] {
 	const resolved = path.resolve(candidate);
 	const spellings = [resolved];
 	const normalizedHome = normalizePathForComparison(canonicalHome);
@@ -73,6 +78,7 @@ function candidateSpellings(candidate: string, canonicalHome: string): string[] 
 	for (;;) {
 		if (
 			normalizePathForComparison(current) !== normalizedHome &&
+			(projectRoot === undefined || !pathIsLexicallyWithin(projectRoot, current)) &&
 			normalizePathForComparison(canonicalPath(current)) === normalizedHome
 		) {
 			spellings.push(path.join(canonicalHome, path.relative(current, resolved)));
@@ -97,8 +103,13 @@ export function isProjectControlledPath(candidate: string, cwd: string): boolean
 	// runs over every HOME-alias spelling of both the candidate and the root.
 	if (lexicalTrustRoot !== undefined) {
 		const trustRootIsHomeScoped = pathIsWithin(canonicalHome, lexicalTrustRoot);
-		const rootSpellings = candidateSpellings(lexicalTrustRoot, canonicalHome);
-		const spellings = candidateSpellings(candidate, canonicalHome);
+		// A root under HOME may legitimately be reached through a HOME alias, and a
+		// bare fallback root (no project marker) owns nothing on its own; a real
+		// project root outside HOME owns every alias directory it contains.
+		const aliasBoundary =
+			!trustRootIsHomeScoped && isProjectMarkerRoot(lexicalTrustRoot) ? lexicalTrustRoot : undefined;
+		const rootSpellings = candidateSpellings(lexicalTrustRoot, canonicalHome, undefined);
+		const spellings = candidateSpellings(candidate, canonicalHome, aliasBoundary);
 		// Every spelling names the same location, so home scope is a property of
 		// the location: one spelling under HOME makes all of them HOME-scoped.
 		const candidateIsHomeScoped = spellings.some(

--- a/packages/coding-agent/src/lsp/path-trust.ts
+++ b/packages/coding-agent/src/lsp/path-trust.ts
@@ -132,7 +132,6 @@ export function isProjectControlledPath(candidate: string, cwd: string): boolean
 	const canonicalTrustRoot = findProjectTrustRoot(canonicalPath(cwd), stopPaths);
 	if (canonicalTrustRoot !== undefined) canonicalTrustRoots.add(canonicalPath(canonicalTrustRoot));
 	for (const trustRoot of canonicalTrustRoots) {
-		if (!isProjectMarkerRoot(trustRoot)) continue;
 		const trustRootIsHomeScoped = pathIsLexicallyWithin(canonicalHome, trustRoot);
 		const parentOwned =
 			pathIsLexicallyWithin(trustRoot, canonicalCandidateParent) && (!parentIsHomeScoped || trustRootIsHomeScoped);

--- a/packages/coding-agent/src/lsp/path-trust.ts
+++ b/packages/coding-agent/src/lsp/path-trust.ts
@@ -61,13 +61,16 @@ function findProjectTrustRoot(start: string, stopPaths: ReadonlySet<string>): st
 
 export function isProjectControlledPath(candidate: string, cwd: string): boolean {
 	const home = os.homedir();
-	const stopPaths = new Set([path.resolve(home), canonicalPath(home)].map(normalizePathForComparison));
+	const canonicalHome = canonicalPath(home);
+	const stopPaths = new Set([path.resolve(home), canonicalHome].map(normalizePathForComparison));
 	const lexicalTrustRoot = findProjectTrustRoot(cwd, stopPaths);
 	// A user-owned executable under HOME (e.g. ~/.gjc/bin) is only exempt from a
 	// trust root that itself lives under HOME. Each check judges home scope on the
-	// same view of the path it inspects (lexical vs canonical); mixing them let a
-	// project link into HOME, or a HOME link into the project, escape rejection.
-	const candidateIsLexicallyHomeScoped = pathIsLexicallyWithin(home, candidate);
+	// same view of the path it inspects, without dereferencing the candidate:
+	// mixing views let a project link into HOME, or a HOME link into the project,
+	// escape rejection. HOME may itself be spelled lexically or canonically.
+	const candidateIsLexicallyHomeScoped =
+		pathIsLexicallyWithin(home, candidate) || pathIsLexicallyWithin(canonicalHome, candidate);
 	if (
 		lexicalTrustRoot !== undefined &&
 		pathIsLexicallyWithin(lexicalTrustRoot, candidate) &&
@@ -77,14 +80,14 @@ export function isProjectControlledPath(candidate: string, cwd: string): boolean
 
 	const canonicalCandidate = canonicalPath(candidate);
 	const canonicalCandidateParent = canonicalParentPath(candidate);
-	const parentIsHomeScoped = pathIsLexicallyWithin(home, canonicalCandidateParent);
-	const targetIsHomeScoped = pathIsWithin(home, canonicalCandidate);
+	const parentIsHomeScoped = pathIsLexicallyWithin(canonicalHome, canonicalCandidateParent);
+	const targetIsHomeScoped = pathIsWithin(canonicalHome, canonicalCandidate);
 	const canonicalTrustRoots = new Set<string>();
 	if (lexicalTrustRoot !== undefined) canonicalTrustRoots.add(canonicalPath(lexicalTrustRoot));
 	const canonicalTrustRoot = findProjectTrustRoot(canonicalPath(cwd), stopPaths);
 	if (canonicalTrustRoot !== undefined) canonicalTrustRoots.add(canonicalPath(canonicalTrustRoot));
 	for (const trustRoot of canonicalTrustRoots) {
-		const trustRootIsHomeScoped = pathIsLexicallyWithin(home, trustRoot) || pathIsWithin(home, trustRoot);
+		const trustRootIsHomeScoped = pathIsLexicallyWithin(canonicalHome, trustRoot);
 		const parentOwned =
 			pathIsLexicallyWithin(trustRoot, canonicalCandidateParent) && (!parentIsHomeScoped || trustRootIsHomeScoped);
 		const targetOwned = pathIsWithin(trustRoot, canonicalCandidate) && (!targetIsHomeScoped || trustRootIsHomeScoped);

--- a/packages/coding-agent/src/lsp/path-trust.ts
+++ b/packages/coding-agent/src/lsp/path-trust.ts
@@ -132,6 +132,7 @@ export function isProjectControlledPath(candidate: string, cwd: string): boolean
 	const canonicalTrustRoot = findProjectTrustRoot(canonicalPath(cwd), stopPaths);
 	if (canonicalTrustRoot !== undefined) canonicalTrustRoots.add(canonicalPath(canonicalTrustRoot));
 	for (const trustRoot of canonicalTrustRoots) {
+		if (!isProjectMarkerRoot(trustRoot)) continue;
 		const trustRootIsHomeScoped = pathIsLexicallyWithin(canonicalHome, trustRoot);
 		const parentOwned =
 			pathIsLexicallyWithin(trustRoot, canonicalCandidateParent) && (!parentIsHomeScoped || trustRootIsHomeScoped);

--- a/packages/coding-agent/src/lsp/path-trust.ts
+++ b/packages/coding-agent/src/lsp/path-trust.ts
@@ -64,11 +64,12 @@ export function isProjectControlledPath(candidate: string, cwd: string): boolean
 	const canonicalHome = canonicalPath(home);
 	const stopPaths = new Set([path.resolve(home), canonicalHome].map(normalizePathForComparison));
 	const lexicalTrustRoot = findProjectTrustRoot(cwd, stopPaths);
-	// A user-owned executable under HOME (e.g. ~/.gjc/bin) is only exempt from a
-	// trust root that itself lives under HOME. Each check judges home scope on the
-	// same view of the path it inspects, without dereferencing the candidate:
-	// mixing views let a project link into HOME, or a HOME link into the project,
-	// escape rejection. HOME may itself be spelled lexically or canonically.
+	// A trust root outside HOME must not claim user executables inside HOME
+	// (e.g. ~/.gjc/bin); a root under HOME still owns what it contains. Each check
+	// judges home scope on the same view of the path it inspects, without
+	// dereferencing the candidate: mixing views let a project link into HOME, or a
+	// HOME link into the project, escape rejection. HOME may itself be spelled
+	// lexically or canonically.
 	const candidateIsLexicallyHomeScoped =
 		pathIsLexicallyWithin(home, candidate) || pathIsLexicallyWithin(canonicalHome, candidate);
 	if (

--- a/packages/coding-agent/src/lsp/path-trust.ts
+++ b/packages/coding-agent/src/lsp/path-trust.ts
@@ -63,25 +63,32 @@ export function isProjectControlledPath(candidate: string, cwd: string): boolean
 	const home = os.homedir();
 	const stopPaths = new Set([path.resolve(home), canonicalPath(home)].map(normalizePathForComparison));
 	const lexicalTrustRoot = findProjectTrustRoot(cwd, stopPaths);
-	const candidateIsHomeScoped = pathIsLexicallyWithin(home, candidate) || pathIsWithin(home, candidate);
+	// A user-owned executable under HOME (e.g. ~/.gjc/bin) is only exempt from a
+	// trust root that itself lives under HOME. Each check judges home scope on the
+	// same view of the path it inspects (lexical vs canonical); mixing them let a
+	// project link into HOME, or a HOME link into the project, escape rejection.
+	const candidateIsLexicallyHomeScoped = pathIsLexicallyWithin(home, candidate);
 	if (
 		lexicalTrustRoot !== undefined &&
 		pathIsLexicallyWithin(lexicalTrustRoot, candidate) &&
-		(!candidateIsHomeScoped || pathIsLexicallyWithin(home, lexicalTrustRoot))
+		(!candidateIsLexicallyHomeScoped || pathIsLexicallyWithin(home, lexicalTrustRoot))
 	)
 		return true;
 
+	const canonicalCandidate = canonicalPath(candidate);
+	const canonicalCandidateParent = canonicalParentPath(candidate);
+	const parentIsHomeScoped = pathIsLexicallyWithin(home, canonicalCandidateParent);
+	const targetIsHomeScoped = pathIsWithin(home, canonicalCandidate);
 	const canonicalTrustRoots = new Set<string>();
 	if (lexicalTrustRoot !== undefined) canonicalTrustRoots.add(canonicalPath(lexicalTrustRoot));
 	const canonicalTrustRoot = findProjectTrustRoot(canonicalPath(cwd), stopPaths);
 	if (canonicalTrustRoot !== undefined) canonicalTrustRoots.add(canonicalPath(canonicalTrustRoot));
 	for (const trustRoot of canonicalTrustRoots) {
-		if (
-			(pathIsLexicallyWithin(trustRoot, canonicalParentPath(candidate)) ||
-				pathIsWithin(trustRoot, canonicalPath(candidate))) &&
-			(!candidateIsHomeScoped || pathIsLexicallyWithin(home, trustRoot) || pathIsWithin(home, trustRoot))
-		)
-			return true;
+		const trustRootIsHomeScoped = pathIsLexicallyWithin(home, trustRoot) || pathIsWithin(home, trustRoot);
+		const parentOwned =
+			pathIsLexicallyWithin(trustRoot, canonicalCandidateParent) && (!parentIsHomeScoped || trustRootIsHomeScoped);
+		const targetOwned = pathIsWithin(trustRoot, canonicalCandidate) && (!targetIsHomeScoped || trustRootIsHomeScoped);
+		if (parentOwned || targetOwned) return true;
 	}
 	return false;
 }

--- a/packages/coding-agent/src/lsp/path-trust.ts
+++ b/packages/coding-agent/src/lsp/path-trust.ts
@@ -59,6 +59,30 @@ function findProjectTrustRoot(start: string, stopPaths: ReadonlySet<string>): st
 	}
 }
 
+/**
+ * Spellings of `candidate` that differ only in how HOME is named: the path as
+ * given, plus the same path with any ancestor that is HOME under another name
+ * replaced by canonical HOME. Nothing beneath HOME is dereferenced, so a
+ * project directory that merely links *into* HOME never becomes an alias.
+ */
+function candidateSpellings(candidate: string, canonicalHome: string): string[] {
+	const resolved = path.resolve(candidate);
+	const spellings = [resolved];
+	const normalizedHome = normalizePathForComparison(canonicalHome);
+	let current = path.dirname(resolved);
+	for (;;) {
+		if (
+			normalizePathForComparison(current) !== normalizedHome &&
+			normalizePathForComparison(canonicalPath(current)) === normalizedHome
+		) {
+			spellings.push(path.join(canonicalHome, path.relative(current, resolved)));
+		}
+		const parent = path.dirname(current);
+		if (parent === current) return spellings;
+		current = parent;
+	}
+}
+
 export function isProjectControlledPath(candidate: string, cwd: string): boolean {
 	const home = os.homedir();
 	const canonicalHome = canonicalPath(home);
@@ -67,17 +91,26 @@ export function isProjectControlledPath(candidate: string, cwd: string): boolean
 	// A trust root outside HOME must not claim user executables inside HOME
 	// (e.g. ~/.gjc/bin); a root under HOME still owns what it contains. Each check
 	// judges home scope on the same view of the path it inspects, without
-	// dereferencing the candidate: mixing views let a project link into HOME, or a
-	// HOME link into the project, escape rejection. HOME may itself be spelled
-	// lexically or canonically.
-	const candidateIsLexicallyHomeScoped =
-		pathIsLexicallyWithin(home, candidate) || pathIsLexicallyWithin(canonicalHome, candidate);
-	if (
-		lexicalTrustRoot !== undefined &&
-		pathIsLexicallyWithin(lexicalTrustRoot, candidate) &&
-		(!candidateIsLexicallyHomeScoped || pathIsLexicallyWithin(home, lexicalTrustRoot))
-	)
-		return true;
+	// dereferencing the candidate's final component: mixing views let a project
+	// link into HOME, or a HOME link into the project, escape rejection. HOME may
+	// be spelled lexically or canonically on either side, so the lexical check
+	// runs over every HOME-alias spelling of both the candidate and the root.
+	if (lexicalTrustRoot !== undefined) {
+		const trustRootIsHomeScoped = pathIsWithin(canonicalHome, lexicalTrustRoot);
+		const rootSpellings = candidateSpellings(lexicalTrustRoot, canonicalHome);
+		const spellings = candidateSpellings(candidate, canonicalHome);
+		// Every spelling names the same location, so home scope is a property of
+		// the location: one spelling under HOME makes all of them HOME-scoped.
+		const candidateIsHomeScoped = spellings.some(
+			spelling => pathIsLexicallyWithin(home, spelling) || pathIsLexicallyWithin(canonicalHome, spelling),
+		);
+		if (
+			(!candidateIsHomeScoped || trustRootIsHomeScoped) &&
+			spellings.some(spelling => rootSpellings.some(root => pathIsLexicallyWithin(root, spelling)))
+		) {
+			return true;
+		}
+	}
 
 	const canonicalCandidate = canonicalPath(candidate);
 	const canonicalCandidateParent = canonicalParentPath(candidate);

--- a/packages/coding-agent/test/lsp/lsp-command-trust.test.ts
+++ b/packages/coding-agent/test/lsp/lsp-command-trust.test.ts
@@ -250,6 +250,29 @@ describe("LSP repository command trust", () => {
 		expect(fs.existsSync(canaryPath)).toBe(false);
 	});
 
+	it("reports configured language servers before a client starts", async () => {
+		using tempDir = TempDir.createSync("@gjc-lsp-configured-status-");
+		const cwd = path.join(tempDir.path(), "repo");
+		const externalBinDir = path.join(os.homedir(), `.gjc-lsp-configured-status-${process.pid}-${Date.now()}`);
+		const rustAnalyzer = path.join(externalBinDir, "rust-analyzer");
+		const forgetExternalGrant = registerOwnedDeletionRoot(externalBinDir);
+		await fs.promises.mkdir(cwd, { recursive: true });
+		await fs.promises.mkdir(externalBinDir, { recursive: true });
+		try {
+			await Bun.write(path.join(cwd, "Cargo.toml"), "[package]\n");
+			await Bun.write(rustAnalyzer, "");
+			vi.spyOn(piUtils, "$which").mockImplementation(command => (command === "rust-analyzer" ? rustAnalyzer : null));
+
+			const tool = new LspTool({ cwd } as ToolSession);
+			const result = await tool.execute("configured-status", { action: "status" });
+
+			expect(result.content).toEqual([{ type: "text", text: "Configured language servers: rust-analyzer" }]);
+		} finally {
+			await safeRm(externalBinDir, { recursive: true, force: true });
+			forgetExternalGrant();
+		}
+	});
+
 	it("wraps supported servers with an external lspmux and honors both disable variables", async () => {
 		using tempDir = TempDir.createSync("@gjc-lspmux-external-");
 		const cwd = path.join(tempDir.path(), "repo");

--- a/packages/coding-agent/test/lsp/lsp-command-trust.test.ts
+++ b/packages/coding-agent/test/lsp/lsp-command-trust.test.ts
@@ -525,6 +525,33 @@ describe("LSP repository command trust", () => {
 		expect(loadConfig(cwd).servers["rust-analyzer"]).toBeUndefined();
 	});
 
+	it("keeps HOME executables exempt from an ancestor cwd when HOME is a symlink, under either spelling", async () => {
+		if (process.platform === "win32") return;
+
+		using tempDir = TempDir.createSync("@gjc-lsp-home-alias-trust-");
+		const canonicalHome = path.join(tempDir.path(), "home");
+		const lexicalHome = path.join(tempDir.path(), "home-link");
+		const userBin = path.join(canonicalHome, ".gjc", "bin");
+		await fs.promises.mkdir(userBin, { recursive: true });
+		await fs.promises.symlink(canonicalHome, lexicalHome);
+		const server = path.join(userBin, "typescript-language-server");
+		await Bun.write(server, "");
+		vi.spyOn(os, "homedir").mockReturnValue(lexicalHome);
+
+		// cwd is HOME's parent: its fallback trust root contains HOME, so only the
+		// home exemption keeps user executables trusted.
+		const cwd = tempDir.path();
+		expect(isProjectControlledPath(path.join(lexicalHome, ".gjc", "bin", "typescript-language-server"), cwd)).toBe(
+			false,
+		);
+		expect(isProjectControlledPath(server, cwd)).toBe(false);
+
+		// A project file directly under that same ancestor cwd is still owned.
+		const projectFile = path.join(cwd, "typescript-language-server");
+		await Bun.write(projectFile, "");
+		expect(isProjectControlledPath(projectFile, cwd)).toBe(true);
+	});
+
 	it("rejects home-crossing symlinks in both directions when the repository is a sibling of HOME", async () => {
 		if (process.platform === "win32") return;
 

--- a/packages/coding-agent/test/lsp/lsp-command-trust.test.ts
+++ b/packages/coding-agent/test/lsp/lsp-command-trust.test.ts
@@ -536,20 +536,48 @@ describe("LSP repository command trust", () => {
 		await fs.promises.symlink(canonicalHome, lexicalHome);
 		const server = path.join(userBin, "typescript-language-server");
 		await Bun.write(server, "");
-		vi.spyOn(os, "homedir").mockReturnValue(lexicalHome);
+		const lexicalServer = path.join(lexicalHome, ".gjc", "bin", "typescript-language-server");
 
 		// cwd is HOME's parent: its fallback trust root contains HOME, so only the
-		// home exemption keeps user executables trusted.
+		// home exemption keeps user executables trusted. Both homedir spellings
+		// must accept both candidate spellings.
 		const cwd = tempDir.path();
-		expect(isProjectControlledPath(path.join(lexicalHome, ".gjc", "bin", "typescript-language-server"), cwd)).toBe(
-			false,
-		);
-		expect(isProjectControlledPath(server, cwd)).toBe(false);
-
-		// A project file directly under that same ancestor cwd is still owned.
 		const projectFile = path.join(cwd, "typescript-language-server");
 		await Bun.write(projectFile, "");
-		expect(isProjectControlledPath(projectFile, cwd)).toBe(true);
+		for (const homedir of [lexicalHome, canonicalHome]) {
+			vi.spyOn(os, "homedir").mockReturnValue(homedir);
+			expect(isProjectControlledPath(lexicalServer, cwd)).toBe(false);
+			expect(isProjectControlledPath(server, cwd)).toBe(false);
+			// A project file directly under that same ancestor cwd is still owned.
+			expect(isProjectControlledPath(projectFile, cwd)).toBe(true);
+		}
+	});
+
+	it("keeps owning a project directory that links into HOME from a canonically spelled cwd", async () => {
+		if (process.platform === "win32") return;
+
+		using tempDir = TempDir.createSync("@gjc-lsp-home-alias-project-link-");
+		const canonicalHome = path.join(tempDir.path(), "home");
+		const lexicalHome = path.join(tempDir.path(), "home-link");
+		const userBin = path.join(canonicalHome, ".gjc", "bin");
+		const repo = path.join(canonicalHome, "repo");
+		await fs.promises.mkdir(userBin, { recursive: true });
+		await fs.promises.mkdir(path.join(repo, ".git"), { recursive: true });
+		await fs.promises.symlink(canonicalHome, lexicalHome);
+		await Bun.write(path.join(userBin, "typescript-language-server"), "");
+		// repo/bin is a project-owned directory symlink into HOME.
+		await fs.promises.symlink(userBin, path.join(repo, "bin"));
+		const projectCandidate = path.join(repo, "bin", "typescript-language-server");
+
+		for (const homedir of [lexicalHome, canonicalHome]) {
+			vi.spyOn(os, "homedir").mockReturnValue(homedir);
+			for (const cwd of [repo, path.join(lexicalHome, "repo")]) {
+				expect(isProjectControlledPath(projectCandidate, cwd)).toBe(true);
+				expect(
+					isProjectControlledPath(path.join(lexicalHome, "repo", "bin", "typescript-language-server"), cwd),
+				).toBe(true);
+			}
+		}
 	});
 
 	it("rejects home-crossing symlinks in both directions when the repository is a sibling of HOME", async () => {

--- a/packages/coding-agent/test/lsp/lsp-command-trust.test.ts
+++ b/packages/coding-agent/test/lsp/lsp-command-trust.test.ts
@@ -622,6 +622,15 @@ describe("LSP repository command trust", () => {
 		const goodLink = path.join(home, ".local", "bin", "rust-analyzer-good");
 		await fs.promises.symlink(rustup, goodLink);
 		expect(isProjectControlledPath(goodLink, repo)).toBe(false);
+
+		// A project-owned directory alias to HOME itself is project content: the
+		// invocation path stays under the repository, so it is still owned.
+		const homeAlias = path.join(repo, "home-link");
+		await fs.promises.symlink(home, homeAlias);
+		const aliasedCandidate = path.join(homeAlias, ".cargo", "bin", "rustup");
+		expect(isProjectControlledPath(aliasedCandidate, repo)).toBe(true);
+		which.mockImplementation(command => (command === "rust-analyzer" ? aliasedCandidate : null));
+		expect(loadConfig(repo).servers["rust-analyzer"]).toBeUndefined();
 	});
 
 	it("treats a repository ..bin child as contained while preserving external executables", async () => {

--- a/packages/coding-agent/test/lsp/lsp-command-trust.test.ts
+++ b/packages/coding-agent/test/lsp/lsp-command-trust.test.ts
@@ -524,6 +524,50 @@ describe("LSP repository command trust", () => {
 		expect(loadConfig(cwd).servers["rust-analyzer"]).toBeUndefined();
 	});
 
+	it("rejects home-crossing symlinks in both directions when the repository is a sibling of HOME", async () => {
+		if (process.platform === "win32") return;
+
+		using tempDir = TempDir.createSync("@gjc-lsp-sibling-home-trust-");
+		const home = path.join(tempDir.path(), "home");
+		const repo = path.join(tempDir.path(), "repo");
+		const cargoBin = path.join(home, ".cargo", "bin");
+		const rustup = path.join(cargoBin, "rustup");
+		await fs.promises.mkdir(cargoBin, { recursive: true });
+		await fs.promises.mkdir(path.join(repo, ".git"), { recursive: true });
+		await fs.promises.mkdir(path.join(repo, "bin"), { recursive: true });
+		await Bun.write(path.join(repo, "Cargo.toml"), "[package]\n");
+		await Bun.write(rustup, "#!/bin/sh\nexit 0\n");
+		await fs.promises.chmod(rustup, 0o755);
+		vi.spyOn(os, "homedir").mockReturnValue(home);
+
+		// Project-owned link whose target is a trusted HOME executable: the link
+		// itself is project-writable, so it must be rejected.
+		const projectLink = path.join(repo, "bin", "rust-analyzer");
+		await fs.promises.symlink(rustup, projectLink);
+		expect(isProjectControlledPath(projectLink, repo)).toBe(true);
+		const which = vi
+			.spyOn(piUtils, "$which")
+			.mockImplementation(command => (command === "rust-analyzer" ? projectLink : null));
+		expect(loadConfig(repo).servers["rust-analyzer"]).toBeUndefined();
+
+		// HOME-owned link whose target is project content: the executable bytes
+		// are project-controlled, so it must be rejected as well.
+		const evilTarget = path.join(repo, "evil-rustup");
+		await Bun.write(evilTarget, "#!/bin/sh\nexit 0\n");
+		await fs.promises.chmod(evilTarget, 0o755);
+		const homeLink = path.join(home, ".local", "bin", "rust-analyzer");
+		await fs.promises.mkdir(path.dirname(homeLink), { recursive: true });
+		await fs.promises.symlink(evilTarget, homeLink);
+		expect(isProjectControlledPath(homeLink, repo)).toBe(true);
+		which.mockImplementation(command => (command === "rust-analyzer" ? homeLink : null));
+		expect(loadConfig(repo).servers["rust-analyzer"]).toBeUndefined();
+
+		// A genuinely external HOME link to a HOME target stays trusted.
+		const goodLink = path.join(home, ".local", "bin", "rust-analyzer-good");
+		await fs.promises.symlink(rustup, goodLink);
+		expect(isProjectControlledPath(goodLink, repo)).toBe(false);
+	});
+
 	it("treats a repository ..bin child as contained while preserving external executables", async () => {
 		if (process.platform === "win32") return;
 

--- a/packages/coding-agent/test/lsp/lsp-command-trust.test.ts
+++ b/packages/coding-agent/test/lsp/lsp-command-trust.test.ts
@@ -311,9 +311,7 @@ describe("LSP repository command trust", () => {
 		expect(loadConfig(repositoryRoot).servers["typescript-language-server"]).toBeUndefined();
 
 		which.mockImplementation(command => (command === "typescript-language-server" ? externalSymlink : null));
-		expect(loadConfig(repositoryRoot).servers["typescript-language-server"]?.resolvedCommand).toBe(
-			fs.realpathSync(externalServer),
-		);
+		expect(loadConfig(repositoryRoot).servers["typescript-language-server"]?.resolvedCommand).toBe(externalSymlink);
 	});
 
 	it("finds repository-root executables through a symlinked nested session cwd", async () => {
@@ -421,7 +419,7 @@ describe("LSP repository command trust", () => {
 			.mockImplementation(command => (command === "typescript-language-server" ? userServer : null));
 
 		expect(isProjectControlledPath(userServer, cwd)).toBe(false);
-		expect(loadConfig(cwd).servers["typescript-language-server"]?.resolvedCommand).toBe(fs.realpathSync(userServer));
+		expect(loadConfig(cwd).servers["typescript-language-server"]?.resolvedCommand).toBe(userServer);
 		resetLspmuxStateForTesting();
 		which.mockImplementation(command => (command === "lspmux" ? userLspmux : null));
 		expect((await detectLspmux(cwd)).available).toBe(true);
@@ -449,13 +447,58 @@ describe("LSP repository command trust", () => {
 		for (const cwd of [lexicalHome, canonicalHome]) {
 			expect(isProjectControlledPath(userServer, cwd)).toBe(false);
 			const server = loadConfig(cwd).servers["typescript-language-server"];
-			expect(server?.resolvedCommand).toBe(fs.realpathSync(userServer));
+			expect(server?.resolvedCommand).toBe(userServer);
 
 			resetLspmuxStateForTesting();
 			which.mockImplementation(command => (command === "lspmux" ? userLspmux : null));
 			expect((await detectLspmux(cwd)).available).toBe(true);
 			which.mockImplementation(command => (command === "typescript-language-server" ? userServer : null));
 		}
+	});
+
+	it("keeps the invocation path for a trusted symlinked launcher so rustup-style proxies see argv[0]", async () => {
+		if (process.platform === "win32") return;
+
+		using tempDir = TempDir.createSync("@gjc-lsp-symlink-launcher-");
+		const home = path.join(tempDir.path(), "home");
+		const cwd = path.join(home, "workspace");
+		const cargoBin = path.join(home, ".cargo", "bin");
+		const rustup = path.join(cargoBin, "rustup");
+		const rustAnalyzer = path.join(cargoBin, "rust-analyzer");
+		await fs.promises.mkdir(cargoBin, { recursive: true });
+		await fs.promises.mkdir(cwd, { recursive: true });
+		await Bun.write(path.join(cwd, "Cargo.toml"), "[package]\n");
+		await Bun.write(rustup, "#!/bin/sh\nexit 0\n");
+		await fs.promises.chmod(rustup, 0o755);
+		await fs.promises.symlink("rustup", rustAnalyzer);
+		vi.spyOn(os, "homedir").mockReturnValue(home);
+		vi.spyOn(piUtils, "$which").mockImplementation(command => (command === "rust-analyzer" ? rustAnalyzer : null));
+
+		const server = loadConfig(cwd).servers["rust-analyzer"];
+		expect(fs.realpathSync(rustAnalyzer)).toBe(rustup);
+		expect(server?.resolvedCommand).toBe(rustAnalyzer);
+	});
+
+	it("still rejects a symlinked launcher whose invocation path is project-controlled", async () => {
+		if (process.platform === "win32") return;
+
+		using tempDir = TempDir.createSync("@gjc-lsp-symlink-project-");
+		const home = path.join(tempDir.path(), "home");
+		const cwd = path.join(home, "workspace");
+		const cargoBin = path.join(home, ".cargo", "bin");
+		const rustup = path.join(cargoBin, "rustup");
+		const projectLink = path.join(cwd, "bin", "rust-analyzer");
+		await fs.promises.mkdir(cargoBin, { recursive: true });
+		await fs.promises.mkdir(path.join(cwd, "bin"), { recursive: true });
+		await fs.promises.mkdir(path.join(cwd, ".git"), { recursive: true });
+		await Bun.write(path.join(cwd, "Cargo.toml"), "[package]\n");
+		await Bun.write(rustup, "#!/bin/sh\nexit 0\n");
+		await fs.promises.chmod(rustup, 0o755);
+		await fs.promises.symlink(rustup, projectLink);
+		vi.spyOn(os, "homedir").mockReturnValue(home);
+		vi.spyOn(piUtils, "$which").mockImplementation(command => (command === "rust-analyzer" ? projectLink : null));
+
+		expect(loadConfig(cwd).servers["rust-analyzer"]).toBeUndefined();
 	});
 
 	it("treats a repository ..bin child as contained while preserving external executables", async () => {

--- a/packages/coding-agent/test/lsp/lsp-command-trust.test.ts
+++ b/packages/coding-agent/test/lsp/lsp-command-trust.test.ts
@@ -267,6 +267,7 @@ describe("LSP repository command trust", () => {
 			const result = await tool.execute("configured-status", { action: "status" });
 
 			expect(result.content).toEqual([{ type: "text", text: "Configured language servers: rust-analyzer" }]);
+			expect(result.details?.success).toBe(true);
 		} finally {
 			await safeRm(externalBinDir, { recursive: true, force: true });
 			forgetExternalGrant();

--- a/packages/coding-agent/test/lsp/lsp-command-trust.test.ts
+++ b/packages/coding-agent/test/lsp/lsp-command-trust.test.ts
@@ -528,7 +528,7 @@ describe("LSP repository command trust", () => {
 	it("keeps HOME executables exempt from an ancestor cwd when HOME is a symlink, under either spelling", async () => {
 		if (process.platform === "win32") return;
 
-		using tempDir = TempDir.createSync("@gjc-lsp-home-alias-trust-");
+		using tempDir = TempDir.createSync("/var/tmp/gjc-lsp-home-alias-trust-");
 		const canonicalHome = path.join(tempDir.path(), "home");
 		const lexicalHome = path.join(tempDir.path(), "home-link");
 		const userBin = path.join(canonicalHome, ".gjc", "bin");

--- a/packages/coding-agent/test/lsp/lsp-command-trust.test.ts
+++ b/packages/coding-agent/test/lsp/lsp-command-trust.test.ts
@@ -17,6 +17,20 @@ const ORIGINAL_DISABLE_LSPMUX = Bun.env.PI_DISABLE_LSPMUX;
 const ORIGINAL_GJC_DISABLE_LSPMUX = Bun.env.GJC_DISABLE_LSPMUX;
 const ORIGINAL_CONFIG_DIR = process.env.GJC_CONFIG_DIR;
 
+/** Ancestors of `start` (inclusive) carrying a `.git` or `.gjc` project marker. */
+function ancestorProjectMarkers(start: string): string[] {
+	const markers: string[] = [];
+	let current = path.resolve(start);
+	for (;;) {
+		for (const marker of [".git", ".gjc"]) {
+			if (fs.existsSync(path.join(current, marker))) markers.push(path.join(current, marker));
+		}
+		const parent = path.dirname(current);
+		if (parent === current) return markers;
+		current = parent;
+	}
+}
+
 async function writeCanaryLspServer(directory: string): Promise<string> {
 	const scriptPath = path.join(directory, "canary-lsp.ts");
 	await Bun.write(
@@ -528,7 +542,7 @@ describe("LSP repository command trust", () => {
 	it("keeps HOME executables exempt from an ancestor cwd when HOME is a symlink, under either spelling", async () => {
 		if (process.platform === "win32") return;
 
-		using tempDir = TempDir.createSync("/var/tmp/gjc-lsp-home-alias-trust-");
+		using tempDir = TempDir.createSync("@gjc-lsp-home-alias-trust-");
 		const canonicalHome = path.join(tempDir.path(), "home");
 		const lexicalHome = path.join(tempDir.path(), "home-link");
 		const userBin = path.join(canonicalHome, ".gjc", "bin");
@@ -538,10 +552,11 @@ describe("LSP repository command trust", () => {
 		await Bun.write(server, "");
 		const lexicalServer = path.join(lexicalHome, ".gjc", "bin", "typescript-language-server");
 
-		// cwd is HOME's parent: its fallback trust root contains HOME, so only the
-		// home exemption keeps user executables trusted. Both homedir spellings
-		// must accept both candidate spellings.
+		// cwd is HOME's parent with no project marker: its fallback trust root
+		// contains HOME, so only the home exemption keeps user executables trusted.
+		// Both homedir spellings must accept both candidate spellings.
 		const cwd = tempDir.path();
+		expect(ancestorProjectMarkers(cwd)).toEqual([]);
 		const projectFile = path.join(cwd, "typescript-language-server");
 		await Bun.write(projectFile, "");
 		for (const homedir of [lexicalHome, canonicalHome]) {


### PR DESCRIPTION
## What

Preserve the discovered executable path when auto-discovering trusted LSP servers, while retaining canonical-path validation for existence and project trust. Report discovered servers as configured until a client has started, and document that status contract.

## Why

Closes #5354. On Linux/macOS and WSL, rust-analyzer is commonly a symlink to rustup. Launching the canonical rustup target loses the rust-analyzer invocation name, so rustup prints its top-level help and exits before the LSP client starts.

## Testing

- `TMPDIR=/var/tmp bun test packages/coding-agent/test/lsp/lsp-command-trust.test.ts` — 21 pass, including rustup-style invocation, HOME-crossing, HOME-alias, and fallback-root trust regressions
- `TMPDIR=/var/tmp bun test packages/coding-agent/test/tools/lsp-regressions.test.ts` — 24 pass
- `TMPDIR=/var/tmp bun test packages/coding-agent/test/lsp/lsp-lifecycle.test.ts` — 9 pass
- `bun --cwd=packages/coding-agent run check:types` — passed
- `bunx biome check docs/tools/lsp.md packages/coding-agent/src/lsp/config.ts packages/coding-agent/src/lsp/index.ts packages/coding-agent/src/lsp/path-trust.ts packages/coding-agent/test/lsp/lsp-command-trust.test.ts` — passed
- `bun run check` — attempted; the repository check reached the SDK closure manifest and Bun 1.4.0 crashed with exit 134 in the unrelated `packages/coding-agent/test/sdk-adapter-dispositions-mcp.test.ts`; no changed-file failure was reported.

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`; the token alone never suffices).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:630b815676d7f687e2e59993ad19e8dab937e289237fef50065960831b8298a9 reviewer:human reviewer-id:Yeachan-Heo evidence:local-tests=TMPDIR-var-tmp:lsp-command-trust,lsp-regressions,lsp-lifecycle,configured-status;owner-risk-record=https://github.com/Yeachan-Heo/gajae-code/pull/5362#issuecomment-5565313720
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken