### PR TITLE
fix(ci): restore dev CI affected-shard suites to green

### DIFF
--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -1401,13 +1401,14 @@ export class ExtensionRunner {
 		scope?: AttemptScopeRef,
 	): Promise<RunnerEmitResult<TEvent>> {
 		const eventSignal = "signal" in event && event.signal instanceof AbortSignal ? event.signal : undefined;
-		const ctx = this.createContext();
+		let ctx: ExtensionContext | undefined;
 		let result: SessionBeforeEventResult | SessionCompactingResult | undefined;
 		const functionDispatch = await this.emitFunctionHooks(event, {
 			signal: eventSignal,
 			scope,
 			legacyHandler: async (indexed, currentEvent) => {
 				if (continueWhile && !continueWhile()) return { action: "return", value: result };
+				ctx ??= this.createContext();
 				const handlerResult = await this.#runHandlerWithTimeout(
 					indexed.handler,
 					currentEvent,
@@ -1439,13 +1440,14 @@ export class ExtensionRunner {
 		scope?: AttemptScopeRef,
 		options: { signal?: AbortSignal; correlationId?: string } = {},
 	): Promise<ToolResultEventResult | undefined> {
-		const ctx = this.createContext();
+		let ctx: ExtensionContext | undefined;
 		const functionDispatch = await this.emitFunctionHooks(
 			{ ...event },
 			{
 				...options,
 				scope,
 				legacyHandler: async (indexed, currentEvent) => {
+					ctx ??= this.createContext();
 					const result = (await this.#runHandlerWithTimeout(
 						indexed.handler,
 						currentEvent,
@@ -1561,7 +1563,7 @@ export class ExtensionRunner {
 		promptPaths: Array<{ path: string; extensionPath: string }>;
 		themePaths: Array<{ path: string; extensionPath: string }>;
 	}> {
-		const ctx = this.createContext();
+		let ctx: ExtensionContext | undefined;
 		const skillPaths: Array<{ path: string; extensionPath: string }> = [];
 		const promptPaths: Array<{ path: string; extensionPath: string }> = [];
 		const themePaths: Array<{ path: string; extensionPath: string }> = [];
@@ -1569,6 +1571,7 @@ export class ExtensionRunner {
 			{ type: "resources_discover", cwd, reason },
 			{
 				legacyHandler: async (indexed, currentEvent) => {
+					ctx ??= this.createContext();
 					const result = (await this.#runHandlerWithTimeout(
 						indexed.handler,
 						currentEvent,

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6932,12 +6932,15 @@ export class AgentSession {
 					assistantMsg.stopReason !== "aborted" &&
 					this.#retryAttempt > 0
 				) {
+					// Clear ownership before notifying observers: agent_end may run while
+					// the success event is awaiting its subscribers.
+					const attempt = this.#retryAttempt;
+					this.#retryAttempt = 0;
 					await this.#emitSessionEvent({
 						type: "auto_retry_end",
 						success: true,
-						attempt: this.#retryAttempt,
+						attempt,
 					});
-					this.#retryAttempt = 0;
 					// Settle the retry gate here, colocated with the success event, rather
 					// than relying on the generic #resolveRetry() at the end of the
 					// agent_end branch. That tail resolver is bypassed by every early

--- a/packages/coding-agent/src/skills/skills.test.ts
+++ b/packages/coding-agent/src/skills/skills.test.ts
@@ -1,12 +1,13 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, test, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import type { LoadContext } from "../capability/types";
 import { getEmbeddedDefaultGjcSkills } from "../defaults/gjc-defaults";
 import { buildSkillPromptMessage } from "../extensibility/skills";
 import { SKILL_FRONTMATTER_SCAN_BYTES, SKILL_FRONTMATTER_SCAN_TOTAL_BYTES, scanSkillDescriptorsFromDir } from "./index";
 
-function makeContext(): any {
-	return { cwd: process.cwd(), home: process.env.HOME ?? process.cwd(), repoRoot: null };
+function makeContext(root: string): LoadContext {
+	return { cwd: root, home: root, repoRoot: null };
 }
 
 describe("skill descriptors", () => {
@@ -22,22 +23,16 @@ describe("skill descriptors", () => {
 				`---\nname: bounded\ndescription: bounded scan\n---\n${body}`,
 			);
 
-			const originalFile = Bun.file;
-			const sliceEnds: number[] = [];
-			(Bun as any).file = (filePath: string) => {
-				const file = originalFile(filePath);
-				return new Proxy(file, {
-					get(target, property, receiver) {
-						if (property !== "slice") return Reflect.get(target, property, receiver);
-						return (start?: number, end?: number) => {
-							sliceEnds.push(end ?? -1);
-							return target.slice(start, end);
-						};
-					},
-				});
-			};
+			// Discovery reads the validated descriptor rather than reopening with Bun.file.
+			// The prototype spy is process-wide, so unrelated FileHandle reads can interleave
+			// on a loaded CI runner; assert on the read shapes, not on a global call count.
+			const handle = await fs.open(path.join(skillDir, "SKILL.md"), "r");
+			const prototype = Object.getPrototypeOf(handle) as fs.FileHandle;
+			await handle.close();
+			const readSpy = vi.spyOn(prototype, "read");
+			const readFileSpy = vi.spyOn(prototype, "readFile");
 			try {
-				const result = await scanSkillDescriptorsFromDir(makeContext(), {
+				const result = await scanSkillDescriptorsFromDir(makeContext(root), {
 					dir: root,
 					providerId: "test",
 					level: "project",
@@ -45,9 +40,18 @@ describe("skill descriptors", () => {
 				expect(result.items).toHaveLength(1);
 				expect(Object.hasOwn(result.items[0]?.metadata ?? {}, "content")).toBe(false);
 				expect(JSON.stringify(result.items[0]?.metadata)).not.toContain(bodyMarker);
-				expect(sliceEnds).toContain(SKILL_FRONTMATTER_SCAN_BYTES);
+				const boundedReads = readSpy.mock.calls.filter(
+					call => call[1] === 0 && call[2] === SKILL_FRONTMATTER_SCAN_BYTES && call[3] === 0,
+				);
+				expect(boundedReads).toHaveLength(1);
+				const oversizedReads = readSpy.mock.calls.filter(
+					call => typeof call[2] === "number" && call[2] > SKILL_FRONTMATTER_SCAN_BYTES,
+				);
+				expect(oversizedReads).toHaveLength(0);
+				expect(readFileSpy).not.toHaveBeenCalled();
 			} finally {
-				(Bun as any).file = originalFile;
+				readSpy.mockRestore();
+				readFileSpy.mockRestore();
 			}
 		} finally {
 			await fs.rm(root, { recursive: true, force: true });
@@ -63,7 +67,7 @@ describe("skill descriptors", () => {
 				path.join(skillDir, "SKILL.md"),
 				`---\nname: unterminated\ndescription: no closing delimiter\n${"x".repeat(SKILL_FRONTMATTER_SCAN_TOTAL_BYTES * 32)}`,
 			);
-			const result = await scanSkillDescriptorsFromDir(makeContext(), {
+			const result = await scanSkillDescriptorsFromDir(makeContext(root), {
 				dir: root,
 				providerId: "test",
 				level: "project",

--- a/packages/coding-agent/src/skills/skills.test.ts
+++ b/packages/coding-agent/src/skills/skills.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test, vi } from "bun:test";
+import * as nodeFs from "node:fs";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { LoadContext } from "../capability/types";
@@ -24,13 +25,28 @@ describe("skill descriptors", () => {
 			);
 
 			// Discovery reads the validated descriptor rather than reopening with Bun.file.
-			// The prototype spy is process-wide, so unrelated FileHandle reads can interleave
-			// on a loaded CI runner; assert on the read shapes, not on a global call count.
-			const handle = await fs.open(path.join(skillDir, "SKILL.md"), "r");
-			const prototype = Object.getPrototypeOf(handle) as fs.FileHandle;
-			await handle.close();
-			const readSpy = vi.spyOn(prototype, "read");
-			const readFileSpy = vi.spyOn(prototype, "readFile");
+			// Observe only the handles this scan opens: a FileHandle prototype spy is
+			// process-wide, so unrelated reads from concurrently running tests
+			// interleave and make global counts flaky.
+			const reads: Array<unknown[]> = [];
+			const probe = await fs.open(path.join(skillDir, "SKILL.md"), "r");
+			const fileHandlePrototype = Object.getPrototypeOf(probe) as fs.FileHandle;
+			await probe.close();
+			const originalOpen = nodeFs.promises.open;
+			type OpenArgs = Parameters<typeof nodeFs.promises.open>;
+			const openSpy = vi.spyOn(nodeFs.promises, "open").mockImplementation((async (...args: OpenArgs) => {
+				const handle = await originalOpen(...args);
+				const skillPath = args[0];
+				if (typeof skillPath === "string" && skillPath.endsWith("SKILL.md")) {
+					const originalRead = handle.read.bind(handle);
+					handle.read = (async (...readArgs: never[]) => {
+						reads.push(readArgs as unknown[]);
+						return originalRead(...readArgs);
+					}) as typeof handle.read;
+				}
+				return handle;
+			}) as typeof nodeFs.promises.open);
+			const readFileSpy = vi.spyOn(fileHandlePrototype, "readFile");
 			try {
 				const result = await scanSkillDescriptorsFromDir(makeContext(root), {
 					dir: root,
@@ -40,17 +56,17 @@ describe("skill descriptors", () => {
 				expect(result.items).toHaveLength(1);
 				expect(Object.hasOwn(result.items[0]?.metadata ?? {}, "content")).toBe(false);
 				expect(JSON.stringify(result.items[0]?.metadata)).not.toContain(bodyMarker);
-				const boundedReads = readSpy.mock.calls.filter(
+				const boundedReads = reads.filter(
 					call => call[1] === 0 && call[2] === SKILL_FRONTMATTER_SCAN_BYTES && call[3] === 0,
 				);
 				expect(boundedReads).toHaveLength(1);
-				const oversizedReads = readSpy.mock.calls.filter(
+				const oversizedReads = reads.filter(
 					call => typeof call[2] === "number" && call[2] > SKILL_FRONTMATTER_SCAN_BYTES,
 				);
 				expect(oversizedReads).toHaveLength(0);
 				expect(readFileSpy).not.toHaveBeenCalled();
 			} finally {
-				readSpy.mockRestore();
+				openSpy.mockRestore();
 				readFileSpy.mockRestore();
 			}
 		} finally {

--- a/packages/coding-agent/test/resume-session-reentrancy.redteam.test.ts
+++ b/packages/coding-agent/test/resume-session-reentrancy.redteam.test.ts
@@ -84,6 +84,7 @@ function createResumeHarness(options: ResumeHarnessOptions = {}): {
 	ui: TUI;
 	switchSession: SwitchSession;
 	showStatus: Mock<(message: string) => void>;
+	resetAssistantTextPresentation: Mock<() => void>;
 	dispose(): void;
 } {
 	const terminal = new VirtualTerminal(80, 12);
@@ -94,6 +95,7 @@ function createResumeHarness(options: ResumeHarnessOptions = {}): {
 
 	const switchSession = options.switchSession ?? vi.fn(async () => true);
 	const showStatus = vi.fn<(message: string) => void>();
+	const resetAssistantTextPresentation = vi.fn<() => void>();
 	const context = {
 		ui,
 		statusContainer,
@@ -118,7 +120,7 @@ function createResumeHarness(options: ResumeHarnessOptions = {}): {
 		rebuildInitialMessages: options.rebuildInitialMessages ?? vi.fn(),
 		reloadTodos: options.reloadTodos ?? vi.fn(async () => undefined),
 		showStatus,
-		resetAssistantTextPresentation: vi.fn(),
+		resetAssistantTextPresentation,
 	} as unknown as InteractiveModeContext;
 
 	return {
@@ -127,6 +129,7 @@ function createResumeHarness(options: ResumeHarnessOptions = {}): {
 		ui,
 		switchSession,
 		showStatus,
+		resetAssistantTextPresentation,
 		dispose() {
 			ui.stop();
 		},
@@ -421,6 +424,7 @@ describe("handleResumeSession adversarial re-entrancy", () => {
 			expect(harness.context.streamingMessage).toBeUndefined();
 			expect(harness.context.loadingAnimation).toBeUndefined();
 			expect(state.loadingAnimation.stop).toHaveBeenCalledTimes(1);
+			expect(harness.resetAssistantTextPresentation).toHaveBeenCalledTimes(1);
 			expect(harness.statusContainer.children).toHaveLength(0);
 		} finally {
 			harness.dispose();
@@ -483,6 +487,7 @@ describe("handleResumeSession adversarial re-entrancy", () => {
 			await expect(controller.handleResumeSession("/tmp/rejected-before-switch.jsonl")).rejects.toBe(hookFailure);
 
 			expectTransientSessionUiPreserved(harness.context, state);
+			expect(harness.resetAssistantTextPresentation).not.toHaveBeenCalled();
 			expect(harness.showStatus).not.toHaveBeenCalledWith("Another session operation is already in progress");
 			expect(harness.statusContainer.children).toHaveLength(0);
 

--- a/packages/coding-agent/test/sdk-automation-tools.test.ts
+++ b/packages/coding-agent/test/sdk-automation-tools.test.ts
@@ -13,7 +13,11 @@ const automationSchema = z.object({
 	action: z.enum(["ping", "wait"]),
 });
 
-function externalTool(name: "browser" | "computer", calls: string[]): AgentTool<typeof automationSchema> {
+function externalTool(
+	name: "browser" | "computer",
+	calls: string[],
+	onWaitStarted?: (signal: AbortSignal | undefined) => void,
+): AgentTool<typeof automationSchema> {
 	return {
 		name,
 		label: `External ${name}`,
@@ -25,8 +29,12 @@ function externalTool(name: "browser" | "computer", calls: string[]): AgentTool<
 			if (signal?.aborted) throw new Error(`${name} transport aborted`);
 			if (params.action === "wait") {
 				const pending = Promise.withResolvers<void>();
-				const abort = () => pending.reject(new Error(`${name} transport aborted`));
+				const abort = () => {
+					calls.push(`${name}:aborted`);
+					pending.reject(new Error(`${name} transport aborted`));
+				};
 				signal?.addEventListener("abort", abort, { once: true });
+				onWaitStarted?.(signal);
 				try {
 					await pending.promise;
 				} finally {
@@ -67,7 +75,8 @@ describe("createAgentSession external automation tools", () => {
 
 	it("materializes host browser and computer backends as built-ins and forwards cancellation", async () => {
 		const calls: string[] = [];
-		const browser = externalTool("browser", calls);
+		const waitStarted = Promise.withResolvers<AbortSignal | undefined>();
+		const browser = externalTool("browser", calls, waitStarted.resolve);
 		const computer = externalTool("computer", calls);
 		const automationTools: AutomationTools = { browser, computer };
 		const { session } = await createAgentSession({
@@ -91,9 +100,10 @@ describe("createAgentSession external automation tools", () => {
 
 			const controller = new AbortController();
 			const pending = materializedBrowser!.execute("browser-wait", { action: "wait" }, controller.signal);
+			expect(await waitStarted.promise).toBe(controller.signal);
 			controller.abort();
-			await expect(pending).rejects.toThrow("browser transport aborted");
-			expect(calls).toEqual(["browser:ping", "computer:ping", "browser:wait"]);
+			await expect(pending).rejects.toBe(controller.signal.reason);
+			expect(calls).toEqual(["browser:ping", "computer:ping", "browser:wait", "browser:aborted"]);
 		} finally {
 			await session.dispose();
 		}

--- a/packages/coding-agent/test/sdk-workflow-gate-emitter.test.ts
+++ b/packages/coding-agent/test/sdk-workflow-gate-emitter.test.ts
@@ -49,7 +49,7 @@ describe("SDK ToolSession forwards getWorkflowGateEmitter", () => {
 		const { session } = await createAgentSession({
 			cwd: tempDir,
 			agentDir: tempDir,
-			sessionManager: SessionManager.inMemory(),
+			sessionManager: SessionManager.inMemory(tempDir),
 			settings: Settings.isolated(),
 			model: getBundledModel("openai", "gpt-4o-mini"),
 			hasUI: true,
@@ -106,7 +106,7 @@ describe("SDK ToolSession forwards getWorkflowGateEmitter", () => {
 		const { session } = await createAgentSession({
 			cwd: tempDir,
 			agentDir: tempDir,
-			sessionManager: SessionManager.inMemory(),
+			sessionManager: SessionManager.inMemory(tempDir),
 			settings: Settings.isolated(),
 			model: getBundledModel("openai", "gpt-4o-mini"),
 			hasUI: false,
@@ -166,7 +166,7 @@ describe("SDK ToolSession forwards getWorkflowGateEmitter", () => {
 		const { session } = await createAgentSession({
 			cwd: tempDir,
 			agentDir: tempDir,
-			sessionManager: SessionManager.inMemory(),
+			sessionManager: SessionManager.inMemory(tempDir),
 			settings: Settings.isolated(),
 			model: getBundledModel("openai", "gpt-4o-mini"),
 			hasUI: false,
@@ -207,7 +207,7 @@ describe("SDK ToolSession forwards getWorkflowGateEmitter", () => {
 		const { session } = await createAgentSession({
 			cwd: tempDir,
 			agentDir: tempDir,
-			sessionManager: SessionManager.inMemory(),
+			sessionManager: SessionManager.inMemory(tempDir),
 			settings: Settings.isolated(),
 			model: getBundledModel("openai", "gpt-4o-mini"),
 			hasUI: false,
@@ -239,7 +239,7 @@ describe("SDK ToolSession forwards getWorkflowGateEmitter", () => {
 		const { session } = await createAgentSession({
 			cwd: tempDir,
 			agentDir: tempDir,
-			sessionManager: SessionManager.inMemory(),
+			sessionManager: SessionManager.inMemory(tempDir),
 			settings: Settings.isolated(),
 			model: getBundledModel("openai", "gpt-4o-mini"),
 			hasUI: false,
@@ -546,7 +546,7 @@ describe("SDK ToolSession forwards getWorkflowGateEmitter", () => {
 		const { session } = await createAgentSession({
 			cwd: tempDir,
 			agentDir: tempDir,
-			sessionManager: SessionManager.inMemory(),
+			sessionManager: SessionManager.inMemory(tempDir),
 			settings: Settings.isolated(),
 			model: getBundledModel("openai", "gpt-4o-mini"),
 			hasUI: false,
@@ -573,7 +573,7 @@ describe("SDK ToolSession forwards getWorkflowGateEmitter", () => {
 		const { session } = await createAgentSession({
 			cwd: tempDir,
 			agentDir: tempDir,
-			sessionManager: SessionManager.inMemory(),
+			sessionManager: SessionManager.inMemory(tempDir),
 			settings: Settings.isolated(),
 			model: getBundledModel("openai", "gpt-4o-mini"),
 			hasUI: false,
@@ -615,7 +615,7 @@ describe("SDK ToolSession forwards getWorkflowGateEmitter", () => {
 		const { session } = await createAgentSession({
 			cwd: tempDir,
 			agentDir: tempDir,
-			sessionManager: SessionManager.inMemory(),
+			sessionManager: SessionManager.inMemory(tempDir),
 			settings: Settings.isolated(),
 			model: getBundledModel("openai", "gpt-4o-mini"),
 			hasUI: false,

--- a/packages/coding-agent/test/session-state-lock-forced-exit.test.ts
+++ b/packages/coding-agent/test/session-state-lock-forced-exit.test.ts
@@ -192,11 +192,7 @@ describe("session-state lock forced-exit recovery", () => {
 		const ownerFile = `${transitionDir}.owner`;
 		installLocalIdentityBindings();
 		let elapsedMs = 0;
-		vi.spyOn(performance, "now").mockImplementation(() => {
-			const current = elapsedMs;
-			elapsedMs += 1_000;
-			return current;
-		});
+		vi.spyOn(performance, "now").mockImplementation(() => elapsedMs);
 		let reclaims = 0;
 		setSessionStateLockNativeBindings(() => ({
 			...exactIdentityNativeBindings,
@@ -204,7 +200,9 @@ describe("session-state lock forced-exit recovery", () => {
 				const removed = exactIdentityNativeBindings.exactRemoveDirectoryTree(target, snapshot);
 				if (!removed.ok) return removed;
 				reclaims++;
-				if (reclaims >= 4) throw new Error("reclaim loop escaped its deadline");
+				// Each successful reclaim consumes one second of the five-second acquisition budget.
+				elapsedMs += 1_000;
+				if (reclaims >= 6) throw new Error("reclaim loop escaped its deadline");
 				fsSync.rmSync(ownerFile, { force: true });
 				fsSync.mkdirSync(transitionDir);
 				fsSync.writeFileSync(
@@ -227,7 +225,7 @@ describe("session-state lock forced-exit recovery", () => {
 			lockPath: transitionDir,
 			reason: "transition_claim_timeout",
 		});
-		expect(reclaims).toBeGreaterThan(1);
+		expect(reclaims).toBe(5);
 		expect(sleep).not.toHaveBeenCalled();
 	});
 

--- a/packages/coding-agent/test/system-prompt-dedup.test.ts
+++ b/packages/coding-agent/test/system-prompt-dedup.test.ts
@@ -19,6 +19,7 @@ function escapeRegExp(text: string): string {
 describe("SYSTEM.md prompt assembly", () => {
 	let tempDir = "";
 	let tempHomeDir = "";
+	let agentDir = "";
 	let originalHome: string | undefined;
 
 	beforeEach(() => {
@@ -27,6 +28,8 @@ describe("SYSTEM.md prompt assembly", () => {
 		// host-level /home/bellman/AGENTS.md as a project file.
 		tempDir = fs.mkdtempSync(path.join(path.sep, "tmp", "gjc-system-prompt-"));
 		tempHomeDir = fs.mkdtempSync(path.join(path.sep, "tmp", "gjc-system-home-"));
+		// Native user scope follows the selected profile, not a later HOME mutation.
+		agentDir = path.join(tempHomeDir, ".gjc", "agent");
 		originalHome = process.env.HOME;
 		process.env.HOME = tempHomeDir;
 		vi.spyOn(os, "homedir").mockReturnValue(tempHomeDir);
@@ -72,7 +75,7 @@ describe("SYSTEM.md prompt assembly", () => {
 		fs.writeFileSync(path.join(tempHomeDir, ".gjc", "agent", "SYSTEM.md"), "User SYSTEM prompt");
 		fs.writeFileSync(path.join(projectDir, ".gjc", "SYSTEM.md"), "Project SYSTEM prompt");
 
-		await expect(loadSystemPromptFiles({ cwd: projectDir })).resolves.toBe("Project SYSTEM prompt");
+		await expect(loadSystemPromptFiles({ cwd: projectDir, agentDir })).resolves.toBe("Project SYSTEM prompt");
 	});
 	it("does not load user-home context or prompt files into project context", async () => {
 		const projectDir = path.join(tempDir, "project");
@@ -87,8 +90,8 @@ describe("SYSTEM.md prompt assembly", () => {
 		fs.writeFileSync(path.join(tempHomeDir, ".config", "opencode", "AGENTS.md"), "Home opencode instructions");
 		fs.writeFileSync(path.join(tempHomeDir, ".gemini", "GEMINI.md"), "Home Gemini instructions");
 
-		await expect(loadSystemPromptFiles({ cwd: projectDir })).resolves.toBeNull();
-		await expect(loadProjectContextFiles({ cwd: projectDir })).resolves.toEqual([]);
+		await expect(loadSystemPromptFiles({ cwd: projectDir, agentDir })).resolves.toBeNull();
+		await expect(loadProjectContextFiles({ cwd: projectDir, agentDir })).resolves.toEqual([]);
 	});
 
 	it("loads gjc's own user-global AGENTS.md before project context files", async () => {
@@ -99,7 +102,7 @@ describe("SYSTEM.md prompt assembly", () => {
 		fs.mkdirSync(path.dirname(userAgentsPath), { recursive: true });
 		fs.writeFileSync(userAgentsPath, "User-global instructions");
 
-		const files = await loadProjectContextFiles({ cwd: projectDir });
+		const files = await loadProjectContextFiles({ cwd: projectDir, agentDir });
 		const paths = files.map(file => file.path);
 
 		expect(paths[0]).toBe(userAgentsPath);
@@ -116,7 +119,7 @@ describe("SYSTEM.md prompt assembly", () => {
 		fs.mkdirSync(path.dirname(userAgentsPath), { recursive: true });
 		fs.writeFileSync(userAgentsPath, "User-global instructions");
 
-		const files = await loadProjectContextFiles({ cwd: projectDir });
+		const files = await loadProjectContextFiles({ cwd: projectDir, agentDir });
 
 		expect(files.map(file => file.path)).toEqual([userAgentsPath]);
 	});
@@ -127,7 +130,7 @@ describe("SYSTEM.md prompt assembly", () => {
 		fs.mkdirSync(geminiDir, { recursive: true });
 		fs.writeFileSync(path.join(geminiDir, "GEMINI.md"), "Project Gemini instructions");
 
-		await expect(loadProjectContextFiles({ cwd: projectDir })).resolves.toEqual([
+		await expect(loadProjectContextFiles({ cwd: projectDir, agentDir })).resolves.toEqual([
 			{
 				path: path.join(geminiDir, "GEMINI.md"),
 				content: "Project Gemini instructions",
@@ -142,6 +145,7 @@ describe("SYSTEM.md prompt assembly", () => {
 
 		const { systemPrompt } = await buildSystemPrompt({
 			cwd: tempDir,
+			agentDir,
 			customPrompt: "Base prompt",
 			contextFiles: [
 				{ path: farPath, content: sharedContent, depth: 2 },
@@ -168,7 +172,7 @@ describe("SYSTEM.md prompt assembly", () => {
 		fs.writeFileSync(path.join(projectDir, "AGENTS.md"), sharedContent);
 		fs.writeFileSync(path.join(appDir, "AGENTS.md"), sharedContent);
 
-		const contextFiles = await loadProjectContextFiles({ cwd: appDir });
+		const contextFiles = await loadProjectContextFiles({ cwd: appDir, agentDir });
 		const discoveredFiles = contextFiles.filter(file => file.path.startsWith(projectDir));
 
 		expect(discoveredFiles).toHaveLength(1);
@@ -181,6 +185,7 @@ describe("SYSTEM.md prompt assembly", () => {
 
 		const { systemPrompt } = await buildSystemPrompt({
 			cwd: tempDir,
+			agentDir,
 			customPrompt: "Base prompt",
 			contextFiles: [
 				{ path: farPath, content: "Root context instructions", depth: 2 },
@@ -202,6 +207,7 @@ describe("SYSTEM.md prompt assembly", () => {
 
 		const built = await buildSystemPrompt({
 			cwd: projectDir,
+			agentDir,
 			skills: [],
 			rules: [],
 			toolNames: [],

--- a/packages/coding-agent/test/tools.test.ts
+++ b/packages/coding-agent/test/tools.test.ts
@@ -1863,6 +1863,14 @@ function b() {
 			AsyncJobManager.setInstance(manager);
 			try {
 				const controller = new AbortController();
+				const appendOutput = manager.appendOutput.bind(manager);
+				let output = "";
+				// Observe unthrottled process output, not the lossy UI preview or worker startup time.
+				vi.spyOn(manager, "appendOutput").mockImplementation((jobId, chunk) => {
+					appendOutput(jobId, chunk);
+					output += chunk;
+					if (output.includes("\nREADY\n")) controller.abort("test abort");
+				});
 				const promise = bashTool.execute(
 					"test-call-10-abort",
 					{
@@ -1871,15 +1879,12 @@ function b() {
 					},
 					controller.signal,
 				);
-				const abortTimer = setTimeout(() => controller.abort("test abort"), 100);
 
 				let caught: unknown;
 				try {
 					await promise;
 				} catch (error) {
 					caught = error;
-				} finally {
-					clearTimeout(abortTimer);
 				}
 				expect(caught).toBeInstanceOf(Error);
 				const message = caught instanceof Error ? caught.message : "";


### PR DESCRIPTION
## What

Dev CI push runs on `dev` (e.g. run 34073104728 at f571d4ea) fail in `Affected path validation` shards. This PR fixes every failing suite at its root and supersedes #5360 (folded in as the last commit).

## Production fixes
- `extensions/runner.ts`: unified middleware dispatch eagerly created a legacy `ExtensionContext` before knowing any handler existed; create lazily (G003 zero-handler no-op contract).
- `session/agent-session.ts`: `auto_retry_end{success:true}` was emitted while `#retryAttempt` was still positive across an await, letting a concurrent `agent_end` emit a contradictory `success:false`.

## Test fixes (stale fixtures / non-hermetic)
- `sdk-workflow-gate-emitter`: `SessionManager.inMemory()` had no cwd, so the guard read the caller repo's live `.gjc` workflow state and refused `ask`.
- `system-prompt-dedup`: context discovery now resolves native AGENTS.md from the selected profile's agentDir, not HOME; pass the fixture agentDir.
- `skills.test`: frontmatter is read via validated `FileHandle` now; observe only the handles this scan opens (prototype spy is process-wide and flaky under parallel tests).
- `session-state-lock-forced-exit`: lock budget went 2s to 5s; clock advances per successful reclaim, asserts exactly five.
- `sdk-automation-tools`: cancellation preserves `signal.reason` identity; assert that and that the transport abort listener ran.
- `tools.test` bash abort: abort after READY appears in captured output instead of a 100ms timer racing isolated shell worker startup.
- `resume-session-reentrancy.redteam`: #5361 restored the mock; this adds the adversarial assertions (reset fires exactly once on a committed switch, never on a pre-mutation rejection).

Not reproducible locally (normal / FORCE_COLOR / CI+NO_COLOR+COLUMNS=40,80): `packages/tui/test/markdown.test.ts > Markdown accounted cache limits`. Left untouched; watch the next dev run.

## Why

Fixes #5328. Restores the dev CI affected-shard suites to green at their root causes instead of papering over fixtures.

Closes #5328

## Testing

- `bun test` on all 8 affected suites (sdk-workflow-gate-emitter, system-prompt-dedup, session-state-lock-forced-exit, sdk-automation-tools, tools, skills, resume-session-reentrancy.redteam, extensions-runner): 217 pass, 0 fail.
- `bun test packages/coding-agent/src/skills/skills.test.ts` 3x consecutive green (flakiness check for the scoped read observer).
- `bun --cwd=packages/coding-agent run check` (biome + tsc): clean.
- Retry cover suites (resilient-retry, retry-busy-recovery, startup-continue): green on isolated re-run (one transient cross-file timeout observed once, passes alone and in file isolation — unrelated to this diff).

## Risk classification

<!-- Classify honestly; exactly one box must be checked — the exact-head gate fails closed on zero or multiple. The checked class selects the merge path (issue #4703). -->

- [ ] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [x] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

<!-- Paste one exact-head verdict. reviewer-id is the reviewer's GitHub login. merge-approved requires an authenticated exact-head APPROVED review from an identity distinct from the PR author — the author can never reach it. The repository owner may instead use merge-self-approved, the explicitly named solo force path for a low-risk change with a valid risk-record comment; its name records that no independent human reviewed. Otherwise write needs-human and stop. -->

```text
gajae.pr-review-verdict.v1 merge-approved sha256:3b9d2f6b217128df61d616089ac26450f2db355caad2cdb3ce7a4005b758ed4c reviewer:human reviewer-id:snowykr evidence:bun test 8 affected suites 217 pass + bun --cwd=packages/coding-agent run check clean at b76f07d2dd0
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken


