### PR TITLE
test(sdk): reap fixture broker leases on abort (#5392)

### DIFF
--- a/packages/coding-agent/test/fixture-broker-cleanup.test.ts
+++ b/packages/coding-agent/test/fixture-broker-cleanup.test.ts
@@ -8,11 +8,10 @@ import {
 	createFixtureRootCleanup,
 	fixtureRootForTest,
 	registerFixtureRuntime,
+	trackedFixtureLeaseCountForTest,
 	withFixtureBrokerEnvironment,
 } from "./helpers/fixture-broker-cleanup";
-
 const temp = () => fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-fixture-cleanup-"));
-
 function lease(events: string[], failures = 0) {
 	let attempts = 0;
 	return {
@@ -340,5 +339,30 @@ describe("fixture broker root cleanup", () => {
 		// ...and is removed when the fixture root is cleaned up (no external residue).
 		await fs.rm(root, { recursive: true, force: true });
 		expect(await exists(child)).toBe(false);
+	});
+
+	it("tracks each created fixture broker lease until its root cleanup verifies", async () => {
+		const before = trackedFixtureLeaseCountForTest();
+		const root = await temp();
+		const cleanup = createFixtureRootCleanup(root, path.join(root, "agent"), lease([]));
+		expect(trackedFixtureLeaseCountForTest()).toBe(before + 1);
+		await cleanupFixtureRoot(cleanup, { absenceObservationMs: 0, rootExists: async () => false });
+		expect(trackedFixtureLeaseCountForTest()).toBe(before);
+		expect(fixtureRootForTest(root)).toBeUndefined();
+	});
+
+	it("retains the abort reap registration while lease close is still pending", async () => {
+		const before = trackedFixtureLeaseCountForTest();
+		const root = await temp();
+		const cleanup = createFixtureRootCleanup(root, path.join(root, "agent"), lease([], 1));
+		expect(trackedFixtureLeaseCountForTest()).toBe(before + 1);
+		await expect(
+			cleanupFixtureRoot(cleanup, { absenceObservationMs: 0, rootExists: async () => false }),
+		).rejects.toThrow("lease close failed");
+		// The child is still alive after a failed close, so the abort hook must still own it.
+		expect(trackedFixtureLeaseCountForTest()).toBe(before + 1);
+		expect(fixtureRootForTest(root)).toBe(cleanup);
+		await cleanupFixtureRoot(cleanup, { absenceObservationMs: 0, rootExists: async () => false });
+		expect(trackedFixtureLeaseCountForTest()).toBe(before);
 	});
 });

--- a/packages/coding-agent/test/helpers/fixture-broker-cleanup.ts
+++ b/packages/coding-agent/test/helpers/fixture-broker-cleanup.ts
@@ -45,6 +45,65 @@ export interface FixtureRootCleanupOptions {
 const roots = new Map<string, FixtureRootCleanup>();
 const cleanupAttempts = new WeakMap<FixtureRootCleanup, Promise<void>>();
 const canonicalRoot = (root: string) => path.resolve(root);
+
+/**
+ * Abort-safe reap for fixture broker leases.
+ *
+ * `cleanupFixtureRoot` only runs on the success path. When a test throws,
+ * times out, or the runner kills the file early, the detached broker child
+ * this process spawned is reparented and keeps its port and memory forever
+ * (fixture roots under /tmp with a live `broker-internal --agent-dir` child
+ * are the signature). This registry targets exactly the leases created in
+ * this process — never a discovery-derived PID, never by name — and reaps
+ * them when the process exits abnormally. Normal cleanup unregisters first,
+ * so the exit hook is a no-op on the success path.
+ */
+interface TrackedFixtureLease {
+	cleanup: FixtureRootCleanup;
+}
+const trackedLeases = new Set<TrackedFixtureLease>();
+let reapHookInstalled = false;
+
+function installAbortReapHook(): void {
+	if (reapHookInstalled) return;
+	reapHookInstalled = true;
+	const reapTrackedLeases = (): void => {
+		// Synchronous only: the process is already exiting, so hand each
+		// retained child the same exact-child termination `close()` performs.
+		// Exact children only — a fixture lease never touches a foreign PID.
+		// The lease is dereferenced live: one caller reassigns `cleanup.lease`
+		// after construction when the real broker starts, and the hook must own
+		// the live lease, not the construction-time placeholder.
+		for (const tracked of [...trackedLeases]) {
+			trackedLeases.delete(tracked);
+			try {
+				const result = tracked.cleanup.lease.close();
+				if (result && typeof (result as Promise<void>).catch === "function")
+					(result as Promise<void>).catch(() => undefined);
+			} catch {
+				// Best-effort: teardown diagnostics must never throw from an exit hook.
+			}
+		}
+	};
+	process.once("beforeExit", reapTrackedLeases);
+	process.once("exit", reapTrackedLeases);
+}
+
+function trackFixtureLease(cleanup: FixtureRootCleanup): void {
+	installAbortReapHook();
+	trackedLeases.add({ cleanup });
+}
+
+function untrackFixtureLease(cleanup: FixtureRootCleanup): void {
+	for (const tracked of [...trackedLeases]) {
+		if (tracked.cleanup === cleanup) trackedLeases.delete(tracked);
+	}
+}
+
+/** Test hook: number of fixture broker leases still owned by this process. */
+export function trackedFixtureLeaseCountForTest(): number {
+	return trackedLeases.size;
+}
 async function exists(root: string): Promise<boolean> {
 	try {
 		await fs.stat(root);
@@ -141,6 +200,7 @@ export function createFixtureRootCleanup(
 		failures: {},
 	};
 	roots.set(canonical, cleanup);
+	trackFixtureLease(cleanup);
 	return cleanup;
 }
 
@@ -251,6 +311,7 @@ async function cleanupFixtureRootOnce(
 		throw error;
 	}
 	roots.delete(root.rootKey);
+	untrackFixtureLease(root);
 }
 
 export function cleanupFixtureRoot(root: FixtureRootCleanup, options: FixtureRootCleanupOptions = {}): Promise<void> {


### PR DESCRIPTION
Closes #5392.

## Scope

Test-fixture teardown only. Production broker spawn/locking/quarantine (#5204, merged) and gateway circuit breaker #174 are out of scope.

## What

- `packages/coding-agent/test/helpers/fixture-broker-cleanup.ts`: track each created fixture lease; on abnormal process exit (`beforeExit`/`exit`) call that lease's own exact-child `close()`. Never by name, never a discovery-derived PID, never foreign processes. Normal cleanup unregisters first (no-op on success); failed-close retries stay registered while the child is alive.
- `packages/coding-agent/test/fixture-broker-cleanup.test.ts`: lease tracking registered on create / unregistered on verified cleanup; registration retained across a failed close for retry.

## Evidence

- `fixture-broker-cleanup.test.ts`: 16 pass, repeated 3x
- Isolated abort proof (child process starts a real fixture broker then `process.exit(1)` without cleanup): spawned broker child gone afterwards, repeated 4x
- Regressions: `sdk-broker-lifecycle-cleanup` 12 pass, `sdk-broker-spawn-log` + `sdk-broker-lock-artifacts` 18 pass, `sdk-broker.test.ts` 90 pass
- Typecheck: `tsc --noEmit` clean for the package
- Head: `2862cb081c32be88774cc55d205363eadcb1b14e`

No historical/unknown process kills, no service restarts, no gateway config changes. Live-operator leak numbers and fixture-prefix attribution were validated read-only; no memory-causation claim is made.

## Risk classification

- [x] `low-risk`

gajae.pr-review-verdict.v1 merge-self-approved sha256:25403f2cfd1a5f591bcc118c15326aacb5a974ee7c3670854297ffc966e57f03 reviewer:critic reviewer-id:Yeachan-Heo evidence:pr-5393-exact-head-ci-plus-focused-tests
