### PR TITLE
fix(lock): preserve malformed-owner fences and accurate diagnostics

### DIFF
--- a/packages/coding-agent/src/config/file-lock.ts
+++ b/packages/coding-agent/src/config/file-lock.ts
@@ -43,7 +43,8 @@ export class FileLockAcquireError extends Error {
 	) {
 		super(
 			`Failed to acquire lock for ${filePath} after ${attempts} attempts: ${holder} (${lockPath}); ` +
-				`a live owner is never displaced — if this is an SDK broker (gjc sdk status), it must finish or be stopped before retrying`,
+				`a live owner is never displaced — if this is an SDK broker (gjc sdk session list), it must finish or be stopped before retrying; ` +
+				`the lock is a directory, remove it only by deleting the directory (${lockPath}) once no live owner remains`,
 		);
 		this.name = "FileLockAcquireError";
 	}
@@ -985,9 +986,11 @@ async function staleLockSnapshot(
 	}
 	if (!info) {
 		// A directory without a valid owner record is either a contender between
-		// native mkdirat ownership and metadata publication, or malformed/foreign
-		// state. Neither case carries enough identity evidence for stale removal;
-		// elapsed mtime must never make this empty namespace reclaimable.
+		// native directory ownership and metadata publication, or malformed state
+		// with no PID/incarnation/host proof of any process generation. Neither
+		// case carries liveness evidence, so elapsed time and byte stability must
+		// never make this namespace reclaimable: only an independently committed
+		// owner record proving its process generation dead authorizes removal.
 		return { stale: false };
 	}
 
