### PR TITLE
fix(auth-gateway): emit plain call_id for compound Codex tool ids

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Documented `GJC_OPENAI_CODE_WEBSOCKET_V2` as a switch that enables a websocket v2 path. No code read it under that name, under the legacy `PI_CODEX_WEBSOCKET_V2`, or under the `PI_OPENAI_CODE_WEBSOCKET_V2` the historical entry records; the v2 beta header has been unconditional for websocket transport. The documentation row is removed rather than reintroducing a knob, and the test that claimed to gate on it no longer writes an environment variable nothing reads.
 - Maintenance reasoning now fails closed for Anthropic models routed through an unverified custom endpoint and for raw reasoning-enabled models without thinking metadata. This prevents unsupported thinking controls and avoids a synchronous missing-metadata crash before provider wire transformation.
+- The auth-gateway OpenAI Responses and Chat Completions encoders now emit only the `call_id` half of a Codex/Responses compound tool-call id (`call_…|fc_…`) on the wire. The compound encoding is gjc-internal replay state; a downstream OpenAI-format client that echoed it back truncated it at its own 64-character limit and every chained tool turn was then rejected with `400 No tool output found for function call`. The item id still travels as the Responses item `id`.
 
 ## [0.16.4] - 2026-09-05
 

--- a/packages/ai/src/providers/openai-chat-server.ts
+++ b/packages/ai/src/providers/openai-chat-server.ts
@@ -20,7 +20,7 @@ import type {
 	ToolResultMessage,
 	TSchema,
 } from "../types";
