### PR TITLE
fix(sdk): evict oldest session.list cursor instead of exhausting budget (#5370)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 
+- Broker `session.list` pagination cursors now evict the oldest entry when the 32-cursor budget is full instead of failing new paginations with `cursor capacity is exhausted` (#5370). Abandoned or partial paginations degrade gracefully (the evicted cursor reports `cursor is expired or invalid` on next use) so unrelated session ops never fail once the index exceeds one page; the obsolete capacity-exhausted path is removed.
 - Runtime state persistence now identifies contradictory `ready_for_input`/`live` fields with their lifecycle state and expected value instead of reporting only a generic invalid/unreadable marker error. Invalid markers remain untouched; this does not migrate or repair old session state.
 - SDK snapshot pages now read and integrity-check one contiguous span instead of rereading chunks per row. Reverse-provider disconnects discard connection-scoped registration receipts; relay shutdown releases backpressure listeners without destroying caller-owned sinks, and fragmented request frames are assembled once per newline.
 

--- a/packages/coding-agent/src/sdk/broker/broker.ts
+++ b/packages/coding-agent/src/sdk/broker/broker.ts
@@ -3045,16 +3045,21 @@ export class Broker {
 			if (this.#chains.get(target) === chain) this.#chains.delete(target);
 		}
 	}
-	#storeSessionListCursor(cursor: SessionListCursor, replacingToken?: string): string | BrokerResponse {
+	#storeSessionListCursor(cursor: SessionListCursor, replacingToken?: string): string {
 		const now = Date.now();
 		for (const [token, stored] of this.#sessionListCursors) {
 			if (stored.expiresAt <= now) this.#sessionListCursors.delete(token);
 		}
-		const replacing = replacingToken !== undefined && this.#sessionListCursors.has(replacingToken);
-		if (!replacing && this.#sessionListCursors.size >= SESSION_LIST_MAX_CURSORS)
-			return error("invalid_input", "session.list cursor capacity is exhausted");
-		const token = randomBytes(24).toString("base64url");
 		if (replacingToken !== undefined) this.#sessionListCursors.delete(replacingToken);
+		// Pagination cursors are a paging convenience, not durable state (#5370).
+		// Evict the oldest cursor when the budget is full so abandoned or partial
+		// paginations degrade gracefully instead of failing unrelated session ops.
+		while (this.#sessionListCursors.size >= SESSION_LIST_MAX_CURSORS) {
+			const oldest = this.#sessionListCursors.keys().next();
+			if (oldest.done) break;
+			this.#sessionListCursors.delete(oldest.value);
+		}
+		const token = randomBytes(24).toString("base64url");
 		this.#sessionListCursors.set(token, cursor);
 		return token;
 	}
@@ -3125,7 +3130,6 @@ export class Broker {
 						{ ...snapshot, offset, expiresAt: Date.now() + SESSION_LIST_CURSOR_TTL_MS },
 						typeof cursor === "string" ? cursor : undefined,
 					);
-		if (isBrokerResponse(continuationCursor)) return continuationCursor;
 		return {
 			ok: true,
 			result: {

--- a/packages/coding-agent/test/sdk-broker-host-integration.test.ts
+++ b/packages/coding-agent/test/sdk-broker-host-integration.test.ts
@@ -123,7 +123,7 @@ test("broker session.list keeps cursor warnings snapshot-stable", async () => {
 	}
 });
 
-test("broker session.list rejects a new cursor stream at capacity without evicting active cursors", async () => {
+test("broker session.list evicts the oldest cursor instead of failing new paginations", async () => {
 	const agentDir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-broker-cursor-capacity-"));
 	const stateRoot = path.join(agentDir, "state");
 	const broker = new Broker({ agentDir });
@@ -143,8 +143,8 @@ test("broker session.list rejects a new cursor stream at capacity without evicti
 			cursors.push(page.continuationCursor as string);
 		}
 
-		// Exact inspection is not a paginated list. Even with all 32 cursor slots
-		// occupied it returns the one requested row without allocating a cursor.
+		// Exact inspection is not a paginated list. It returns the one requested
+		// row without allocating a cursor.
 		expect(await broker.handleRequest("session.list", { resolveSessionId: "session-2" })).toMatchObject({
 			ok: true,
 			result: { sessions: [{ sessionId: "session-2" }] },
@@ -152,25 +152,73 @@ test("broker session.list rejects a new cursor stream at capacity without evicti
 		const exact = await broker.handleRequest("session.list", { resolveSessionId: "session-2" });
 		expect(exact.ok && (exact.result as { continuationCursor?: string }).continuationCursor).toBeUndefined();
 
-		expect(await broker.handleRequest("session.list", { limit: 1 })).toEqual({
-			ok: false,
-			error: { code: "invalid_input", message: "session.list cursor capacity is exhausted" },
-		});
+		// A new pagination stream evicts the oldest abandoned cursor instead of
+		// failing: abandoned/partial pagination must never make unrelated
+		// session ops fail (#5370).
+		const overflow = await broker.handleRequest("session.list", { limit: 1 });
+		expect(overflow.ok).toBe(true);
+		if (!overflow.ok) throw new Error(overflow.error.message);
+		expect((overflow.result as { continuationCursor?: string }).continuationCursor).toEqual(expect.any(String));
 
-		const continued = await broker.handleRequest("session.list", { cursor: cursors[0] });
-		expect(continued).toMatchObject({
-			ok: true,
-			result: { sessions: [{ sessionId: "session-2" }] },
-		});
-		if (!continued.ok) throw new Error(continued.error.message);
+		// The evicted oldest cursor no longer resolves.
 		expect(await broker.handleRequest("session.list", { cursor: cursors[0] })).toEqual({
 			ok: false,
 			error: { code: "invalid_input", message: "cursor is expired or invalid" },
 		});
-		expect(await broker.handleRequest("session.list", { limit: 1 })).toMatchObject({
-			ok: true,
-			result: { sessions: [{ sessionId: "session-1" }], continuationCursor: expect.any(String) },
+
+		// The most recently used cursor still continues its stream.
+		const continued = await broker.handleRequest("session.list", {
+			cursor: (overflow.result as { continuationCursor?: string }).continuationCursor,
 		});
+		expect(continued).toMatchObject({
+			ok: true,
+			result: { sessions: [{ sessionId: "session-2" }] },
+		});
+	} finally {
+		await broker.stop();
+		await fs.rm(agentDir, { recursive: true, force: true });
+	}
+});
+
+test("broker session.list with more than one page of sessions survives abandoned paginations", async () => {
+	const agentDir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-broker-cursor-overflow-"));
+	const stateRoot = path.join(agentDir, "state");
+	const broker = new Broker({ agentDir });
+	await broker.start();
+	try {
+		const busIndex = await new SessionIndex(agentDir).open();
+		for (let index = 0; index < 150; index += 1)
+			await busIndex.append(event("host_registered", `overflow-session-${index + 1}`, stateRoot));
+
+		// Abandon 3x the cursor budget worth of first-page reads without ever
+		// following the continuation cursor (the inspect/status/tail leak shape).
+		for (let index = 0; index < 96; index += 1) {
+			const abandoned = await broker.handleRequest("session.list", { limit: 100 });
+			expect(abandoned.ok).toBe(true);
+			if (!abandoned.ok) throw new Error(abandoned.error.message);
+			expect((abandoned.result as { continuationCursor?: string }).continuationCursor).toEqual(expect.any(String));
+		}
+
+		// Unrelated session ops still succeed: a fresh full traversal drains.
+		const first = await broker.handleRequest("session.list", { limit: 100 });
+		expect(first.ok).toBe(true);
+		if (!first.ok) throw new Error(first.error.message);
+		const firstPage = first.result as { continuationCursor?: string; sessions: unknown[] };
+		expect(firstPage.sessions).toHaveLength(100);
+		expect(firstPage.continuationCursor).toEqual(expect.any(String));
+		const second = await broker.handleRequest("session.list", { cursor: firstPage.continuationCursor });
+		expect(second.ok).toBe(true);
+		if (!second.ok) throw new Error(second.error.message);
+		expect((second.result as { sessions: unknown[] }).sessions).toHaveLength(50);
+		expect((second.result as { continuationCursor?: string }).continuationCursor).toBeUndefined();
+
+		// Exact id resolution never allocates a cursor and never fails.
+		const resolved = await broker.handleRequest("session.list", { resolveSessionId: "overflow-session-149" });
+		expect(resolved).toMatchObject({
+			ok: true,
+			result: { sessions: [{ sessionId: "overflow-session-149" }] },
+		});
+		expect(resolved.ok && (resolved.result as { continuationCursor?: string }).continuationCursor).toBeUndefined();
 	} finally {
 		await broker.stop();
 		await fs.rm(agentDir, { recursive: true, force: true });


### PR DESCRIPTION
## What

Broker `session.list` pagination cursors evict the oldest entry when the 32-cursor budget is full instead of failing new paginations with `session.list cursor capacity is exhausted` (fixes #5370). Removes the obsolete capacity-exhausted error path.

## Why

With >100 sessions indexed, every id-resolving CLI verb allocates a continuation cursor on page 1 and frees it only by draining to the last page. Abandoned/partial traversals leaked cursors for 15 min, so the global 32-cursor budget exhausted within minutes and then EVERY `session.list`-dependent op failed until broker restart or TTL expiry.

## Testing

- `bun --cwd=packages/coding-agent test test/sdk-broker-host-integration.test.ts` — 7 pass (2 new regression tests: LRU eviction ordering, 150-session index surviving 96 abandoned paginations)
- `bun --cwd=packages/coding-agent test test/sdk-broker.test.ts` — 87 pass
- `bun --cwd=packages/coding-agent test test/sdk-lifecycle-service.test.ts` — 25 pass
- `bun --cwd=packages/coding-agent test test/sdk-session-list.test.ts test/sdk-mcp-adapter.test.ts` — 15 pass
- `bun --cwd=packages/coding-agent run check` — clean

Affected-path plan (from real diff, `bun scripts/ci-dev-affected.ts --dry-run`):
```
Dev affected-path CI
Changed paths: 3
 - packages/coding-agent/CHANGELOG.md
 - packages/coding-agent/src/sdk/broker/broker.ts
 - packages/coding-agent/test/sdk-broker-host-integration.test.ts
Planned tasks:
 - Check @gajae-code/coding-agent: bun run check (cwd: packages/coding-agent)
 - Test @gajae-code/coding-agent shard 1/8..8/8
 - Test @gajae-code/coding-agent production SDK host in isolation
 - Check/Test @gajae-code/typescript-edit-benchmark
 - GJC CLI smoke test
 - Test sdk-broker-restart, notifications-live-stream, session-manager-resident-cache
 - Build linux x64 native addons + Build @gajae-code/coding-agent
```

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:9d47c879d278a12d83960aedb364535bddbae34cb2709501bd4061806d465d79 reviewer:human reviewer-id:Yeachan-Heo evidence:https://github.com/Yeachan-Heo/gajae-code/actions/runs/34084976756
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [ ] Verdict above matches the exact PR head, not an earlier commit
- [ ] Risk classification above matches the actual review path taken