### PR TITLE
fix(sdk): quantize endpoint incarnation mtime to whole milliseconds (#5376)

### DIFF
--- a/packages/coding-agent/src/sdk/broker/endpoint-authority.ts
+++ b/packages/coding-agent/src/sdk/broker/endpoint-authority.ts
@@ -40,7 +40,12 @@ export function endpointIncarnation(
 		.update(
 			JSON.stringify({
 				endpointGeneration: record.endpointGeneration,
-				endpointMtimeMs: record.endpointMtimeMs,
+				// Filesystem mtime is only millisecond-precise, and the two stat
+				// spellings used across this path (bigint mtimeNs/1e6 vs libuv
+				// double mtimeMs) can disagree by 1 float ulp (~0.00024ms) for the
+				// same file (#5376). Quantize so equivalent reads hash identically;
+				// a genuine replacement still differs by >=1ms or pid/generation.
+				endpointMtimeMs: Math.round(record.endpointMtimeMs),
 				pid: record.pid,
 				sessionId,
 			}),

--- a/packages/coding-agent/test/sdk-broker.test.ts
+++ b/packages/coding-agent/test/sdk-broker.test.ts
@@ -19,6 +19,7 @@ import {
 	redactBrokerDiscovery,
 	writeBrokerDiscovery,
 } from "../src/sdk/broker/discovery";
+import { endpointIncarnation } from "../src/sdk/broker/endpoint-authority";
 import {
 	brokerOwnerForTest,
 	brokerSpawnEnvironmentForTest,
@@ -49,6 +50,14 @@ import {
 } from "../src/session/session-storage";
 
 const temp = () => fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-broker-"));
+const nextFloat = (value: number): number => {
+	const buf = new ArrayBuffer(8);
+	const f64 = new Float64Array(buf);
+	const u64 = new BigUint64Array(buf);
+	f64[0] = value;
+	u64[0] = u64[0]! + 1n;
+	return f64[0]!;
+};
 
 it("does not disclose launch paths when cleanup remains uncertain", () => {
 	const executable = "/private/runtime/gjc-secret";
@@ -2081,14 +2090,13 @@ describe("SDK broker identity and discovery", () => {
 			endpointGeneration: 3,
 			pid: process.pid,
 		});
-		const endpointIncarnation = createHash("sha256")
-			.update(JSON.stringify({ endpointGeneration: 3, endpointMtimeMs, pid: process.pid, sessionId: "s" }))
-			.digest("hex");
+		const boundIncarnation = endpointIncarnation({ endpointGeneration: 3, endpointMtimeMs, pid: process.pid }, "s");
+		expect(boundIncarnation).toBeString();
 		expect(
 			await broker.handleRequest("session.get_endpoint", {
 				sessionId: "s",
 				endpointGeneration: 3,
-				endpointIncarnation,
+				endpointIncarnation: boundIncarnation,
 			}),
 		).toEqual({
 			ok: true,
@@ -2347,6 +2355,84 @@ describe("SDK broker identity and discovery", () => {
 				ok: false,
 				error: { code: "endpoint_stale", message: "lifecycle replay target was replaced" },
 			});
+		} finally {
+			await broker.stop();
+			await saved?.close();
+			await fs.rm(dir, { recursive: true, force: true });
+		}
+	});
+	it("replays a lifecycle success when endpoint mtime differs by one float ulp (#5376)", async () => {
+		const dir = await temp();
+		const cwd = path.join(dir, "repo");
+		const stateRoot = path.join(cwd, ".gjc", "state");
+		const broker = new Broker({ agentDir: dir });
+		let saved: SessionManager | undefined;
+		try {
+			await fs.mkdir(cwd, { recursive: true });
+			saved = SessionManager.create(cwd, SessionManager.managedDestination(cwd, dir));
+			await saved.ensureOnDisk();
+			const sessionId = saved.getSessionId();
+			const sessionPath = saved.getSessionFile();
+			if (!sessionPath) throw new Error("Expected a saved session path.");
+			const captured = SessionManager.captureTranscriptStrict(sessionPath);
+			if (captured.kind !== "captured") throw new Error("Expected a captured saved session.");
+			const identity = captured.snapshot.identity;
+			const endpointPath = path.join(stateRoot, "sdk", `${sessionId}.json`);
+			await fs.mkdir(path.dirname(endpointPath), { recursive: true });
+			await fs.writeFile(
+				endpointPath,
+				JSON.stringify({ sessionId, pid: process.pid, url: "ws://127.0.0.1:1", token: "original-token" }),
+			);
+			await broker.start();
+			const firstEndpointMtimeMs = (await fs.stat(endpointPath)).mtimeMs;
+			const locator = { cwd, worktreeRoot: null, stateRoot };
+			await broker.index.append({
+				type: "host_registered",
+				sessionId,
+				locator,
+				endpointGeneration: 1,
+				pid: process.pid,
+				endpointMtimeMs: firstEndpointMtimeMs,
+			});
+			await broker.index.append({
+				type: "host_heartbeat",
+				sessionId,
+				locator,
+				endpointGeneration: 1,
+				pid: process.pid,
+			});
+			const input = {
+				cwd,
+				stateRoot,
+				sessionId,
+				sessionPath,
+				sessionIdentity: {
+					dev: identity.dev.toString(),
+					ino: identity.ino.toString(),
+					size: identity.size,
+					mtimeMs: identity.mtimeMs,
+					mtimeNs: identity.mtimeNs.toString(),
+					sha256: identity.sha256,
+				},
+			};
+			const first = await broker.handleRequest("session.resume", input, "ulp-replay");
+			expect(first).toMatchObject({
+				ok: true,
+				result: { endpointGeneration: 1, endpoint: { token: "original-token" } },
+			});
+			const skewedMtimeMs = nextFloat(firstEndpointMtimeMs);
+			expect(Math.abs(skewedMtimeMs - firstEndpointMtimeMs)).toBeLessThan(0.001);
+			expect(skewedMtimeMs).not.toBe(firstEndpointMtimeMs);
+			await broker.index.append({
+				type: "host_registered",
+				sessionId,
+				locator,
+				endpointGeneration: 1,
+				pid: process.pid,
+				endpointMtimeMs: skewedMtimeMs,
+			});
+			const replayed = await broker.handleRequest("session.resume", input, "ulp-replay");
+			expect(replayed).toMatchObject({ ok: true });
 		} finally {
 			await broker.stop();
 			await saved?.close();


### PR DESCRIPTION
Resolves #5376.

Root cause: two stat spellings for one endpoint file (bigint mtimeNs/1e6 in readEndpointFile vs libuv double mtimeMs in fs.stat) disagree by 1 float ulp (~0.00024ms) ~12% of the time (37/300 fresh files probed). The endpoint incarnation hash fed raw mtimeMs, so lifecycle replay read a live endpoint as replaced: endpoint_stale 'lifecycle replay target was replaced'.

Fix: quantize the hashed mtime to whole milliseconds in the single canonical endpointIncarnation() helper (endpoint-authority.ts). Genuine replacements still differ by >=1ms or pid/generation. The incarnation-bound endpoint test now uses the canonical helper instead of a hand-rolled hash.

Evidence:
- New 1-ulp replay test fails pre-fix (endpoint_stale) and passes post-fix.
- sdk-broker.test.ts 91/91 post-fix.
- sdk-machine-lifecycle-topology.test.ts 7/7 x7 consecutive post-fix (3 + 4).
- packages/coding-agent check (biome + tsc) clean.

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:4ca48b622add5bd0a29ce65156305ee68a6d52afa5d10b8e23f7a2bf94e320b6 reviewer:architect reviewer-id:Yeachan-Heo evidence:bun test packages/coding-agent/test/sdk-broker.test.ts 91/91; bun test packages/coding-agent/test/sdk-machine-lifecycle-topology.test.ts 7/7 x7
```
