### PR TITLE
fix(sdk): bind endpoint file identity into incarnation; canonicalize coordinator producer (#5376 follow-up)

### DIFF
--- a/packages/coding-agent/src/coordinator-mcp/server.ts
+++ b/packages/coding-agent/src/coordinator-mcp/server.ts
@@ -25,6 +25,7 @@ import {
 import { listMcpDelegateHostContexts } from "../hooks/mcp-delegate-host-context";
 import type { WorkflowGate, WorkflowGateQueryRecord } from "../modes/shared/agent-wire/workflow-gate-types";
 import type { BrokerDiscovery } from "../sdk/broker/discovery";
+import { endpointIncarnation } from "../sdk/broker/endpoint-authority";
 import { type EnsureBrokerSettings, ensureBroker } from "../sdk/broker/ensure";
 import { lifecycleRequestTimeoutMs } from "../sdk/broker/startup-budget";
 import { UnsupportedStateVersionError } from "../sdk/broker/state-version";
@@ -5633,9 +5634,19 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 			endpointMtimeMs <= 0
 		)
 			return null;
-		return createHash("sha256")
-			.update(canonicalJson({ endpointGeneration, endpointMtimeMs, pid, sessionId }))
-			.digest("hex");
+		// Single canonical producer lives in endpoint-authority.ts (#5376
+		// follow-up): never reimplement the digest recipe here.
+		return (
+			endpointIncarnation(
+				{
+					endpointGeneration,
+					endpointMtimeMs,
+					pid,
+					...(typeof session.endpointFileId === "string" ? { endpointFileId: session.endpointFileId } : {}),
+				},
+				sessionId,
+			) ?? null
+		);
 	}
 
 	type BrokerSessionAuthority = {

--- a/packages/coding-agent/src/sdk/broker/endpoint-authority.ts
+++ b/packages/coding-agent/src/sdk/broker/endpoint-authority.ts
@@ -23,7 +23,7 @@ export type IndexedEndpointAuthority = {
 
 /** Derive the broker-compatible opaque authority for one indexed endpoint generation. */
 export function endpointIncarnation(
-	record: { endpointGeneration: number; endpointMtimeMs?: number; pid: number },
+	record: { endpointGeneration: number; endpointMtimeMs?: number; pid: number; endpointFileId?: string },
 	sessionId: string,
 ): string | undefined {
 	if (
@@ -43,9 +43,12 @@ export function endpointIncarnation(
 				// Filesystem mtime is only millisecond-precise, and the two stat
 				// spellings used across this path (bigint mtimeNs/1e6 vs libuv
 				// double mtimeMs) can disagree by 1 float ulp (~0.00024ms) for the
-				// same file (#5376). Quantize so equivalent reads hash identically;
-				// a genuine replacement still differs by >=1ms or pid/generation.
+				// same file (#5376). Quantize so equivalent reads hash identically.
+				// The immutable endpoint file identity (dev:ino) stays exact, so a
+				// genuine same-millisecond successor replacement still changes the
+				// digest even when pid/generation are reused.
 				endpointMtimeMs: Math.round(record.endpointMtimeMs),
+				...(record.endpointFileId === undefined ? {} : { endpointFileId: record.endpointFileId }),
 				pid: record.pid,
 				sessionId,
 			}),

--- a/packages/coding-agent/test/coordinator-mcp-server.test.ts
+++ b/packages/coding-agent/test/coordinator-mcp-server.test.ts
@@ -53,6 +53,7 @@ import {
 	readBrokerDiscovery,
 	writeBrokerDiscovery,
 } from "../src/sdk/broker/discovery";
+import { endpointIncarnation } from "../src/sdk/broker/endpoint-authority";
 import {
 	brokerOwnerForTest,
 	type EnsureBrokerSettings,
@@ -352,15 +353,20 @@ async function createSdkControlServer(
 			) as Record<string, unknown>;
 			existing.broker_workspace = brokerWorkspace;
 			existing.endpoint_generation = session.endpointGeneration ?? 1;
-			existing.endpoint_incarnation = createHash("sha256")
-				.update(
-					// brokerEndpointIncarnation hashes a sorted-key canonical object;
-					// keep the fixture digest byte-identical to the broker's.
-					`{"endpointGeneration":${JSON.stringify(session.endpointGeneration ?? 1)},"endpointMtimeMs":${
-						session.endpointMtimeMs
-					},"pid":${session.pid},"sessionId":${JSON.stringify(sessionId)}}`,
-				)
-				.digest("hex");
+			const generation = typeof session.endpointGeneration === "number" ? session.endpointGeneration : 1;
+			const pid = typeof session.pid === "number" ? session.pid : 0;
+			const mtimeMs = typeof session.endpointMtimeMs === "number" ? session.endpointMtimeMs : NaN;
+			const fixtureIncarnation = endpointIncarnation(
+				{
+					endpointGeneration: generation,
+					endpointMtimeMs: mtimeMs,
+					pid,
+					...(typeof session.endpointFileId === "string" ? { endpointFileId: session.endpointFileId } : {}),
+				},
+				sessionId,
+			);
+			if (!fixtureIncarnation) throw new Error("fixture session lacks endpoint authority");
+			existing.endpoint_incarnation = fixtureIncarnation;
 			// The verifier is minted through the server so its private key stays in
 			// the server's signing map and signed sidecar patches remain verifiable.
 			existing.sidecar_verifier ??= server.mintSidecarSigningAuthorityForTest();
@@ -384,6 +390,7 @@ async function createSdkControlServer(
 					endpointGeneration: session.endpointGeneration,
 					pid: session.pid,
 					endpointMtimeMs: session.endpointMtimeMs,
+					...(typeof session.endpointFileId === "string" ? { endpointFileId: session.endpointFileId } : {}),
 					indexSeq: 1,
 				};
 			}),

--- a/packages/coding-agent/test/helpers/sdk-exact-session-authority.ts
+++ b/packages/coding-agent/test/helpers/sdk-exact-session-authority.ts
@@ -9,6 +9,7 @@ export interface ExactSessionAuthorityFixture {
 	readonly endpointGeneration: number;
 	readonly pid: number;
 	readonly endpointMtimeMs: number;
+	readonly endpointFileId: string;
 	readonly endpoint: {
 		readonly sessionId: string;
 		readonly pid: number;
@@ -39,11 +40,13 @@ export async function prepareExactSessionAuthority(
 		token: options.token,
 	};
 	await Bun.write(endpointFile, `${JSON.stringify({ version: 1, ...endpoint })}\n`);
+	const stat = await fs.stat(endpointFile, { bigint: true });
 	return {
 		sessionId: options.sessionId,
 		endpointGeneration,
 		pid: process.pid,
-		endpointMtimeMs: (await fs.stat(endpointFile)).mtimeMs,
+		endpointMtimeMs: Number(stat.mtimeNs) / 1_000_000,
+		endpointFileId: `${stat.dev}:${stat.ino}`,
 		endpoint,
 	};
 }
@@ -67,6 +70,7 @@ export async function publishExactSessionAuthority(
 		locator: { cwd: options.cwd, worktreeRoot: null, stateRoot },
 		endpointGeneration: authority.endpointGeneration,
 		pid: authority.pid,
+		endpointFileId: authority.endpointFileId,
 		// A real host publishes its own OS start incarnation; without it the
 		// pid-reuse fence (incarnationMatches) never holds and the session
 		// reads not-live, so the fixture publishes the test process's

--- a/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
+++ b/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
@@ -11,6 +11,7 @@ import { openLifecycleSessionManager, runSessionHost, watchSessionHostBrokerLive
 import { planLaunchWorktree } from "../src/gjc-runtime/launch-worktree";
 import { AcpAgent } from "../src/modes/acp/acp-agent";
 import { Broker, type BrokerCleanupEvidence, type BrokerResponse } from "../src/sdk/broker/broker";
+import { endpointIncarnation } from "../src/sdk/broker/endpoint-authority";
 import { brokerOwnerForTest, startFixtureBrokerWithLeaseForTest } from "../src/sdk/broker/ensure";
 import { deriveIdempotencyIdentity } from "../src/sdk/broker/identity";
 import {
@@ -4999,9 +5000,11 @@ test("idempotent lifecycle replay refreshes unchanged authority after a broker r
 		const targetHash = createHash("sha256").update(canonicalJson({ sessionId })).digest("hex");
 		const identity = await deriveIdempotencyIdentity(agentDir, "session.resume", key, targetHash);
 		const input = { cwd: root, stateRoot, sessionId };
-		const endpointIncarnation = createHash("sha256")
-			.update(canonicalJson({ endpointGeneration: 2, endpointMtimeMs, pid: host.pid, sessionId }))
-			.digest("hex");
+		const seededIncarnation = endpointIncarnation(
+			{ endpointGeneration: 2, endpointMtimeMs, pid: host.pid },
+			sessionId,
+		);
+		expect(seededIncarnation).toBeString();
 		const requestHash = createHash("sha256")
 			.update(canonicalJson({ operation: "session.resume", input }))
 			.digest("hex");
@@ -5013,7 +5016,7 @@ test("idempotent lifecycle replay refreshes unchanged authority after a broker r
 					sessionId,
 					cwd: root,
 					endpointGeneration: 2,
-					endpointIncarnation,
+					endpointIncarnation: seededIncarnation,
 					pid: host.pid,
 					endpointMtimeMs,
 					reused: true,
@@ -5030,7 +5033,7 @@ test("idempotent lifecycle replay refreshes unchanged authority after a broker r
 				sessionId,
 				cwd: root,
 				endpointGeneration: 2,
-				endpointIncarnation,
+				endpointIncarnation: seededIncarnation,
 				pid: host.pid,
 				endpointMtimeMs,
 				reused: true,

--- a/packages/coding-agent/test/sdk-broker.test.ts
+++ b/packages/coding-agent/test/sdk-broker.test.ts
@@ -2361,7 +2361,21 @@ describe("SDK broker identity and discovery", () => {
 			await fs.rm(dir, { recursive: true, force: true });
 		}
 	});
-	it("replays a lifecycle success when endpoint mtime differs by one float ulp (#5376)", async () => {
+	it("endpoint incarnation is stable across one float ulp but binds file identity (#5376)", async () => {
+		const base = { endpointGeneration: 1, endpointMtimeMs: 1788784000000.25, pid: 1234 };
+		const skewed = nextFloat(base.endpointMtimeMs);
+		expect(skewed).not.toBe(base.endpointMtimeMs);
+		expect(Math.abs(skewed - base.endpointMtimeMs)).toBeLessThan(0.001);
+		// Same file, two stat spellings: identical digest.
+		expect(endpointIncarnation({ ...base, endpointMtimeMs: skewed }, "s")).toBe(endpointIncarnation(base, "s"));
+		// Same-millisecond successor with a distinct file identity: stale.
+		expect(endpointIncarnation({ ...base, endpointMtimeMs: skewed, endpointFileId: "64768:111" }, "s")).not.toBe(
+			endpointIncarnation({ ...base, endpointFileId: "64768:222" }, "s"),
+		);
+		// Legacy rows without a file identity still hash (back-compat).
+		expect(endpointIncarnation(base, "s")).toBeString();
+	});
+	it("replays a lifecycle success when the indexed mtime matches the live file (#5376)", async () => {
 		const dir = await temp();
 		const cwd = path.join(dir, "repo");
 		const stateRoot = path.join(cwd, ".gjc", "state");
@@ -2384,7 +2398,8 @@ describe("SDK broker identity and discovery", () => {
 				JSON.stringify({ sessionId, pid: process.pid, url: "ws://127.0.0.1:1", token: "original-token" }),
 			);
 			await broker.start();
-			const firstEndpointMtimeMs = (await fs.stat(endpointPath)).mtimeMs;
+			const liveStat = await fs.stat(endpointPath, { bigint: true });
+			const liveMtimeMs = Number(liveStat.mtimeNs) / 1_000_000;
 			const locator = { cwd, worktreeRoot: null, stateRoot };
 			await broker.index.append({
 				type: "host_registered",
@@ -2392,7 +2407,8 @@ describe("SDK broker identity and discovery", () => {
 				locator,
 				endpointGeneration: 1,
 				pid: process.pid,
-				endpointMtimeMs: firstEndpointMtimeMs,
+				endpointMtimeMs: liveMtimeMs,
+				endpointFileId: `${liveStat.dev}:${liveStat.ino}`,
 			});
 			await broker.index.append({
 				type: "host_heartbeat",
@@ -2415,24 +2431,40 @@ describe("SDK broker identity and discovery", () => {
 					sha256: identity.sha256,
 				},
 			};
-			const first = await broker.handleRequest("session.resume", input, "ulp-replay");
+			const first = await broker.handleRequest("session.resume", input, "fileid-replay");
 			expect(first).toMatchObject({
 				ok: true,
 				result: { endpointGeneration: 1, endpoint: { token: "original-token" } },
 			});
-			const skewedMtimeMs = nextFloat(firstEndpointMtimeMs);
-			expect(Math.abs(skewedMtimeMs - firstEndpointMtimeMs)).toBeLessThan(0.001);
-			expect(skewedMtimeMs).not.toBe(firstEndpointMtimeMs);
+			// Same file re-registered through the libuv-double spelling must replay.
+			const floatStat = await fs.stat(endpointPath);
 			await broker.index.append({
 				type: "host_registered",
 				sessionId,
 				locator,
 				endpointGeneration: 1,
 				pid: process.pid,
-				endpointMtimeMs: skewedMtimeMs,
+				endpointMtimeMs: floatStat.mtimeMs,
+				endpointFileId: `${liveStat.dev}:${liveStat.ino}`,
 			});
-			const replayed = await broker.handleRequest("session.resume", input, "ulp-replay");
-			expect(replayed).toMatchObject({ ok: true });
+			expect(await broker.handleRequest("session.resume", input, "fileid-replay")).toMatchObject({ ok: true });
+			// A genuine successor with a distinct file identity but the same
+			// pid/generation and a colliding rounded mtime is descriptor-stale.
+			await broker.index.append({
+				type: "host_registered",
+				sessionId,
+				locator,
+				endpointGeneration: 1,
+				pid: process.pid,
+				endpointMtimeMs: floatStat.mtimeMs,
+				endpointFileId: "64768:999999999",
+			});
+			// The successor row no longer matches the live descriptor, so the
+			// descriptor-bound read rejects it before replay comparison.
+			expect(await broker.handleRequest("session.resume", input, "fileid-replay")).toEqual({
+				ok: false,
+				error: { code: "endpoint_stale", message: "session endpoint is stale" },
+			});
 		} finally {
 			await broker.stop();
 			await saved?.close();


### PR DESCRIPTION
Follow-up to #5394 addressing the boundary cohort BLOCK findings.

Gaps in quantization-only fix:
1. Coordinator MCP reimplemented the digest with raw mtime (brokerEndpointIncarnation) — deterministic mismatch vs broker for fractional mtimes. Now delegates to canonical endpointIncarnation().
2. Same-millisecond successor with same pid/generation could collide in one rounded bucket. The digest now also binds exact immutable endpoint file identity (dev:ino); same-file ULP reads still agree, distinct files differ.
3. ULP regression test hardened: deterministic controlled base + explicit successor-rejection case.
4. All fixture digest recipes (coordinator mock, e2e replay, exact-session helper) use the canonical helper; helper publishes endpointFileId.

Evidence:
- sdk-broker.test.ts 92/92.
- e2e replay subset 8/8.
- coordinator endpoint subset 6/6 (one unrelated failure in full file also fails on clean dev baseline).
- New unit test fails pre-fix / passes post-fix (verified by stash).
- biome+tsc clean on all touched files (one repo-wide check nit in untouched fixture-broker-cleanup.test.ts is pre-existing on clean dev).

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:607d65b9fb7090af826f6d934b40c5e9e00fb84217caced04a4cd1f81446b21b reviewer:architect reviewer-id:Yeachan-Heo evidence:bun test packages/coding-agent/test/sdk-broker.test.ts 92/92; e2e replay 8/8; coordinator endpoint 6/6
```
