### PR TITLE
fix(sdk): avoid false shutdown failures on durable endpoint placeholders

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -46,6 +46,8 @@
 
 ### Fixed
 
+- SDK `session.close` now accepts a native payload-durable zero-byte endpoint placeholder when cleaning up a dead host. The broker no longer retries that proven placeholder as JSON and falsely reports `terminal_uncertain`; unknown or replaced artifacts remain refused.
+
 - SDK submissions that reject during post-turn cleanup no longer publish a contradictory second terminal after their correlation has already settled.
 - Paseo session imports discard unused CLI stdout instead of leaving an unread pipe.
 - SDK live-attach streams preserve producer order across text deltas, final messages, and tool events even when asynchronous extension handlers are slow, without replaying or broadcasting turn content. Content observed while the correlated `agent_start` is still being durably recorded is held and released after the start frame, so no consumer sees turn content before the turn it belongs to; held content is delivered only to the owners that held the run when it was produced, and the hold is bounded (256 events, oldest dropped with one warning) so a wedged start write can neither invert the start/content boundary nor accumulate a whole response in memory.

--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -3812,7 +3812,17 @@ async function removeExactDeadSessionEndpoint(
 			? authorizedDetachedSource
 			: candidates.find(candidate => {
 					try {
-						return fsSync.lstatSync(candidate).isFile();
+						const metadata = fsSync.lstatSync(candidate);
+						// A native-proven scrubbed placeholder is no longer endpoint JSON.
+						// Unknown empty files and nonempty replacements still require validation.
+						if (
+							durablePlaceholders?.has(path.resolve(candidate)) &&
+							metadata.isFile() &&
+							metadata.nlink === 1 &&
+							metadata.size === 0
+						)
+							return false;
+						return metadata.isFile();
 					} catch {
 						return false;
 					}

--- a/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
+++ b/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
@@ -4857,6 +4857,173 @@ test("close removes an unchanged dead endpoint with a fractional nanosecond mtim
 	}
 });
 
+test("close accepts a native durable placeholder for a dead endpoint", async () => {
+	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-broker-dead-placeholder-"));
+	const agentDir = path.join(root, "agent");
+	const stateRoot = path.join(root, ".gjc", "state");
+	const sessionId = "durable-placeholder";
+	const endpointPath = path.join(stateRoot, "sdk", `${sessionId}.json`);
+	const deadPid = 4_194_304;
+	const broker = new Broker({ agentDir });
+	const originalKill = process.kill;
+	let sigkillAttempts = 0;
+	try {
+		expect(() => process.kill(deadPid, 0)).toThrow();
+		await fs.mkdir(path.dirname(endpointPath), { recursive: true });
+		await fs.writeFile(
+			endpointPath,
+			JSON.stringify({ sessionId, pid: deadPid, url: "ws://127.0.0.1:1", token: "durable-placeholder" }),
+		);
+		const endpointMtimeMs = (await fs.stat(endpointPath)).mtimeMs;
+		await broker.start();
+		await broker.index.append({
+			type: "host_registered",
+			sessionId,
+			locator: { cwd: root, worktreeRoot: null, stateRoot },
+			endpointGeneration: 1,
+			pid: deadPid,
+			processIncarnation: "dead-incarnation",
+			endpointMtimeMs,
+		});
+		const originalExactUnlink = native.exactUnlink.bind(native);
+		const unlinkSpy = vi.spyOn(native, "exactUnlink").mockImplementation((pathname, identity) => {
+			if (path.resolve(pathname) !== endpointPath) return originalExactUnlink(pathname, identity);
+			if (!identity.quarantineName) throw new Error("Expected endpoint cleanup quarantine name.");
+			const detachedPath = path.join(path.dirname(pathname), identity.quarantineName);
+			const retainedPlaceholderPath = path.join(path.dirname(pathname), ".gjc-exact-unlink-placeholder-fixture");
+			syncFs.renameSync(pathname, detachedPath);
+			syncFs.truncateSync(detachedPath, 0);
+			syncFs.writeFileSync(retainedPlaceholderPath, "");
+			return {
+				ok: false,
+				code: "cleanup_pending",
+				payloadDurable: true,
+				detachedPath,
+				retainedPlaceholderPath,
+			};
+		});
+		process.kill = ((pid: number, signal?: NodeJS.Signals | number) => {
+			if (pid === deadPid && signal === "SIGKILL") sigkillAttempts += 1;
+			return originalKill(pid, signal);
+		}) as typeof process.kill;
+		try {
+			expect(await broker.handleRequest("session.close", { sessionId }, "durable-placeholder-close")).toMatchObject({
+				ok: true,
+				result: { sessionId },
+			});
+		} finally {
+			unlinkSpy.mockRestore();
+		}
+		expect(sigkillAttempts).toBe(0);
+		await expect(fs.access(endpointPath)).rejects.toThrow();
+		expect(broker.index.listSessions().sessions).toEqual([
+			expect.objectContaining({ sessionId, terminal: true, live: false }),
+		]);
+	} finally {
+		process.kill = originalKill;
+		await broker.stop();
+		await fs.rm(root, { recursive: true, force: true });
+	}
+}, 15_000);
+
+test("close refuses an unknown empty endpoint placeholder", async () => {
+	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-broker-unknown-placeholder-"));
+	const stateRoot = path.join(root, ".gjc", "state");
+	const endpointPath = path.join(stateRoot, "sdk/unknown-placeholder.json");
+	const broker = new Broker({ agentDir: path.join(root, "agent") });
+	try {
+		const deadPid = 4_194_304;
+		await fs.mkdir(path.dirname(endpointPath), { recursive: true });
+		await fs.writeFile(endpointPath, JSON.stringify({ sessionId: "unknown-placeholder", pid: deadPid }));
+		const endpointMtimeMs = (await fs.stat(endpointPath)).mtimeMs;
+		await broker.start();
+		await broker.index.append({
+			type: "host_registered",
+			sessionId: "unknown-placeholder",
+			locator: { cwd: root, worktreeRoot: null, stateRoot },
+			endpointGeneration: 1,
+			pid: deadPid,
+			processIncarnation: "dead-incarnation",
+			endpointMtimeMs,
+		});
+		const unlinkSpy = vi.spyOn(native, "exactUnlink").mockImplementation(pathname => {
+			syncFs.truncateSync(pathname, 0);
+			return { ok: false, code: "cleanup_pending", payloadDurable: true };
+		});
+		try {
+			expect(
+				await broker.handleRequest(
+					"session.close",
+					{ sessionId: "unknown-placeholder" },
+					"unknown-placeholder-close",
+				),
+			).toMatchObject({ ok: false, error: { code: "terminal_uncertain" } });
+		} finally {
+			unlinkSpy.mockRestore();
+		}
+		expect(syncFs.lstatSync(endpointPath).size).toBe(0);
+	} finally {
+		await broker.stop();
+		await fs.rm(root, { recursive: true, force: true });
+	}
+}, 15_000);
+
+test("close refuses a nonempty replacement of a durable endpoint placeholder", async () => {
+	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-broker-replaced-placeholder-"));
+	const stateRoot = path.join(root, ".gjc", "state");
+	const sessionId = "replaced-placeholder";
+	const endpointPath = path.join(stateRoot, "sdk", `${sessionId}.json`);
+	const broker = new Broker({ agentDir: path.join(root, "agent") });
+	try {
+		const deadPid = 4_194_304;
+		await fs.mkdir(path.dirname(endpointPath), { recursive: true });
+		await fs.writeFile(endpointPath, JSON.stringify({ sessionId, pid: deadPid }));
+		const endpointMtimeMs = (await fs.stat(endpointPath)).mtimeMs;
+		await broker.start();
+		await broker.index.append({
+			type: "host_registered",
+			sessionId,
+			locator: { cwd: root, worktreeRoot: null, stateRoot },
+			endpointGeneration: 1,
+			pid: deadPid,
+			processIncarnation: "dead-incarnation",
+			endpointMtimeMs,
+			lifecycleRequestId: "replaced-placeholder-request",
+		});
+		const originalExactUnlink = native.exactUnlink.bind(native);
+		let detachedPath: string | undefined;
+		const unlinkSpy = vi.spyOn(native, "exactUnlink").mockImplementation((pathname, identity) => {
+			if (path.resolve(pathname) !== endpointPath) return originalExactUnlink(pathname, identity);
+			if (!identity.quarantineName) throw new Error("Expected endpoint cleanup quarantine name.");
+			detachedPath = path.join(path.dirname(pathname), identity.quarantineName);
+			syncFs.renameSync(pathname, detachedPath);
+			syncFs.writeFileSync(detachedPath, JSON.stringify({ sessionId, pid: deadPid, replacement: true }));
+			return {
+				ok: false,
+				code: "cleanup_pending",
+				payloadDurable: true,
+				detachedPath,
+				retainedPlaceholderPath: path.join(path.dirname(pathname), ".gjc-exact-unlink-placeholder-fixture"),
+			};
+		});
+		try {
+			expect(await broker.handleRequest("session.close", { sessionId }, "replaced-placeholder-close")).toMatchObject(
+				{
+					ok: false,
+					error: { code: "terminal_uncertain" },
+				},
+			);
+		} finally {
+			unlinkSpy.mockRestore();
+		}
+		if (!detachedPath) throw new Error("Expected retained replacement path.");
+		expect(JSON.parse(await fs.readFile(detachedPath, "utf8"))).toMatchObject({ replacement: true });
+	} finally {
+		await broker.stop();
+		await fs.rm(root, { recursive: true, force: true });
+	}
+}, 15_000);
+
 test("startup cleanup accepts a payload-durable scrubbed endpoint placeholder", async () => {
 	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-broker-scrubbed-endpoint-"));
 	const agentDir = path.join(root, "agent");


### PR DESCRIPTION
## What

Fix the reproduced `restart:sdk-broker --close-session-hosts` failure: dead-host cleanup no longer reselects a native-proven, scrubbed zero-byte endpoint placeholder and attempts to parse it as JSON. Unknown empty artifacts and nonempty replacements remain refused.

## Why

Native endpoint deletion can durably scrub an endpoint payload while retaining an empty placeholder. Re-reading that proven placeholder as JSON falsely reported `terminal_uncertain` after the host had already exited.

## Testing

- `bun test ./packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts ./packages/coding-agent/test/sdk-broker-lifecycle-cleanup.test.ts ./scripts/restart-sdk-broker.test.ts` — 129 passed, 0 failed, 643 expectations, with ambient GJC lifecycle variables removed.
- `bun node_modules/typescript/bin/tsc -p packages/coding-agent/tsconfig.json --noEmit` — passed.
- Focused Biome check, `git diff --check`, and `bun scripts/verify-gjc-state-writers.ts --fail --root .` — passed; writer gate reported 0 violations.

## Risk classification

- [ ] `low-risk`
- [x] `regression-risk` — narrowly scoped lifecycle cleanup change; exact-head independent review required.
- [ ] `high-risk`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:c9005d078a9d01f000af0cbde4b17c8a989b0834433c2c5850e0431f8b765411 reviewer:human reviewer-id:Yeachan-Heo evidence:https://github.com/Yeachan-Heo/gajae-code/pull/5404#pullrequestreview-5137849621; exact-head lifecycle tests and local gates passed
```

- [x] Target branch is `dev`
- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated
- [x] Verdict above matches the exact PR head f0a1979631deedcbc2ea5eb8bef53ad2ec8f1d4d and immutable base 4dba402157d1ad482222364958dcd619ebad99fe
- [x] Risk classification matches the destructive lifecycle review path

