### PR TITLE
fix(sdk): keep own session id in GJC_SESSION_ID on bash tool env (#5374)

### DIFF
--- a/packages/coding-agent/src/sdk/cli/master-cli.ts
+++ b/packages/coding-agent/src/sdk/cli/master-cli.ts
@@ -15,7 +15,7 @@ import { SdkClientError } from "../client";
 import { dispatchSpawnGlobal } from "../lifecycle/broker-client";
 
 const MASTER_CAPABILITY_ENV = "GJC_MASTER_CAPABILITY";
-const MASTER_SESSION_ENV = "GJC_SESSION_ID";
+const MASTER_SESSION_ENV = "GJC_MASTER_OWNER_SESSION_ID";
 const SPAWN_TIMEOUT_MS = 120_000;
 
 export class SdkMasterCliError extends Error {

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -103,6 +103,7 @@ const BASH_ERROR_MAX_BYTES = 4096;
 const ARTIFACT_SAVE_DIAGNOSTIC_MAX_BYTES = 256;
 const BASH_ENV_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const MASTER_CAPABILITY_ENV = "GJC_MASTER_CAPABILITY";
+const MASTER_OWNER_SESSION_ENV = "GJC_MASTER_OWNER_SESSION_ID";
 const DEFAULT_AUTO_BACKGROUND_THRESHOLD_MS = 60_000;
 const ACP_RELEASE_TIMEOUT_MS = 1_000;
 const READ_ONLY_BASH_ENV: Record<string, string> = {
@@ -725,7 +726,12 @@ export function masterCommandEnvOverrides(
 	directMasterSpawn: boolean,
 ): Record<string, string> {
 	if (directMasterSpawn) return {};
-	return Object.fromEntries(Object.entries(env ?? {}).filter(([key]) => key !== MASTER_CAPABILITY_ENV));
+	// The master capability is single-use spawn authority and the owner id is
+	// spawn-lineage identity: neither is ambient state for ordinary Bash or a
+	// chained/pipelined descendant (issue #5374).
+	return Object.fromEntries(
+		Object.entries(env ?? {}).filter(([key]) => key !== MASTER_CAPABILITY_ENV && key !== MASTER_OWNER_SESSION_ENV),
+	);
 }
 
 function escapeBashEnvValueForDisplay(value: string): string {
@@ -1445,7 +1451,10 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 		// command that contained shell syntax into a privileged one.
 		const directMasterSpawn = isStrictDirectSdkSpawnCommand(rawCommand) && isStrictDirectSdkSpawnCommand(command);
 		const masterCapability = directMasterSpawn ? this.session.getMasterBashCapability?.() : undefined;
-		const masterOwnerSessionId = directMasterSpawn ? this.session.getMasterOwnerSessionId?.() : undefined;
+		// Master ownership is lineage identity, not session identity: it travels
+		// under its own variable on every bash env so a master-owned child can
+		// still read its OWN id from GJC_SESSION_ID (issue #5374).
+		const masterOwnerSessionId = this.session.getMasterOwnerSessionId?.();
 		const commandEnvOverrides = masterCommandEnvOverrides(expandedEnv, directMasterSpawn);
 		const resolvedEnv = {
 			...buildGjcRuntimeSessionEnv({
@@ -1458,7 +1467,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 				: {}),
 			...commandEnvOverrides,
 			...(masterCapability ? { [MASTER_CAPABILITY_ENV]: masterCapability } : {}),
-			...(masterOwnerSessionId ? { GJC_MASTER_OWNER_SESSION_ID: masterOwnerSessionId } : {}),
+			...(masterOwnerSessionId ? { [MASTER_OWNER_SESSION_ENV]: masterOwnerSessionId } : {}),
 			...(this.session.bashRestrictionProfile === "read-only" ? READ_ONLY_BASH_ENV : {}),
 			...(allowedPrefixes && allowedPrefixes.length > 0 ? { [GJC_RESTRICTED_ROLE_AGENT_BASH_ENV]: "1" } : {}),
 		};
@@ -1510,8 +1519,9 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 		resolvedEnv: Record<string, string> | undefined,
 	): Promise<BashResult> {
 		const masterCapability = resolvedEnv?.[MASTER_CAPABILITY_ENV];
+		const ownerSessionId = resolvedEnv?.[MASTER_OWNER_SESSION_ENV];
 		const sessionAgentDir = resolvedEnv?.GJC_CODING_AGENT_DIR;
-		if (masterCapability === undefined || sessionAgentDir === undefined)
+		if (masterCapability === undefined || ownerSessionId === undefined || sessionAgentDir === undefined)
 			throw new ToolError("Master spawn authority context is unavailable.");
 		const args = parseDirectSdkSpawnArgs(command);
 		args.agentDir = sessionAgentDir;
@@ -1519,8 +1529,8 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 		const request = runSdkSpawn(args, {
 			env: {
 				...process.env,
-				GJC_MASTER_CAPABILITY: masterCapability,
-				GJC_SESSION_ID: resolvedEnv?.GJC_MASTER_OWNER_SESSION_ID ?? this.session.getSessionId?.() ?? undefined,
+				[MASTER_CAPABILITY_ENV]: masterCapability,
+				[MASTER_OWNER_SESSION_ENV]: ownerSessionId,
 				GJC_CODING_AGENT_DIR: sessionAgentDir,
 			},
 		});

--- a/packages/coding-agent/test/sdk-master-mode-e2e.test.ts
+++ b/packages/coding-agent/test/sdk-master-mode-e2e.test.ts
@@ -148,7 +148,7 @@ describe("master mode end to end", () => {
 			const idempotencyKey = "shared-cli-spawn-key";
 
 			const cliDeps = {
-				env: { GJC_MASTER_CAPABILITY: grant, GJC_SESSION_ID: ownerId },
+				env: { GJC_MASTER_CAPABILITY: grant, GJC_MASTER_OWNER_SESSION_ID: ownerId },
 				dispatch: async (_dir: string, payload: Record<string, unknown>, idempotencyKey: string) => {
 					dispatched.push(payload);
 					dispatchedKeys.push(idempotencyKey);

--- a/packages/coding-agent/test/sdk-spawn-cli.test.ts
+++ b/packages/coding-agent/test/sdk-spawn-cli.test.ts
@@ -12,7 +12,7 @@ import { SdkClientError } from "../src/sdk/client/client";
 const task = "secret-task-fixture";
 const capability = "secret-capability-fixture";
 
-const masterEnv = { GJC_MASTER_CAPABILITY: capability, GJC_SESSION_ID: "master-cli-owner" };
+const masterEnv = { GJC_MASTER_CAPABILITY: capability, GJC_MASTER_OWNER_SESSION_ID: "master-cli-owner" };
 const epoch = async () => "epoch-cli";
 
 describe("gjc sdk spawn CLI", () => {

--- a/packages/coding-agent/test/tools/bash-master-owner-session-id.test.ts
+++ b/packages/coding-agent/test/tools/bash-master-owner-session-id.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import type { ToolSession } from "../../src/tools";
+import { BashTool } from "../../src/tools/bash";
+import { stubBashExecutorSettings } from "../helpers/tool-session-settings";
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+/**
+ * Issue #5374: `GJC_SESSION_ID` must mean "this session's own id" on the
+ * bash tool-env path, and master ownership must travel under its own distinct
+ * variable (`GJC_MASTER_OWNER_SESSION_ID`).
+ *
+ * The direct `gjc sdk spawn` dispatch env previously read
+ * `GJC_SESSION_ID: resolvedEnv?.GJC_MASTER_OWNER_SESSION_ID ?? own id`, which
+ * overloaded one name with two meanings (master identity vs. own identity).
+ */
+function createSession(sessionId: string, ownerSessionId?: string): ToolSession {
+	return {
+		cwd: process.cwd(),
+		getSessionFile: () => null,
+		getSessionId: () => sessionId,
+		getMasterBashCapability: () => "master-capability-fixture",
+		...(ownerSessionId === undefined
+			? { getMasterOwnerSessionId: () => undefined }
+			: { getMasterOwnerSessionId: () => ownerSessionId }),
+		settings: {
+			has: () => false,
+			get: () => undefined,
+			getBashInterceptorRules: () => [],
+			...stubBashExecutorSettings,
+		},
+	} as unknown as ToolSession;
+}
+
+function echoSessionEnv(): string {
+	return 'printf "own=%s owner=%s" "$GJC_SESSION_ID" "$GJC_MASTER_OWNER_SESSION_ID"';
+}
+
+function textOf(result: unknown): string {
+	if (typeof result === "string") return result;
+	const content = (result as { content?: { type: string; text?: string }[] }).content ?? [];
+	return content.find(block => block.type === "text")?.text ?? "";
+}
+
+describe("issue #5374: session identity on the bash tool-env path", () => {
+	it("a master-owned child exposes its own id in GJC_SESSION_ID", async () => {
+		const result = await new BashTool(createSession("child-session", "master-owner")).execute("call", {
+			command: echoSessionEnv(),
+		});
+		expect(textOf(result)).toContain("own=child-session");
+	});
+
+	it("master ownership travels under GJC_MASTER_OWNER_SESSION_ID", async () => {
+		const result = await new BashTool(createSession("child-session", "master-owner")).execute("call", {
+			command: echoSessionEnv(),
+		});
+		expect(textOf(result)).toContain("owner=master-owner");
+	});
+
+	it("a master session exposes its own id", async () => {
+		const result = await new BashTool(createSession("master-owner", "master-owner")).execute("call", {
+			command: echoSessionEnv(),
+		});
+		expect(textOf(result)).toContain("own=master-owner");
+	});
+});


### PR DESCRIPTION
## What

`GJC_SESSION_ID` means "this session's own id" on every path, including master-owned children. Master ownership travels only under `GJC_MASTER_OWNER_SESSION_ID`. Fixes #5374.

## Why

The direct-spawn dispatch read the master owner id through `GJC_SESSION_ID` (`resolvedEnv?.GJC_MASTER_OWNER_SESSION_ID ?? own id`), so a master-owned child saw the master's id in bash env instead of its own — no supported self-identification, and self-scoped ops built on it target the master. One variable carried two meanings (`master-cli.ts` `MASTER_SESSION_ENV` vs. every own-identity consumer). The collision is removed with no fallback and no dual-meaning shim.

## Testing

- `bun test packages/coding-agent/test/tools/bash-master-owner-session-id.test.ts packages/coding-agent/test/sdk-spawn-cli.test.ts packages/coding-agent/test/tools/bash-interceptor.test.ts` — 30 pass, 0 fail (new failing-first regression: child sees own id, owner stays under its own var, master sees own id)
- `bun test packages/coding-agent/test/sdk-master-mode-e2e.test.ts packages/coding-agent/test/sdk-broker.test.ts` — 88 pass, 0 fail
- `bun --cwd=packages/coding-agent run check:types` — clean; `biome check` on touched files — clean

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:4d84f69cce9525127ddcd037727bbb203bdcf1a0ce337bfea9a357429be5304c reviewer:human reviewer-id:Yeachan-Heo evidence:local-focused-suites-30-pass-plus-88-pass
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken