### PR TITLE
fix(lock): retain dead-owner stale-removal refusal diagnostics

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Fixed
 
+- File-lock acquisition timeouts now retain the last stale-removal refusal instead of hiding it behind `dead but not reaped`. Exact-removal and live-owner protections are unchanged.
 - A failing `gjc --smoke-test` no longer leaves its isolated-shell worker behind. The readiness bail-out ran a `finally` that only removed marker files, so the probe shell stayed alive and its abandoned run went unobserved; the wider readiness/run deadlines made that window long. Teardown now aborts the probe, retires the worker, and observes the run on every exit path — graceful close alone would have waited out the command’s own sleep.
 
 ## [0.16.6] - 2026-09-07

--- a/packages/coding-agent/src/config/file-lock.ts
+++ b/packages/coding-agent/src/config/file-lock.ts
@@ -980,16 +980,23 @@ async function staleLockSnapshot(
 	return { stale: false };
 }
 
-async function removeStaleLockForAcquire(lockPath: string, snapshot: LockStaleSnapshot): Promise<boolean> {
-	if (!snapshot.stale) return false;
+async function removeStaleLockForAcquire(
+	lockPath: string,
+	snapshot: LockStaleSnapshot,
+): Promise<{ removed: boolean; refusal?: string }> {
+	if (!snapshot.stale) return { removed: false };
 	try {
-		return (await removeFileLockDirForGc(lockPath, snapshot.owner, snapshot.identity)) === "removed";
-	} catch {
+		const result = await removeFileLockDirForGc(lockPath, snapshot.owner, snapshot.identity);
+		return result === "removed" ? { removed: true } : { removed: false, refusal: result };
+	} catch (error) {
 		// Exact removal refusal is not authority to fail or mutate by another path.
 		// Keep contending: a concurrent reclaimer may already be completing the same
 		// dead generation, while a persistent refusal remains fail-closed until the
 		// normal retry budget reports the still-held lock.
-		return false;
+		return {
+			removed: false,
+			refusal: error instanceof Error ? error.message : "unknown removal failure",
+		};
 	}
 }
 
@@ -1410,6 +1417,7 @@ export async function acquireFileLock(filePath: string, options: FileLockOptions
 	}
 	const ownerToken = crypto.randomUUID();
 	const contentionStartTimes = new Map<string, string | null>();
+	let lastStaleRemovalRefusal: string | undefined;
 	for (let attempt = 0; attempt < opts.retries; attempt++) {
 		if (opts.signal?.aborted) throw opts.signal.reason ?? new Error("File lock acquisition aborted");
 		const localKey = await localLockKey(lockPath);
@@ -1441,7 +1449,9 @@ export async function acquireFileLock(filePath: string, options: FileLockOptions
 			opts.previousOwnerHostIds,
 			contentionStartTimes,
 		);
-		if (await removeStaleLockForAcquire(lockPath, stale)) continue;
+		const removal = await removeStaleLockForAcquire(lockPath, stale);
+		lastStaleRemovalRefusal = removal.refusal;
+		if (removal.removed) continue;
 		if (!opts.signal) {
 			await Bun.sleep(opts.retryDelayMs);
 			continue;
@@ -1456,7 +1466,13 @@ export async function acquireFileLock(filePath: string, options: FileLockOptions
 			opts.signal.removeEventListener("abort", onAbort);
 		}
 	}
-	throw new FileLockAcquireError(filePath, lockPath, opts.retries, await lockHolderDescription(lockPath));
+	const holder = await lockHolderDescription(lockPath);
+	throw new FileLockAcquireError(
+		filePath,
+		lockPath,
+		opts.retries,
+		lastStaleRemovalRefusal ? `${holder}; last stale removal refused: ${lastStaleRemovalRefusal}` : holder,
+	);
 }
 
 /**

--- a/packages/coding-agent/test/file-lock-gc-toctou.test.ts
+++ b/packages/coding-agent/test/file-lock-gc-toctou.test.ts
@@ -687,6 +687,46 @@ describe("host-qualified file lock publication", () => {
 	});
 });
 describe("file lock cleanup failure handling (#2478)", () => {
+	test.each([
+		"quarantine_collision",
+		"identity_mismatch",
+	] as const)("reports %s when dead-owner removal keeps failing without stealing the lock", async code => {
+		const lockedFile = path.join(await makeTemp(), "state.json");
+		const lockDir = `${lockedFile}.lock`;
+		await writeInfo(lockDir, { pid: DEAD_PID, timestamp: Date.now() - 60_000 });
+		const originalInfo = await Bun.file(path.join(lockDir, "info")).text();
+		const realKill = process.kill;
+		vi.spyOn(process, "kill").mockImplementation((pid, signal) => {
+			if (pid === DEAD_PID) throw Object.assign(new Error("dead owner"), { code: "ESRCH" });
+			return realKill(pid, signal);
+		});
+		let attempts = 0;
+		FileLockTestHooks.nativeQuarantineBindings = () => ({
+			snapshotDirectoryTree,
+			exactRemoveDirectoryTree: () => {
+				attempts++;
+				return { ok: false, code };
+			},
+		});
+		let entered = false;
+		const pending = withFileLock(
+			lockedFile,
+			async () => {
+				entered = true;
+			},
+			{ retries: 2, retryDelayMs: 1 },
+		);
+		await expect(pending).rejects.toBeInstanceOf(FileLockAcquireError);
+		await expect(pending).rejects.toThrow(
+			code === "identity_mismatch"
+				? "last stale removal refused: owner_changed"
+				: "last stale removal refused: Failed to remove file lock tree: quarantine_collision.",
+		);
+		expect(attempts).toBe(2);
+		expect(entered).toBe(false);
+		expect(await Bun.file(path.join(lockDir, "info")).text()).toBe(originalInfo);
+	});
+
 	test("refuses generic release without pre-verdict identity instead of capturing a successor", async () => {
 		const base = await makeTemp();
 		const lockedFile = path.join(base, "state.json");


### PR DESCRIPTION
## Status: diagnostic prerequisite, NOT a verified startup fix
The reported macOS startup failed acquiring `sdk/sessions/index.jsonl` after 600 attempts and described PID 24712 as `dead but not reaped`. That phrase is emitted after an ESRCH/dead verdict; it is not evidence of a zombie process.

The historical lock is no longer present. A fresh native build and current baseline session-index tests pass. The incident's exact removal refusal cannot currently be established. Keep this PR draft until the underlying incident is reproduced or its refusal evidence is recovered.

## Source-proven defect addressed
`removeStaleLockForAcquire` discarded both guarded-removal outcomes and exceptions. Exhaustion therefore hid whether native removal hit a quarantine collision, identity change, or another refusal. This patch retains the final attempt's refusal in the existing typed acquisition error, clearing it on a subsequent attempt that no longer attempts stale removal.

No liveness rules, timestamp/identity fences, native removal authority, retry limits, or live runtime files are changed. No speculative zombie workaround or timestamp-check removal is included.

## Verification
- Native bindings built on macOS arm64.
- `bun test packages/coding-agent/test/file-lock-gc-toctou.test.ts packages/coding-agent/test/sdk-session-index-lock-contention.test.ts`: 193 passed, 3 skipped, 0 failed (6 files including test imports).
- New deterministic regressions cover quarantine collision and identity mismatch, assert refusal diagnostics, and verify the lock remains unchanged and the critical section is never entered.
- `bun --cwd=packages/coding-agent run check:types`: passed.
- Focused Biome checks and `git diff --check`: passed.

## Unresolved
Capture the refusal from a reproduced startup before choosing a recovery fix. The original crash has not been reproduced or claimed fixed, and the currently installed GJC binary has not been replaced.