### PR TITLE
chore(github): automatically request repository reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Automatically request reviews for all changes; GitHub excludes the PR author.
+* @snowykr @Yeachan-Heo @probepark


### PR DESCRIPTION
## Summary
- Add `.github/CODEOWNERS` for every changed path.
- Automatically request `snowykr`, `Yeachan-Heo`, and `probepark`, based on #5411 plus the requesting user.
- GitHub excludes the PR author. Draft PRs receive automatic requests when marked ready for review.
- Automatic requests apply once this file exists on the PR base branch; they do not retroactively update existing PRs.

## Verification
- Confirmed all three accounts have write/admin repository access.
- Validated the exact all-paths ownership rule.
- `git diff --check` passed.
- Actual automatic assignment is not tested before merge into the base branch.

No product runtime behavior changed; product tests and changelogs are unchanged.