-import { sanitizeJsonStrings } from "../utils";
+import { sanitizeJsonStrings, wireToolCallId } from "../utils";
 import {
 	type OpenAIChatContentPart,
 	type OpenAIChatMessage,
@@ -377,7 +377,7 @@ export function encodeResponse(message: AssistantMessage, requestedModelId: stri
 	}
 	if (toolCalls.length > 0) {
 		responseMessage.tool_calls = toolCalls.map(tc => ({
-			id: tc.id,
+			id: wireToolCallId(tc.id),
 			type: "function",
 			function: { name: tc.name, arguments: stringifyArgs(tc.arguments) },
 		}));
@@ -639,7 +639,7 @@ export function encodeStream(
 										tool_calls: [
 											{
 												index: idx,
-												id: call?.id ?? "",
+												id: call ? wireToolCallId(call.id) : "",
 												type: "function",
 												function: { name: call?.name ?? "", arguments: "" },
 											},

--- a/packages/ai/src/providers/openai-responses-server.ts
+++ b/packages/ai/src/providers/openai-responses-server.ts
@@ -22,7 +22,7 @@ import type {
 	Tool,
 	ToolCall,
 } from "../types";
-import { sanitizeJsonStrings } from "../utils";
+import { sanitizeJsonStrings, wireToolCallId } from "../utils";
 import {
 	type OpenAIResponsesFunctionCallItem,
 	type OpenAIResponsesFunctionCallOutputItem,
@@ -666,7 +666,7 @@ function buildOutputItems(message: AssistantMessage): OutputItem[] {
 				out.push({
 					type: "custom_tool_call",
 					id: part.thoughtSignature ?? makeCustomCallId(),
-					call_id: part.id,
+					call_id: wireToolCallId(part.id),
 					name: part.customWireName,
 					input: rawInput,
 					status: "completed",
@@ -675,7 +675,7 @@ function buildOutputItems(message: AssistantMessage): OutputItem[] {
 				out.push({
 					type: "function_call",
 					id: part.thoughtSignature ?? makeFuncCallId(),
-					call_id: part.id,
+					call_id: wireToolCallId(part.id),
 					name: part.name,
 					arguments: JSON.stringify(sanitizeJsonStrings(part.arguments ?? {})),
 					status: "completed",
@@ -850,7 +850,7 @@ export function encodeStream(
 						: undefined;
 				const isCustom = customWireName !== undefined;
 				const itemId = tc?.thoughtSignature ?? (isCustom ? makeCustomCallId() : makeFuncCallId());
-				const callId = tc?.id ?? "";
+				const callId = tc ? wireToolCallId(tc.id) : "";
 				const name = customWireName ?? tc?.name ?? "";
 				const item = isCustom
 					? {
@@ -1143,7 +1143,7 @@ export function encodeStream(
 							const tc = ev.toolCall;
 							if (tc.customWireName && !cur.customWireName) cur.customWireName = tc.customWireName;
 							if (tc.thoughtSignature) cur.itemId = tc.thoughtSignature;
-							cur.callId = tc.id;
+							cur.callId = wireToolCallId(tc.id);
 							cur.name = cur.customWireName ?? tc.name;
 							if (cur.customWireName) {
 								// Custom tool: raw input string. Streamed deltas accumulated

--- a/packages/ai/src/utils.ts
+++ b/packages/ai/src/utils.ts
@@ -64,6 +64,23 @@ export function normalizeToolCallId(id: string): string {
 	return sanitized.length > 64 ? sanitized.slice(0, 64) : sanitized;
 }
 
+/**
+ * Wire-facing tool call id for a canonical ToolCall served to a foreign client.
+ *
+ * Responses-backed upstreams (Codex, OpenAI Responses) encode the tool call as
+ * `${call_id}|${item_id}` in `ToolCall.id` so their own replay can recover the
+ * item id. That encoding is gjc-internal: a downstream OpenAI-format client
+ * (OpenCodex, another gjc) truncates the compound value at its own 64-char
+ * limit and can no longer pair its tool output with the call it echoed back,
+ * so the whole chained turn is rejected with "No tool output found". Emit only
+ * the `call_id` half on the wire; the item id travels separately as the item
+ * `id` where the wire format has one.
+ */
+export function wireToolCallId(id: string): string {
+	const separator = id.indexOf("|");
+	return separator === -1 ? id : id.slice(0, separator);
+}
+
 type ResponsesToolItemIdPrefix = "fc" | "ctc";
 
 export function normalizeResponsesToolCallId(

--- a/packages/ai/test/auth-gateway-openai-chat.test.ts
+++ b/packages/ai/test/auth-gateway-openai-chat.test.ts
@@ -264,6 +264,27 @@ describe("auth-gateway openai-chat: encodeResponse", () => {
 		});
 	});
 
+	it("emits only the call_id half of a Codex compound tool id", () => {
+		const message: AssistantMessage = {
+			...emptyAssistant(),
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			content: [
+				{
+					type: "toolCall",
+					id: "call_X0JvpoDX2wMBEwKU9g2sOpy3|fc_08831fab12f9c248016a9e3828210487d080cd050199114e89",
+					name: "compute",
+					arguments: { x: 1 },
+				},
+			],
+			stopReason: "toolUse",
+		};
+
+		const out = encodeResponse(message, "gpt-5.2");
+		const choices = out.choices as Array<{ message: { tool_calls?: Array<{ id: string }> } }>;
+		expect(choices[0].message.tool_calls?.[0]?.id).toBe("call_X0JvpoDX2wMBEwKU9g2sOpy3");
+	});
+
 	it("surfaces only the finalized summary for mixed reasoning", () => {
 		const message: AssistantMessage = {
 			...emptyAssistant(),
@@ -312,6 +333,35 @@ describe("auth-gateway openai-chat: encodeResponse", () => {
 });
 
 describe("auth-gateway openai-chat: encodeStream", () => {
+	it("streams only the call_id half of a Codex compound tool id", async () => {
+		const partial = emptyAssistant();
+		partial.content = [
+			{
+				type: "toolCall",
+				id: "call_X0JvpoDX2wMBEwKU9g2sOpy3|fc_08831fab12f9c248016a9e3828210487d080cd050199114e89",
+				name: "skill",
+				arguments: {},
+			},
+		];
+		const events: AssistantMessageEvent[] = [
+			{ type: "toolcall_start", contentIndex: 0, partial },
+			{ type: "toolcall_delta", contentIndex: 0, delta: "{}", partial },
+			{ type: "done", reason: "toolUse", message: { ...partial, stopReason: "toolUse" } },
+		];
+
+		const payloads = (await collectStream(encodeStream(makeEventStream(events, partial), "gpt-5.2"))).map(
+			parseSseLine,
+		) as Array<{ choices?: Array<{ delta: { tool_calls?: Array<{ id?: string }> } }> } | string>;
+		const ids = payloads
+			.filter(
+				(p): p is { choices: Array<{ delta: { tool_calls?: Array<{ id?: string }> } }> } => typeof p === "object",
+			)
+			.flatMap(p => p.choices[0].delta.tool_calls ?? [])
+			.map(tc => tc.id)
+			.filter((id): id is string => typeof id === "string" && id.length > 0);
+		expect(ids).toEqual(["call_X0JvpoDX2wMBEwKU9g2sOpy3"]);
+	});
+
 	it("emits role chunk, text deltas, tool_call deltas with sequential indexes, then [DONE]", async () => {
 		const partial = emptyAssistant();
 		// Pre-populate partial.content so toolcall_start can look up id/name by contentIndex.

--- a/packages/ai/test/auth-gateway-openai-responses.test.ts
+++ b/packages/ai/test/auth-gateway-openai-responses.test.ts
@@ -306,6 +306,39 @@ describe("openai-responses encodeResponse", () => {
 		});
 	});
 
+	it("emits only the call_id half of a Codex compound tool id", () => {
+		// Codex/Responses upstreams store `${call_id}|${item_id}` in ToolCall.id.
+		// A downstream Responses client truncates the compound value at 64 chars
+		// and then cannot pair its output with the call it echoed back.
+		const message: AssistantMessage = {
+			role: "assistant",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			model: "gpt-5",
+			content: [
+				{
+					type: "toolCall",
+					id: "call_X0JvpoDX2wMBEwKU9g2sOpy3|fc_08831fab12f9c248016a9e3828210487d080cd050199114e89",
+					name: "skill",
+					arguments: { name: "autoresearch" },
+					thoughtSignature: "fc_08831fab12f9c248016a9e3828210487d080cd050199114e89",
+				},
+			],
+			usage: zeroUsage(),
+			stopReason: "toolUse",
+			timestamp: 1_700_000_000_000,
+		};
+
+		const output = encodeResponse(message, "gpt-5").output as Array<Record<string, unknown>>;
+		expect(output).toHaveLength(1);
+		expect(output[0]).toMatchObject({
+			type: "function_call",
+			id: "fc_08831fab12f9c248016a9e3828210487d080cd050199114e89",
+			call_id: "call_X0JvpoDX2wMBEwKU9g2sOpy3",
+		});
+		expect(output[0]!.call_id as string).not.toContain("|");
+	});
+
 	it("marks length-limited responses incomplete", () => {
 		const message: AssistantMessage = {
 			role: "assistant",
@@ -490,6 +523,45 @@ describe("openai-responses encodeStream", () => {
 		});
 		// Critical gotcha: id and call_id are distinct.
 		expect(output[2]!.id).not.toBe(output[2]!.call_id);
+	});
+
+	it("streams only the call_id half of a Codex compound tool id", async () => {
+		const stream = new AssistantMessageEventStream();
+		const compoundId = "call_X0JvpoDX2wMBEwKU9g2sOpy3|fc_08831fab12f9c248016a9e3828210487d080cd050199114e89";
+		const toolCall = {
+			type: "toolCall" as const,
+			id: compoundId,
+			name: "skill",
+			arguments: { name: "autoresearch" },
+			thoughtSignature: "fc_08831fab12f9c248016a9e3828210487d080cd050199114e89",
+		};
+		const message: AssistantMessage = {
+			role: "assistant",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			model: "gpt-5",
+			content: [toolCall],
+			usage: zeroUsage(),
+			stopReason: "toolUse",
+			timestamp: 1_700_000_000_000,
+		};
+		queueMicrotask(() => {
+			stream.push({ type: "start", partial: { ...message, content: [] } });
+			stream.push({ type: "toolcall_start", contentIndex: 0, partial: message });
+			stream.push({ type: "toolcall_end", contentIndex: 0, toolCall, partial: message });
+			stream.push({ type: "done", reason: "toolUse", message });
+		});
+
+		const frames = parseSse(await collectStream(encodeStream(stream, "gpt-5")));
+		const added = frames.find(f => f.event === "response.output_item.added")!.data as Record<string, unknown>;
+		const completed = frames.find(f => f.event === "response.completed")!.data as Record<string, unknown>;
+		const output = (completed.response as Record<string, unknown>).output as Array<Record<string, unknown>>;
+		expect((added.item as Record<string, unknown>).call_id).toBe("call_X0JvpoDX2wMBEwKU9g2sOpy3");
+		expect(output[0]).toMatchObject({
+			type: "function_call",
+			id: "fc_08831fab12f9c248016a9e3828210487d080cd050199114e89",
+			call_id: "call_X0JvpoDX2wMBEwKU9g2sOpy3",
+		});
 	});
 
 	it("emits response.incomplete for length-limited streams", async () => {


### PR DESCRIPTION
## What

The auth-gateway OpenAI Responses and Chat Completions encoders now emit only the `call_id` half of a Codex/Responses compound tool-call id on the wire. A small `wireToolCallId()` helper in `packages/ai/src/utils.ts` is applied at the six OpenAI egress sites (Responses `function_call`/`custom_tool_call` non-streaming, streaming `output_item.added` and `toolcall_end`; Chat `tool_calls[].id` non-streaming and streaming). The internal compound encoding (`encodeResponsesToolCallId`) and every non-gateway Codex replay path are untouched.

## Why

Codex/OpenAI Responses upstreams store `${call_id}|${item_id}` in `ToolCall.id` so gjc's own replay can recover the Responses item id. The gateway forwarded that ~80-character compound value as the wire `call_id`. A downstream OpenAI-format client (OpenCodex, another gjc) truncates it at its own 64-character limit, so the id it echoes back on the next turn no longer matches the `function_call_output` gjc sends, and every chained tool turn fails with `400 No tool output found for function call`. Single-shot requests without tools were unaffected, which is why the existing gateway fixtures (`call_x`, `call_42`) never exercised it.

Observed against a gjc auth-gateway fronted by OpenCodex 2.45.0: the first tool call succeeds, every subsequent turn 400s until the session is abandoned.

The item id still travels as the Responses item `id` (`thoughtSignature`), and the gateway decode side already stores the plain `call_id` (`openai-responses-server.ts` `parseRequest`), so the client's wire view loses nothing and the round trip to the Codex upstream pairs by plain `call_id`.

Out of scope, noted for consistency only: `anthropic-messages-server.ts` still emits the raw `ToolCall.id` as `tool_use.id`. Anthropic has a single tool-use identity rather than a `call_id`/item-id pair, so that is a separate protocol question, not part of this fix.

## Testing

- Four regression tests added: non-streaming and streaming Responses encoder, non-streaming and streaming Chat encoder, each with the 80-character compound id from the observed failure. All four fail on the parent commit and pass here.
- `bun test` on `auth-gateway-openai-responses`, `auth-gateway-openai-chat`, `auth-gateway-pi-native`, `auth-gateway-anthropic-messages`: 75 pass, 0 fail.
- `biome check` on the touched files: clean. `packages/ai` `bun run check`: clean.
- Live: a chained tool turn through auth-gateway → OpenCodex → gjc client now returns 200; `gjc -p --tools=read` completes a real tool loop through the relay.

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:309b2929fb053b8111e72fba5df0f6c85036340ff1ce09285d88b7547caac27e reviewer:human reviewer-id:Yeachan-Heo evidence:https://github.com/Yeachan-Heo/gajae-code/pull/5389#pullrequestreview-5131957881
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken


