### PR TITLE
fix(telegram): expose session lifecycle in stale threads

### DIFF
--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -877,12 +877,16 @@ End-to-end manual check once `gjc notify setup` has paired your private chat:
    <branch>`, or `/session_create dir <newdir>`. The SDK lifecycle service submits
    one canonical Broker create request; the bot reports the credential-free
    outcome.
-3. `/session_recent` lists verified recent managed sessions.
+3. `/session_recent` lists verified recent managed sessions, marks whether each
+   session is connected or only saved, and includes a resume command for saved
+   sessions.
 4. `/session_close <sessionId>` asks Broker lifecycle to close the exact managed
-   session and preserves history.
+   session and preserves history. Inside that session's Telegram topic, omit the
+   ID and use `/session_close`.
 5. `/session_resume <sessionId|prefix>` resolves verified managed history,
    reattaches a live session or performs canonical Broker resume, and refuses
-   ambiguous prefixes.
+   ambiguous prefixes. Inside an existing session topic, including an inactive
+   topic left by a stopped session, omit the ID and use `/session_resume`.
 
 Commands are accepted only from the paired chat. Duplicate Telegram updates and
 replayed topic reservations reuse their original request identity; they never

--- a/docs/telegram-onboarding.md
+++ b/docs/telegram-onboarding.md
@@ -370,8 +370,13 @@ Reply paths:
   - `/session_create worktree <repo> <branch>`
   - `/session_create dir <newdir>`
   - `/session_recent [create|resume]`
-  - `/session_close <sessionId>`
-  - `/session_resume <sessionId|prefix>`
+  - `/session_close [sessionId]`
+  - `/session_resume [sessionId|prefix]`
+
+`/session_recent` labels daemon-connected sessions separately from saved
+history and prints a resume command for each saved session. The close/resume
+target is optional only inside the existing Telegram topic for that session;
+the chat root still requires an explicit ID or prefix.
 
 The removed legacy `/answer <session-tag> <answer>` flow is not the primary UX;
 Telegram topic routing identifies the target session when the configured chat

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -50,6 +50,7 @@
 ### Fixed
 
 - Registry fingerprints now enforce the existing regular-file and 32 MiB admission limits with bounded reads. Model activation, thinking overlay lookup, transcript navigation, slash autocomplete, and observer digest updates avoid repeated allocations; status lines without a git segment no longer request git status.
+- Telegram `/session_recent` now distinguishes sessions currently connected to the notification daemon from saved history and prints a ready-to-copy resume command. Inside a session's existing topic, `/session_resume` and `/session_close` can omit the session ID, including after that topic became inactive.
 - Credential replacement lookups now propagate the owning request's cancellation through scoped and allowed unscoped retries, preventing aborted turns from continuing OAuth preparation or selecting another key.
 - Removing the committed status-line command segment or clearing its trusted command now cancels the running process and clears stale output; draft-only previews remain side-effect-free.
 - Slack inbound acknowledgment reactions now use bounded, abortable, tracked provider work that drains on shutdown or attachment retirement without delaying accepted turns; rejected or timed-out reactions emit sanitized diagnostics.

--- a/packages/coding-agent/src/sdk/bus/lifecycle-commands.ts
+++ b/packages/coding-agent/src/sdk/bus/lifecycle-commands.ts
@@ -15,10 +15,15 @@ import * as os from "node:os";
 import type { SessionCloseTarget, SessionCreateTarget, SessionLifecycleResponse, SessionResumeTarget } from "./index";
 
 export type LifecycleCommandVerb = "session_create" | "session_close" | "session_resume";
-function normalizeLifecycleCommandToken(
-	token: string,
-	ctx: { chatType?: string; botUsername?: string } = {},
-): string | undefined {
+
+export interface LifecycleCommandContext {
+	chatType?: string;
+	botUsername?: string;
+	/** Session durably associated with the Telegram topic containing the command. */
+	threadSessionId?: string;
+}
+
+function normalizeLifecycleCommandToken(token: string, ctx: LifecycleCommandContext = {}): string | undefined {
 	const at = token.indexOf("@");
 	const command = at === -1 ? token : token.slice(0, at);
 	if (!/^\/session_(create|close|resume|recent)\b/.test(command)) return undefined;
@@ -44,8 +49,8 @@ const USAGE = [
 	"/session_create path <dir> [--mpreset <profile>]",
 	"/session_create worktree <repo> <branch> [--mpreset <profile>]",
 	"/session_create dir <newdir> [--mpreset <profile>]",
-	"/session_close <sessionId>",
-	"/session_resume <sessionId|prefix>",
+	"/session_close <sessionId> (ID optional inside its session thread)",
+	"/session_resume <sessionId|prefix> (ID optional inside its session thread)",
 	"/session_recent [create|resume]",
 ].join("\n");
 
@@ -103,10 +108,7 @@ export function isLifecycleCommandLikeText(text: string | undefined): boolean {
 }
 
 /** True when the text begins an addressable /session_* command (cheap pre-gate). */
-export function isLifecycleCommandText(
-	text: string | undefined,
-	ctx: { chatType?: string; botUsername?: string } = {},
-): boolean {
+export function isLifecycleCommandText(text: string | undefined, ctx: LifecycleCommandContext = {}): boolean {
 	if (!text) return false;
 	const [rawCommand] = text.trim().split(/\s+/, 1);
 	return normalizeLifecycleCommandToken(rawCommand ?? "", ctx) !== undefined;
@@ -139,7 +141,7 @@ function extractModelPreset(args: string[]): { positional: string[]; modelPreset
  */
 export function parseLifecycleCommand(
 	text: string | undefined,
-	ctx: { chatType?: string; botUsername?: string } = {},
+	ctx: LifecycleCommandContext = {},
 ): ParsedLifecycleCommand {
 	const tokens = tokenizeLifecycleCommand((text ?? "").trim());
 	if (!tokens) return { kind: "usage", message: USAGE };
@@ -166,6 +168,8 @@ export function parseLifecycleCommand(
 	}
 
 	if (command === "/session_close") {
+		if (args.length === 0 && ctx.threadSessionId)
+			return { kind: "close", target: { sessionId: ctx.threadSessionId } };
 		if (args.length !== 1) return { kind: "usage", message: USAGE };
 		const sessionId = args[0]!;
 		if (!isSafeIdentifier(sessionId)) {
@@ -175,6 +179,8 @@ export function parseLifecycleCommand(
 	}
 
 	if (command === "/session_resume") {
+		if (args.length === 0 && ctx.threadSessionId)
+			return { kind: "resume", target: { sessionIdOrPrefix: ctx.threadSessionId } };
 		if (args.length !== 1) return { kind: "usage", message: USAGE };
 		const idOrPrefix = args[0]!;
 		if (!isSafeIdentifier(idOrPrefix)) {

--- a/packages/coding-agent/src/sdk/bus/telegram-daemon.ts
+++ b/packages/coding-agent/src/sdk/bus/telegram-daemon.ts
@@ -4821,7 +4821,11 @@ export class TelegramNotificationDaemon {
 					.catch(() => undefined);
 			}
 		};
-		const parsed = parseLifecycleCommand(text, commandCtx);
+		const threadSessionId =
+			threadId === undefined
+				? undefined
+				: this.topics.sessionForLifecycleTopic(String(threadId), String(this.opts.chatId));
+		const parsed = parseLifecycleCommand(text, { ...commandCtx, threadSessionId });
 		if (parsed.kind === "none") return false;
 		if (updateId !== undefined && this.dispatchState.seenUpdateIds.has(updateId)) return true;
 		if (updateId !== undefined) await this.rememberSeenUpdateId(updateId);
@@ -4841,7 +4845,17 @@ export class TelegramNotificationDaemon {
 					? `Recent sessions could not be verified: ${recent.message}`
 					: recent.entries.length
 						? recent.entries
-								.map(entry => `• ${code(entry.sessionId)}${entry.path ? ` (${code(entry.path)})` : ""}`)
+								.map(entry => {
+									const connected = this.#logicalSessionOwners.has(entry.sessionId);
+									return [
+										`${connected ? "🟢 connected" : "⚪ saved"} — ${code(entry.sessionId)}`,
+										entry.title ? `  ${code(entry.title)}` : undefined,
+										entry.path ? `  ${code(entry.path)}` : undefined,
+										connected ? undefined : `  Resume: ${code(`/session_resume ${entry.sessionId}`)}`,
+									]
+										.filter((line): line is string => line !== undefined)
+										.join("\n");
+								})
 								.join("\n")
 						: "No recent sessions.";
 			await replyHtml(

--- a/packages/coding-agent/src/sdk/bus/topic-registry.ts
+++ b/packages/coding-agent/src/sdk/bus/topic-registry.ts
@@ -775,6 +775,25 @@ export class TopicRegistry {
 		return this.byTopic.get(topicId);
 	}
 
+	/**
+	 * Resolve a durable topic association for explicit lifecycle controls.
+	 *
+	 * Unlike inbound message routing, this may return an inactive session so a
+	 * user can resume it from its old topic. Ambiguous, malformed, cross-chat,
+	 * and quarantined records fail closed.
+	 */
+	sessionForLifecycleTopic(topicId: string, chatId: string): string | undefined {
+		if (!isValidTopicId(topicId)) return undefined;
+		const matches = [...this.topics].filter(
+			([, record]) =>
+				record.topicId === topicId &&
+				record.chatId === chatId &&
+				!record.bindingMalformed &&
+				record.authorityState !== "legacy_quarantined",
+		);
+		return matches.length === 1 ? matches[0]![0] : undefined;
+	}
+
 	/** All session ids with a persisted topic record. */
 	sessionIds(): string[] {
 		return [...this.topics.keys()];

--- a/packages/coding-agent/test/notifications-lifecycle-command-routing.test.ts
+++ b/packages/coding-agent/test/notifications-lifecycle-command-routing.test.ts
@@ -96,10 +96,16 @@ function daemon(
 	});
 }
 
-function message(text: string, updateId: number): unknown {
+function message(text: string, updateId: number, threadId?: number): unknown {
 	return {
 		update_id: updateId,
-		message: { chat: { id: "42", type: "private" }, from: { id: 42, is_bot: false }, text, message_id: updateId },
+		message: {
+			chat: { id: "42", type: "private" },
+			from: { id: 42, is_bot: false },
+			text,
+			message_id: updateId,
+			...(threadId === undefined ? {} : { message_thread_id: threadId }),
+		},
 	};
 }
 
@@ -120,6 +126,47 @@ describe("Telegram lifecycle command routing", () => {
 		expect(JSON.stringify(botCalls)).not.toContain("token");
 		expect(factoryCalls.count).toBe(1);
 		fs.rmSync(agentDir, { recursive: true, force: true });
+	});
+
+	test("resumes the durably associated session when invoked without an id in its old thread", async () => {
+		const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-lifecycle-thread-route-"));
+		const notificationsDir = path.join(agentDir, "notifications");
+		fs.mkdirSync(notificationsDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(notificationsDir, "telegram-topics.json"),
+			JSON.stringify({
+				version: 2,
+				registryGeneration: 1,
+				topics: {
+					"broker-session-1": {
+						topicId: "77",
+						topicOrigin: "daemon_created",
+						sessionUuid: "00000000-0000-4000-8000-000000000077",
+						identitySent: true,
+						createdAt: 1,
+						authorityEpoch: 1,
+						authorityState: "inactive",
+						chatId: "42",
+						telegramBinding: { chatId: "42", transport: "telegram" },
+					},
+				},
+			}),
+		);
+		const { calls, service } = lifecycleHarness();
+		const telegram = bot();
+		const daemonInstance = daemon(agentDir, telegram.api, service, { count: 0 });
+		try {
+			await daemonInstance.loadTopics();
+			await daemonInstance.handleTelegramUpdate(message("/session_resume", 13, 77));
+			expect(calls).toContainEqual(
+				expect.objectContaining({
+					operation: "session.resume",
+					target: { sessionIdOrPrefix: "broker-session-1" },
+				}),
+			);
+		} finally {
+			fs.rmSync(agentDir, { recursive: true, force: true });
+		}
 	});
 
 	test("duplicate update across daemon restart reuses one stable lifecycle request key", async () => {
@@ -177,6 +224,8 @@ describe("Telegram lifecycle command routing", () => {
 		const recent = calls.find(call => call.method === "sendMessage");
 		expect(recent?.body.parse_mode).toBe(TELEGRAM_PARSE_MODE);
 		expect(String(recent?.body.text)).toContain("broker-session-1");
+		expect(String(recent?.body.text)).toContain("saved");
+		expect(String(recent?.body.text)).toContain("/session_resume broker-session-1");
 		expect(JSON.stringify(calls)).not.toContain("endpoint");
 		expect(JSON.stringify(calls)).not.toContain("token");
 		fs.rmSync(agentDir, { recursive: true, force: true });

--- a/packages/coding-agent/test/notifications-lifecycle-commands.test.ts
+++ b/packages/coding-agent/test/notifications-lifecycle-commands.test.ts
@@ -64,6 +64,23 @@ describe("lifecycle command parser (G009)", () => {
 		expect(parseLifecycleCommand("/session_recent")).toEqual({ kind: "recent", which: "all" });
 		expect(parseLifecycleCommand("/session_recent create")).toEqual({ kind: "recent", which: "create" });
 	});
+
+	it("infers close and resume targets inside a known session thread", () => {
+		const ctx = { threadSessionId: "session-from-topic" };
+		expect(parseLifecycleCommand("/session_close", ctx)).toEqual({
+			kind: "close",
+			target: { sessionId: "session-from-topic" },
+		});
+		expect(parseLifecycleCommand("/session_resume", ctx)).toEqual({
+			kind: "resume",
+			target: { sessionIdOrPrefix: "session-from-topic" },
+		});
+		expect(parseLifecycleCommand("/session_resume")).toEqual({
+			kind: "usage",
+			message: lifecycleUsage(),
+		});
+	});
+
 	it("accepts only this bot's Telegram username suffix in non-private chats", () => {
 		const groupCtx = { chatType: "supergroup", botUsername: "GajaeCodeBot" };
 		expect(isLifecycleCommandText("/session_recent@GajaeCodeBot", groupCtx)).toBe(true);

--- a/packages/coding-agent/test/notifications-topic-registry.test.ts
+++ b/packages/coding-agent/test/notifications-topic-registry.test.ts
@@ -372,6 +372,31 @@ describe("TopicRegistry", () => {
 		await expect(reg.getOrCreateTopic("s1", async () => "2")).rejects.toThrow("topic authority is archive-fenced");
 		expect(reg.get("s1")?.topicId).toBe("1");
 	});
+
+	test("resolves inactive topics only for explicit same-chat lifecycle controls", async () => {
+		const reg = new TopicRegistry({
+			version: 2,
+			registryGeneration: 1,
+			topics: {
+				s1: {
+					topicId: "1",
+					topicOrigin: "daemon_created",
+					sessionUuid: "00000000-0000-4000-8000-000000000001",
+					identitySent: true,
+					createdAt: 1,
+					authorityEpoch: 1,
+					authorityState: "inactive",
+					chatId: "42",
+					telegramBinding: { chatId: "42", transport: "telegram" },
+				},
+			},
+		});
+
+		expect(reg.sessionForTopic("1")).toBeUndefined();
+		expect(reg.sessionForLifecycleTopic("1", "42")).toBe("s1");
+		expect(reg.sessionForLifecycleTopic("1", "other-chat")).toBeUndefined();
+	});
+
 	test("clears disconnect grace before persisting an archive fence", async () => {
 		const reg = new TopicRegistry();
 		await reg.getOrCreateTopic("s1", async () => "1");


### PR DESCRIPTION
## What

- Label `/session_recent` entries as daemon-connected or saved and include copyable resume commands.
- Let `/session_resume` and `/session_close` infer the durable session ID when invoked inside that session topic, including an inactive topic.
- Reject ambiguous, malformed, cross-chat, and quarantined topic associations.

## Why

Stopped sessions leave Telegram topics behind, but users could neither identify currently connected sessions nor recover a saved session from its topic without discovering and copying its full ID.

## Testing

- `bun test packages/coding-agent/test/notifications-lifecycle-commands.test.ts packages/coding-agent/test/notifications-topic-registry.test.ts packages/coding-agent/test/notifications-lifecycle-command-routing.test.ts` (87 passed)
- `bun --cwd=packages/coding-agent run check`
- `git diff --check origin/dev...HEAD`

## Risk classification

- [ ] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [x] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:b2da1590e0f42c31640b7fcca7ae7a4c5a501412c9ed667adc52fd35a00b32e1 reviewer:human reviewer-id:Yeachan-Heo evidence:bun-test-87pass-coding-agent-check
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken
