### PR TITLE
fix(session): use attempt-based backoff for managed fallback

### DIFF
--- a/docs/non-compaction-retry-policy.md
+++ b/docs/non-compaction-retry-policy.md
@@ -87,7 +87,7 @@ Flow (`#handleRetryableError`):
 3. Increment `#retryAttempt`.
 4. Create `#retryPromise` once (first attempt in a chain).
 5. In the legacy single-model path, ordinary transient errors retry without an attempt limit. Typed provider-overload replays, canonical idle-stream watchdog stalls, and unknown/no-code errors stop after `retry.maxRetries`. Managed fallback instead uses its controller's per-entry `fallback.maxAttempts` budget.
-6. Compute exponential full-jitter delay capped at `retry.maxDelayMs`; legacy parsed provider retry-after values override computed backoff and are capped at `retry.maxDelayMs`, while managed typed Retry-After values are intentionally uncapped.
+6. Compute exponential full-jitter delay capped at `retry.maxDelayMs`. Managed fallback ignores Retry-After when calculating retry delays and advances when its attempt budget is consumed. Legacy parsed provider retry-after values still override computed backoff and are capped at `retry.maxDelayMs`.
 7. For usage-limit errors, call auth storage (`markUsageLimitReached(...)`); if credential switching succeeds, force delay to `0`, otherwise use the applicable backoff.
 8. Eligible ordered role-array fallback chains advance on entry-budget exhaustion. A selected fallback entry remains sticky until the head selector's rate-limit cooldown expires, when `retry.fallbackRevertPolicy: cooldown-expiry` probes it again on a new turn.
 9. Emit `auto_retry_start`.
@@ -145,7 +145,7 @@ Backoff uses capped exponential full jitter. With default settings the maximum j
 - attempt 2: 4000 ms
 - attempt 3: 8000 ms
 
-`retry.maxDelayMs` caps every legacy session retry delay, including provider retry-after hints, which otherwise take precedence over computed backoff. Managed fallback intentionally does not cap typed Retry-After values because it retries within its separate per-entry `fallback.maxAttempts` budget. In the legacy single-model path, transient errors have unbounded attempts except canonical idle-stream watchdog stalls, which are bounded by `retry.maxRetries`; unknown/no-code errors use the same bound.
+Managed fallback uses capped exponential full jitter and `fallback.maxAttempts` (including the initial request), not Retry-After, to schedule attempts. Rate-limit selector cooldown is recorded when the entry advances or exhausts, rather than interrupting its remaining attempts. Credential rotation retains its existing policy. `retry.maxDelayMs` caps legacy retry delays including provider hints; zero retains the existing uncapped backoff setting. In the legacy single-model path, transient errors have unbounded attempts except canonical idle-stream watchdog stalls, which are bounded by `retry.maxRetries`; unknown/no-code errors use the same bound.
 
 ## Abort mechanics
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -21774,6 +21774,15 @@ export class AgentSession {
 					? "retry"
 					: "exhausted";
 		}
+		if (
+			managedFallback &&
+			outcome !== "retry" &&
+			trigger.class === "rate_limit" &&
+			trigger.retryAfterMs !== undefined &&
+			failedSelector
+		) {
+			this.#modelRegistry.suppressSelector(failedSelector, Date.now() + trigger.retryAfterMs);
+		}
 		// Credential rotation is unbounded: a fresh credential is a different
 		// retry dimension from transient-error backoff, so it overrides maxRetries
 		// exhaustion and forces an immediate same-model retry.
@@ -21837,14 +21846,10 @@ export class AgentSession {
 			credentialRotated || outcome === "advance"
 				? 0
 				: managedFallback
-					? effectiveFallbackDelay(retrySettings.baseDelayMs, retrySettings.maxDelayMs, attemptsUsed, retryAfterMs)
+					? effectiveFallbackDelay(retrySettings.baseDelayMs, retrySettings.maxDelayMs, attemptsUsed)
 					: retryAfterMs !== undefined
 						? Math.min(retryAfterMs, retrySettings.maxDelayMs)
 						: cappedExponentialWithFullJitter(retrySettings.baseDelayMs, retrySettings.maxDelayMs, attemptsUsed);
-
-		if (managedFallback && trigger.class === "rate_limit" && trigger.retryAfterMs !== undefined && failedSelector) {
-			this.#modelRegistry.suppressSelector(failedSelector, Date.now() + trigger.retryAfterMs);
-		}
 
 		const retry = async (ownership?: ManagedAttemptContinuationOwnership): Promise<void> => {
 			const activePromptHandle = this.activePromptHandle;

--- a/packages/coding-agent/src/session/fallback-chain-controller.ts
+++ b/packages/coding-agent/src/session/fallback-chain-controller.ts
@@ -242,13 +242,11 @@ export function cappedExponentialWithFullJitter(
 /**
  * Legacy auto-compaction retry delay.
  *
- * Deliberately the mirror image of `effectiveFallbackDelay`: this path recovers
+ * Unlike managed fallback, this path recovers
  * Retry-After by regex over provider error prose (`#parseRetryAfterMsFromError`),
  * so it follows the documented legacy rule — `retry.maxDelayMs` caps every
  * legacy session retry delay, including provider retry-after hints. Managed
- * fallback stays uncapped because it retries within its own per-entry budget;
- * compaction has no such budget, so the final candidate would otherwise sleep
- * for the full server-suggested duration.
+ * fallback ignores these hints when scheduling its attempt-based retries.
  *
  * `maxDelayMs <= 0` means "no cap", matching `cappedExponentialWithFullJitter`.
  * A missing, NaN, or infinite hint collapses to "no usable hint".
@@ -303,13 +301,11 @@ export function describeCompactionCandidateFailures(
 	);
 }
 
-/** Retry-After is intentionally uncapped. */
 export function effectiveFallbackDelay(
 	baseDelayMs: number,
 	maxDelayMs: number,
 	attemptK: number,
-	retryAfterMs: number | undefined,
 	random: () => number = Math.random,
 ): number {
-	return Math.max(cappedExponentialWithFullJitter(baseDelayMs, maxDelayMs, attemptK, random), retryAfterMs ?? 0);
+	return cappedExponentialWithFullJitter(baseDelayMs, maxDelayMs, attemptK, random);
 }

--- a/packages/coding-agent/test/agent-session-fallback-attempt-accounting.test.ts
+++ b/packages/coding-agent/test/agent-session-fallback-attempt-accounting.test.ts
@@ -108,13 +108,13 @@ describe("effective fallback delay precedence", () => {
 		expect(cappedExponentialWithFullJitter(100, 10_000, 3, () => 0.5)).toBe(200);
 	});
 
-	it("Retry-After wins when larger and is never capped by maxDelayMs", () => {
-		// Retry-After (60s) far exceeds the capped exponential window (<=250ms).
-		expect(effectiveFallbackDelay(100, 250, 2, 60_000, () => 1)).toBe(60_000);
+	it("ignores Retry-After and keeps the capped exponential window", () => {
+		// Managed fallback never waits on provider hints; the configured cap applies.
+		expect(effectiveFallbackDelay(100, 250, 2, () => 1)).toBe(200);
 	});
 
-	it("jittered delay wins when it exceeds Retry-After", () => {
-		expect(effectiveFallbackDelay(1_000, 10_000, 3, 100, () => 1)).toBe(4_000);
+	it("uses attempt count for managed retry delay", () => {
+		expect(effectiveFallbackDelay(1_000, 10_000, 3, () => 1)).toBe(4_000);
 	});
 });
 

--- a/packages/coding-agent/test/agent-session-fallback-upstream-count.e2e.test.ts
+++ b/packages/coding-agent/test/agent-session-fallback-upstream-count.e2e.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from "bun:test";
 import * as path from "node:path";
 import { scheduler } from "node:timers/promises";
 import { Agent, type AgentOptions } from "@gajae-code/agent-core";
@@ -157,6 +157,7 @@ describe("AgentSession fallback upstream request counts", () => {
 	let authStorage: AuthStorage;
 	let modelRegistry: ModelRegistry;
 	let session: AgentSession | undefined;
+	let waitSpy: Mock<typeof scheduler.wait>;
 
 	beforeEach(async () => {
 		tempDir = TempDir.createSync("@fallback-upstream-count-");
@@ -165,7 +166,7 @@ describe("AgentSession fallback upstream request counts", () => {
 		authStorage.setRuntimeApiKey("openai", "openai-test-key");
 		authStorage.setRuntimeApiKey("alibaba-token-plan", "alibaba-token-plan-test-key");
 		modelRegistry = new ModelRegistry(authStorage);
-		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		waitSpy = vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
 	});
 
 	afterEach(async () => {
@@ -380,6 +381,91 @@ describe("AgentSession fallback upstream request counts", () => {
 		for (const call of calls) {
 			expect(call).toMatchObject({ fallbackManaged: true, fallbackAttempt: { attemptId: expect.any(String) } });
 		}
+	});
+
+	it("consumes three attempts before fallback despite an hours-long Retry-After", async () => {
+		const calls: string[] = [];
+		const events: AgentSessionEvent[] = [];
+		const { primary, fallback } = createSession(
+			3,
+			(model, _context, _options) => {
+				calls.push(selector(model));
+				return selector(model) === selector(primary)
+					? typedRateLimitStream(model, 8_259_000)
+					: successfulStream(model, "Recovered without waiting");
+			},
+			{ "retry.maxDelayMs": 1_000 },
+		);
+		session!.subscribe(event => events.push(event));
+
+		await session!.prompt("Advance past an hours-long Retry-After");
+		await session!.waitForIdle();
+
+		expect(calls).toEqual([selector(primary), selector(primary), selector(primary), selector(fallback)]);
+		expect(waitSpy.mock.calls.some(([delay]) => Number(delay) > 1_000)).toBe(false);
+		expect(events).toContainEqual(expect.objectContaining({ type: "auto_retry_start", delayMs: 0 }));
+		expect(session!.messages.at(-1)).toMatchObject({ role: "assistant", stopReason: "stop" });
+	});
+
+	it("ignores even short Retry-After hints when scheduling same-model retries", async () => {
+		vi.spyOn(Math, "random").mockReturnValue(1);
+		const calls: string[] = [];
+		let primaryAttempts = 0;
+		const { primary, fallback } = createSession(
+			2,
+			(model, _context, _options) => {
+				calls.push(selector(model));
+				if (selector(model) === selector(primary)) {
+					primaryAttempts += 1;
+					return primaryAttempts === 1
+						? typedRateLimitStream(model, 50)
+						: successfulStream(model, "Recovered after bounded wait");
+				}
+				return successfulStream(fallback);
+			},
+			{ "retry.maxDelayMs": 1_000, "retry.baseDelayMs": 10 },
+		);
+
+		await session!.prompt("Retry within the configured delay ceiling");
+		await session!.waitForIdle();
+
+		expect(calls).toEqual([selector(primary), selector(primary)]);
+		const waits = waitSpy.mock.calls;
+		expect(waits).toHaveLength(1);
+		expect(waits[0]?.[0]).toBe(10);
+	});
+
+	it("terminates an exhausted chain without waiting on the last long Retry-After", async () => {
+		const calls: string[] = [];
+		const events: AgentSessionEvent[] = [];
+		const { primary, fallback } = createSession(
+			3,
+			model => {
+				calls.push(selector(model));
+				return typedRateLimitStream(model, 8_259_000);
+			},
+			{ "retry.maxDelayMs": 1_000 },
+		);
+		session!.subscribe(event => events.push(event));
+
+		await session!.prompt("Exhaust every unavailable fallback candidate");
+		await session!.waitForIdle();
+
+		expect(calls).toEqual([
+			selector(primary),
+			selector(primary),
+			selector(primary),
+			selector(fallback),
+			selector(fallback),
+			selector(fallback),
+		]);
+		expect(waitSpy.mock.calls.some(([delay]) => Number(delay) > 1_000)).toBe(false);
+		expect(events.filter(event => event.type === "agent_end")).toHaveLength(1);
+		expect(session!.messages.at(-1)).toMatchObject({
+			role: "assistant",
+			stopReason: "error",
+			errorMessage: expect.stringContaining("fallback chain exhausted"),
+		});
 	});
 
 	it("keeps an opaque typed overflow budget-neutral before one rate limit advances N=1", async () => {

--- a/packages/coding-agent/test/routing-adversarial.test.ts
+++ b/packages/coding-agent/test/routing-adversarial.test.ts
@@ -55,21 +55,18 @@ describe("routing adversarial contract probes", () => {
 		expect(classifyFallbackTrigger({ kind: "transport", status: 429 })).toEqual({ class: "rate_limit" });
 	});
 
-	test("keeps legacy backoff capped while managed retry-after remains intentionally uncapped", () => {
+	test("keeps legacy and managed backoff capped", () => {
 		expect(cappedExponentialWithFullJitter(100, 1_000, 10, () => 1)).toBe(1_000);
 		expect(Math.min(THREE_HOURS_MS, 1_000)).toBe(1_000);
-		expect(effectiveFallbackDelay(100, 1_000, 1, THREE_HOURS_MS, () => 1)).toBe(THREE_HOURS_MS);
+		expect(effectiveFallbackDelay(100, 1_000, 10, () => 1)).toBe(1_000);
 	});
 
-	// Mirror image of the contract above: auto-compaction recovers Retry-After by
-	// regex over provider error prose, so it is legacy and MUST stay capped.
-	// Managed fallback is uncapped only because it retries within its own
-	// per-entry budget; compaction has no such budget.
+	// Auto-compaction retains its legacy capped provider-hint policy.
 	test("caps legacy compaction retry-after at retry.maxDelayMs", () => {
 		// A hostile/misconfigured provider asking for 3h cannot outrun the cap.
 		expect(compactionRetryDelay(100, 1_000, 0, THREE_HOURS_MS)).toBe(1_000);
-		// Same hint, managed fallback path: still honoured verbatim.
-		expect(effectiveFallbackDelay(100, 1_000, 1, THREE_HOURS_MS, () => 1)).toBe(THREE_HOURS_MS);
+		// Managed fallback uses only attempt-based backoff.
+		expect(effectiveFallbackDelay(100, 1_000, 1, () => 1)).toBe(100);
 	});
 
 	test("compaction retry delay honours hints below the cap and keeps exponential growth", () => {


### PR DESCRIPTION
## Summary
Closes #5396.

- Remove Retry-After from managed fallback retry-delay calculation; use existing capped exponential full jitter and per-entry attempt budgets.
- Record rate-limit selector suppression when advancing/exhausting an entry, not before its remaining attempts.
- Preserve legacy retry/auto-compaction policy, credential rotation and configured chain schema.
- Update session-level, accounting and adversarial regressions plus retry-policy documentation.

This deliberately changes the existing managed policy: a 429 with an hours-long Retry-After no longer parks the chain for hours. With fallback.maxAttempts=3, the primary is tried three times total before advancing. It is NOT the alternative policy of immediately skipping the primary on a long hint.

## Tradeoff and scope
Bounded retries may hit the same rate limit before the provider-recommended retry time. This policy favors the explicitly configured attempt budget and usable fallback over honoring that delay for managed same-model retries. Full selector cooldown is retained when the entry is left/exhausted.

No model resolver/task selection changes, user configuration changes, installed binary replacement or unrelated fixes are included. Earlier unrelated model-selection work was removed.

## Verification
Rebased onto dev d8a1fd5ceae56f992f39507155f6acd1769bf6fe; preserved upstream compaction-candidate additions when resolving the helper-file conflict.

- 96 tests passed across 8 focused files (2440 assertions): agent-session-fallback-upstream-count.e2e, agent-session-fallback-attempt-accounting, routing-adversarial, fallback-controller-credential-rotation, agent-session-retry-fallback, model-profile-fallback-chain.e2e, task-agent-model-overrides-fallback-chain.e2e, agent-session-fallback-cancel-idle.
- Changed TypeScript files: biome check passed.
- coding-agent check:types passed.
- git diff --check passed.
- Full coding-agent check is blocked by an existing base lint error in test/fixture-broker-cleanup.test.ts:14 (missing blank line after imports). Verified that file is unchanged relative to base. Not suppressed or bundled into this fix.

Live OpenCodex requests were attempted after the change, but primary quota had reset and returned successful responses. Final failure-to-fallback behavior is therefore verified with controlled typed HTTP429 stream fixtures, not claimed as a final live quota-exhaustion result.

## Related upstream policy
See #1368/#1369, #1370, #2377, and #3156. This proposal addresses the managed-session waiting layer left intentionally uncapped by those earlier fixes.

## Risk classification

- [ ] `low-risk`
- [x] `regression-risk`
- [ ] `high-risk`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:69493136027aa0d58510fff575cabd671abf84b754f62fc1aae7a340b4813303 reviewer:human reviewer-id:Yeachan-Heo evidence:https://github.com/Yeachan-Heo/gajae-code/pull/5397#pullrequestreview-5134041419
```

Independent exact-head review completed by Yeachan-Heo (APPROVED on 7d392044; review 5134041419, superseding the earlier CHANGES_REQUESTED gate hold 5133970114). Detailed findings in the signed review below.