@@ -1440,6 +1443,9 @@ async function lockHolderDescription(lockPath: string): Promise<string> {
 			);
 		}
 		try {
+			const bytes = await readLockInfoBytes(lockPath);
+			if (bytes !== null)
+				return "held by an owner record that never became readable (empty, truncated, or non-JSON info); malformed records carry no liveness proof and are never reclaimed — inspect and remove the directory manually once no publisher remains";
 			await fs.stat(path.join(lockPath, "info"));
 			return "held by an owner whose metadata is not yet readable";
 		} catch (error) {

--- a/packages/coding-agent/src/config/file-lock.ts
+++ b/packages/coding-agent/src/config/file-lock.ts
@@ -1415,7 +1415,12 @@ async function lockHolderDescription(lockPath: string): Promise<string> {
 		if (process.platform !== "win32" && (await fileLockRemovalTransitionExists(lockPath))) {
 			return "blocked by retained removal transition; retry the owning process cleanup or inspect the exact orphan manually; unproven transition ownership is never removed";
 		}
-		const info = await readLockInfo(lockPath);
+		let info = await readLockInfo(lockPath);
+		let bytes: string | null = null;
+		if (!info) {
+			bytes = await readLockInfoBytes(lockPath);
+			info = bytes === null ? null : parseLockInfoBytes(bytes);
+		}
 		if (info) {
 			// A lock record carrying a foreign owner_host_id belongs to another
 			// machine (shared-volume topic registry): its pid is meaningful only
@@ -1443,7 +1448,6 @@ async function lockHolderDescription(lockPath: string): Promise<string> {
 			);
 		}
 		try {
-			const bytes = await readLockInfoBytes(lockPath);
 			if (bytes !== null)
 				return "held by an owner record that never became readable (empty, truncated, or non-JSON info); malformed records carry no liveness proof and are never reclaimed — inspect and remove the directory manually once no publisher remains";
 			await fs.stat(path.join(lockPath, "info"));

--- a/packages/coding-agent/test/file-lock-gc-toctou.test.ts
+++ b/packages/coding-agent/test/file-lock-gc-toctou.test.ts
@@ -531,26 +531,125 @@ describe("withFileLock stale owner liveness (#652)", () => {
 		expect(await fs.exists(lockDir)).toBe(true);
 	});
 
-	test("fails closed when present lock metadata is malformed", async () => {
-		const invalidMetadata = [
+	test("fails closed on aged stable malformed records with no liveness proof", async () => {
+		const malformedMetadata = [
 			["empty", ""],
+			["truncated", "{"],
+			["non-json", "not-json"],
 			["null", "null"],
-			["bad pid", JSON.stringify({ pid: 0, start_time: "test-start", timestamp: Date.now() - 10_000 })],
+			["bad pid", JSON.stringify({ pid: 0, start_time: "test-start", timestamp: Date.now() - 60_000 })],
 			["bad timestamp", JSON.stringify({ pid: process.pid, start_time: "test-start", timestamp: "old" })],
 		] as const;
 
-		for (const [label, contents] of invalidMetadata) {
+		for (const [label, contents] of malformedMetadata) {
 			const base = await makeTemp();
 			const lockedFile = path.join(base, `${label}.json`);
 			const lockDir = `${lockedFile}.lock`;
 			await fs.mkdir(lockDir, { recursive: true });
 			await fs.writeFile(path.join(lockDir, "info"), contents);
+			const old = new Date(Date.now() - 60_000);
+			await fs.utimes(path.join(lockDir, "info"), old, old);
 
 			await expect(
 				withFileLock(lockedFile, async () => {}, { staleMs: 1, retries: 2, retryDelayMs: 1 }),
 			).rejects.toThrow(FileLockAcquireError);
 			expect(await fs.exists(lockDir)).toBe(true);
 		}
+	});
+
+	test("does not reclaim an aged stable malformed record while a live publisher may own it", async () => {
+		// A paused live legacy publisher holds the directory while its info bytes
+		// stay stable: without PID/incarnation/host proof no clock or stability
+		// argument may delete its exact dir and overlap two critical sections.
+		const base = await makeTemp();
+		const lockedFile = path.join(base, "paused-publisher.json");
+		const lockDir = `${lockedFile}.lock`;
+		await fs.mkdir(lockDir, { recursive: true });
+		await fs.writeFile(path.join(lockDir, "info"), "");
+		const old = new Date(Date.now() - 60_000);
+		await fs.utimes(path.join(lockDir, "info"), old, old);
+
+		await expect(
+			withFileLock(lockedFile, async () => {}, { staleMs: 1, retries: 2, retryDelayMs: 1 }),
+		).rejects.toThrow(FileLockAcquireError);
+		expect(await fs.exists(lockDir)).toBe(true);
+	});
+
+	test("does not reclaim a malformed record carrying a foreign owner_host_id", async () => {
+		const base = await makeTemp();
+		const lockedFile = path.join(base, "foreign-malformed.json");
+		const lockDir = `${lockedFile}.lock`;
+		await fs.mkdir(lockDir, { recursive: true });
+		await fs.writeFile(path.join(lockDir, "info"), "{foreign-partial");
+		const old = new Date(Date.now() - 60_000);
+		await fs.utimes(path.join(lockDir, "info"), old, old);
+
+		await expect(
+			withFileLock(lockedFile, async () => {}, {
+				staleMs: 1,
+				retries: 2,
+				retryDelayMs: 1,
+				ownerHostId: "this-host",
+			}),
+		).rejects.toThrow(FileLockAcquireError);
+		expect(await fs.exists(lockDir)).toBe(true);
+	});
+
+	test("does not reclaim a fresh malformed record inside the publication window", async () => {
+		const base = await makeTemp();
+		const lockedFile = path.join(base, "fresh-malformed.json");
+		const lockDir = `${lockedFile}.lock`;
+		await fs.mkdir(lockDir, { recursive: true });
+		await fs.writeFile(path.join(lockDir, "info"), "");
+
+		await expect(
+			withFileLock(lockedFile, async () => {}, { staleMs: 1, retries: 2, retryDelayMs: 1 }),
+		).rejects.toThrow(FileLockAcquireError);
+		expect(await fs.exists(lockDir)).toBe(true);
+	});
+
+	test("does not reclaim a malformed record rewritten during observation", async () => {
+		const base = await makeTemp();
+		const lockedFile = path.join(base, "racing-malformed.json");
+		const lockDir = `${lockedFile}.lock`;
+		await fs.mkdir(lockDir, { recursive: true });
+		await fs.writeFile(path.join(lockDir, "info"), "");
+		const old = new Date(Date.now() - 60_000);
+		await fs.utimes(path.join(lockDir, "info"), old, old);
+		const realSleep = Bun.sleep;
+		vi.spyOn(Bun, "sleep").mockImplementation((async (ms?: number) => {
+			if (ms === 100) await fs.writeFile(path.join(lockDir, "info"), "{partial");
+			return await realSleep(ms ?? 0);
+		}) as typeof Bun.sleep);
+
+		await expect(
+			withFileLock(lockedFile, async () => {}, { staleMs: 1, retries: 2, retryDelayMs: 1 }),
+		).rejects.toThrow(FileLockAcquireError);
+		expect(await fs.exists(lockDir)).toBe(true);
+	});
+
+	test("does not reclaim a malformed record that becomes valid during observation", async () => {
+		const base = await makeTemp();
+		const lockedFile = path.join(base, "publishing-malformed.json");
+		const lockDir = `${lockedFile}.lock`;
+		await fs.mkdir(lockDir, { recursive: true });
+		await fs.writeFile(path.join(lockDir, "info"), "");
+		const old = new Date(Date.now() - 60_000);
+		await fs.utimes(path.join(lockDir, "info"), old, old);
+		const realSleep = Bun.sleep;
+		vi.spyOn(Bun, "sleep").mockImplementation((async (ms?: number) => {
+			if (ms === 100)
+				await fs.writeFile(
+					path.join(lockDir, "info"),
+					JSON.stringify({ pid: process.pid, start_time: "unknown", timestamp: Date.now() }),
+				);
+			return await realSleep(ms ?? 0);
+		}) as typeof Bun.sleep);
+
+		await expect(
+			withFileLock(lockedFile, async () => {}, { staleMs: 1, retries: 2, retryDelayMs: 1 }),
+		).rejects.toThrow(FileLockAcquireError);
+		expect(await fs.exists(lockDir)).toBe(true);
 	});
 
 	test("fails closed when lock metadata is a dangling symlink", async () => {
@@ -1053,7 +1152,6 @@ describe("file lock cleanup failure handling (#2478)", () => {
 		expect(await fs.exists(lockDir)).toBe(false);
 		expect(await fs.exists(`${lockDir}.removing`)).toBe(false);
 	});
-
 	test("reclaims a self-owned release leak on the next same-process acquisition", async () => {
 		const base = await makeTemp();
 		const lockedFile = path.join(base, "state.json");

--- a/packages/coding-agent/test/file-lock-gc-toctou.test.ts
+++ b/packages/coding-agent/test/file-lock-gc-toctou.test.ts
@@ -57,6 +57,47 @@ test("acquisition exhaustion reports typed context for a live in-process holder"
 	});
 });
 
+test("exhaustion reports a valid owner published after parsing a null owner observation", async () => {
+	const filePath = path.join(await makeTemp(), "diagnostic-publication.json");
+	const lockDir = `${filePath}.lock`;
+	const infoPath = path.join(lockDir, "info");
+	await fs.mkdir(lockDir);
+	await fs.writeFile(infoPath, "null");
+	const originalDirectory = await fs.stat(lockDir);
+	const timestamp = Date.now();
+	const replacementBytes = JSON.stringify({ pid: process.pid, timestamp, owner_host_id: "publisher-host" });
+	const contender = vi.fn(async () => {});
+	let exhausted = false;
+	let mutated = false;
+	const realSleep = Bun.sleep;
+	vi.spyOn(Bun, "sleep").mockImplementation((async (ms?: number) => {
+		if (ms === 1) exhausted = true;
+		return await realSleep(ms ?? 0);
+	}) as typeof Bun.sleep);
+	const realParse = JSON.parse;
+	vi.spyOn(JSON, "parse").mockImplementation((text, reviver) => {
+		const parsed = realParse(text, reviver);
+		// The validated diagnostic observation is null; publish before its next read.
+		if (exhausted && text === "null" && !mutated) {
+			writeFileSync(infoPath, replacementBytes);
+			mutated = true;
+		}
+		return parsed;
+	});
+
+	const attempt = withFileLock(filePath, contender, { retries: 1, retryDelayMs: 1 });
+	await expect(attempt).rejects.toBeInstanceOf(FileLockAcquireError);
+	await expect(attempt).rejects.toMatchObject({
+		holder:
+			`held by pid ${process.pid} on host publisher-host (liveness unknown from this host)` +
+			` since ${new Date(timestamp).toISOString()}`,
+	});
+	expect(mutated).toBe(true);
+	expect(await fs.readFile(infoPath, "utf8")).toBe(replacementBytes);
+	expect(await fs.stat(lockDir)).toMatchObject({ dev: originalDirectory.dev, ino: originalDirectory.ino });
+	expect(contender).not.toHaveBeenCalled();
+});
+
 async function writeInfo(
 	lockDir: string,
 	info: {
@@ -616,16 +657,26 @@ describe("withFileLock stale owner liveness (#652)", () => {
 		await fs.writeFile(path.join(lockDir, "info"), "");
 		const old = new Date(Date.now() - 60_000);
 		await fs.utimes(path.join(lockDir, "info"), old, old);
+		const originalDirectory = await fs.stat(lockDir);
+		const replacementBytes = "{partial";
+		let mutated = false;
+		const contender = vi.fn(async () => {});
 		const realSleep = Bun.sleep;
 		vi.spyOn(Bun, "sleep").mockImplementation((async (ms?: number) => {
-			if (ms === 100) await fs.writeFile(path.join(lockDir, "info"), "{partial");
+			if (ms === 1 && !mutated) {
+				await fs.writeFile(path.join(lockDir, "info"), replacementBytes);
+				mutated = true;
+			}
 			return await realSleep(ms ?? 0);
 		}) as typeof Bun.sleep);
 
-		await expect(
-			withFileLock(lockedFile, async () => {}, { staleMs: 1, retries: 2, retryDelayMs: 1 }),
-		).rejects.toThrow(FileLockAcquireError);
-		expect(await fs.exists(lockDir)).toBe(true);
+		await expect(withFileLock(lockedFile, contender, { staleMs: 1, retries: 2, retryDelayMs: 1 })).rejects.toThrow(
+			FileLockAcquireError,
+		);
+		expect(mutated).toBe(true);
+		expect(await fs.readFile(path.join(lockDir, "info"), "utf8")).toBe(replacementBytes);
+		expect(await fs.stat(lockDir)).toMatchObject({ dev: originalDirectory.dev, ino: originalDirectory.ino });
+		expect(contender).not.toHaveBeenCalled();
 	});
 
 	test("does not reclaim a malformed record that becomes valid during observation", async () => {
@@ -636,20 +687,26 @@ describe("withFileLock stale owner liveness (#652)", () => {
 		await fs.writeFile(path.join(lockDir, "info"), "");
 		const old = new Date(Date.now() - 60_000);
 		await fs.utimes(path.join(lockDir, "info"), old, old);
+		const originalDirectory = await fs.stat(lockDir);
+		const replacementBytes = JSON.stringify({ pid: process.pid, start_time: "unknown", timestamp: Date.now() });
+		let mutated = false;
+		const contender = vi.fn(async () => {});
 		const realSleep = Bun.sleep;
 		vi.spyOn(Bun, "sleep").mockImplementation((async (ms?: number) => {
-			if (ms === 100)
-				await fs.writeFile(
-					path.join(lockDir, "info"),
-					JSON.stringify({ pid: process.pid, start_time: "unknown", timestamp: Date.now() }),
-				);
+			if (ms === 1 && !mutated) {
+				await fs.writeFile(path.join(lockDir, "info"), replacementBytes);
+				mutated = true;
+			}
 			return await realSleep(ms ?? 0);
 		}) as typeof Bun.sleep);
 
-		await expect(
-			withFileLock(lockedFile, async () => {}, { staleMs: 1, retries: 2, retryDelayMs: 1 }),
-		).rejects.toThrow(FileLockAcquireError);
-		expect(await fs.exists(lockDir)).toBe(true);
+		await expect(withFileLock(lockedFile, contender, { staleMs: 1, retries: 2, retryDelayMs: 1 })).rejects.toThrow(
+			FileLockAcquireError,
+		);
+		expect(mutated).toBe(true);
+		expect(await fs.readFile(path.join(lockDir, "info"), "utf8")).toBe(replacementBytes);
+		expect(await fs.stat(lockDir)).toMatchObject({ dev: originalDirectory.dev, ino: originalDirectory.ino });
+		expect(contender).not.toHaveBeenCalled();
 	});
 
 	test("fails closed when lock metadata is a dangling symlink", async () => {

--- a/packages/coding-agent/test/session-state-lock.test.ts
+++ b/packages/coding-agent/test/session-state-lock.test.ts
@@ -950,6 +950,22 @@ describe("coordinator session state lock", () => {
 		expect((await readJson(stateFile)).activity).toBeUndefined();
 	});
 
+	it("fails closed on an aged stable malformed legacy directory with a live-shaped sibling", async () => {
+		// An aged, byte-stable, unparseable info record proves nothing about the
+		// process generation that owns the directory: clocks are neither
+		// monotonic nor cross-host trustworthy, so the legacy reclaimer must
+		// leave it for manual inspection even when the generic verdict is stale.
+		const { stateFile } = await seededRunningSession("lock-malformed-directory-aged-live");
+		const lockFile = `${stateFile}.lock`;
+		await fs.mkdir(lockFile, { recursive: true });
+		await Bun.write(path.join(lockFile, "info"), "");
+		const stale = new Date(Date.now() - 60_000);
+		await fs.utimes(path.join(lockFile, "info"), stale, stale);
+		await reclaimStaleSessionStateLock(lockFile);
+		expect(fsSync.statSync(lockFile).isDirectory()).toBe(true);
+		expect((await readJson(stateFile)).activity).toBeUndefined();
+	});
+
 	it("refuses to delete a legacy directory whose owner token changed", async () => {
 		const root = await tempRoot();
 		const lockDir = path.join(root, "state.json.lock");


### PR DESCRIPTION
## Current change

The former automatic malformed-lock reclamation design was removed. This exact diff keeps malformed or missing owner metadata fail-closed, improves the exhausted-lock diagnostic, and adds effective publication-race regressions. It does not authorize deleting an owner from age or stable bytes alone.

- Parse the second validated metadata observation before deciding whether it is malformed or names a valid owner.
- Exercise malformed-to-malformed and malformed-to-valid publications at an actual retry boundary; assert mutation, retained directory identity/bytes, and no contender entry.
- Keep legacy session-lock consumers protected when owner metadata is unreadable.

## Verification

At `7774250061f297bd3416a3cb29a5745b39fcfa11` on `f19e6867547068d1c7eec237c68150c0fd69bcab`: 177 tests passed with 648 assertions. Full coding-agent Biome/typecheck passed. The three task files are byte-identical to the previously reviewed lock delta. This is explicit owner-only low-risk authorization, not independent human approval.

## Risk classification
- [x] `low-risk`

## GJC verdict

gajae.pr-review-verdict.v1 merge-approved sha256:d763b86c2fb240098c4b357fcab7ef9193385d7ebdb370ea1a9e3ff50dc360af reviewer:architect reviewer-id:probepark evidence:current-dev-ancestry-and-canonical-diff-verified;no-new-approval-created

<details>
<summary>Historical proposal and earlier evidence (superseded; not the current implementation)</summary>

Field repro (Proxmox LXC, root, gjc-linux-x64, gjc 0.16.x):

gjc cannot start. Every launch hangs in "GJC warming workspace" and then crashes:

Error: Failed to acquire lock for /root/.gjc/agent/sdk/sessions/index.jsonl after 600 attempts: held by an owner whose metadata is not yet readable (/root/.gjc/agent/sdk/sessions/index.jsonl.lock); a live owner is never displaced — if this is an SDK broker (gjc sdk status), it must finish or be stopped before retrying

crash fingerprints: 1f48ef6bd175d52df414a871c6bc0ff2, 893345a0a374e9e10b6492dcee88db9f.
ps aux | grep gjc shows zero gjc processes. The condition survives restarts — it is permanent, not transient.

Root cause (verified in packages/coding-agent/src/config/file-lock.ts):
1. lockHolderDescription emits "metadata is not yet readable" only on the branch where readLockInfo(lockPath) returned null but fs.stat(<lockDir>/info) succeeded — so info exists on disk and is not a valid owner record (empty, truncated, or non-JSON; crash between mkdirat ownership and metadata publication).
2. staleLockSnapshot has if (!info) return { stale: false }; with no other exit for that state, so removeStaleLockForAcquire never reclaims it. An info file that never becomes parseable is an unreclaimable orphan: acquireLock burns all retries and throws forever.

Change:
- staleLockSnapshot routes the !info case to staleOrphanInfoSnapshot: requires info present on both observations, both unparseable, byte-and-inode identity stable across a bounded window (captureFileLockDirIdentity / sameGenericFileLockDirIdentity, the same fence stale removal uses), plus age >= max(staleMs, 10s floor). Reclaims through the existing removeFileLockDirForGc path with an orphan-bytes authorization (judged bytes must still match, still unparseable, identity fence still holds before native exact removal).
- Missing info entirely keeps the conservative handling: no byte identity to fence, never reclaimed on mtime alone.
- No compat flag, env escape hatch, or force-unlock command.
- Diagnostics: exhaustion message now points at gjc sdk session list (gjc sdk accepts serve|search|spawn|session|guides; gjc sdk status is not valid) and names the lock as a directory with the exact directory path for recovery.

Why each protected case still fails closed:
- Live pid record: untouched live-owner path (ownerIsAlive / ownerLiveness) returns not-stale before the orphan path is ever reached; regression tests preserve live holder without start_time, with unknown start_time, and indeterminate-liveness cases.
- Foreign owner_host_id: orphan path carries no host identity to prove local, so it cannot authorize; valid-record host checks unchanged, foreign-host test still preserves.
- Publication race (bytes rewritten mid-window): second identity/bytes comparison fails, verdict is not-stale; new tests cover rewrite-to-partial and rewrite-to-valid during the window.
- Fresh orphan: age gate (max(staleMs, 10s)) refuses; new test covers fresh empty info.
- Missing info: first-bytes null returns not-stale explicitly; manually verified.

Verification (actually run):
- bun test packages/coding-agent/test/file-lock-gc-toctou.test.ts packages/coding-agent/test/sdk-session-index-lock-contention.test.ts → 67 pass, 0 fail, 200 expect() calls
- bun test packages/coding-agent/test/session-state-lock.test.ts → 91 pass, 0 fail
- bun --cwd=packages/coding-agent run check:types → clean (tsc --noEmit)
- Manual probe: aged zero-byte orphan reclaimed ok; missing-info protected ok; live pid protected ok.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*

Risk classification
Historical risk classification retained for context; see current classification above.

[Historical verdict superseded by the current exact-head record above.]





</details>


<!-- gjc-maintenance-01a083b2 -->
Current maintenance snapshot: base `f19e6867547068d1c7eec237c68150c0fd69bcab`, head `7774250061f297bd3416a3cb29a5745b39fcfa11`. Earlier narrative/test evidence is historical unless explicitly rebound to this head. Rebase/diff verification does not replace required CI or independent approval.
<!-- /gjc-maintenance-01a083b2 -->
