### PR TITLE
fix(mcp): clarify quarantined public command boundary

### DIFF
--- a/docs/standalone-mcp.md
+++ b/docs/standalone-mcp.md
@@ -32,7 +32,19 @@ Malformed or unparseable definitions are skipped fail-closed: they are never par
 
 Pass `--no-mcp` to skip conventional autoload for one session (plugin-bundle MCPs and exact-file `--mcp-config` remain governed by their own surfaces). `--no-mcp` and `--mcp-config` are mutually exclusive.
 
-### Subagents and lifecycle
+## Public slash-command boundary
+
+The ordinary interactive TUI and ACP slash-command surfaces intentionally do not
+register a top-level `/mcp` command. `/mcp test`, `/mcp reauth`, `/mcp
+reconnect`, and `/mcp reload` are not supported user-input entry points. Use
+`gjc mcp add`, `gjc mcp list`, or `gjc mcp remove` to manage stored registrations
+and start a new session. `--mcp-config` and the SDK's `mcpConfigPath` are
+explicit connection-consumer entry points for a trusted config; they do not
+initiate MCP OAuth authorization. Existing credentials bound through `auth` may
+be refreshed by the runtime, but there is no public MCP OAuth authorization or
+reauthorization entry path, nor a public `/mcp` reconnection or reload contract.
+
+## Subagents and lifecycle
 
 Top-level sessions own their MCP manager and clean up server processes on session end. Subagents inherit the parent session's manager facade: they never spawn duplicate server processes and never take ownership of cleanup.
 
@@ -46,7 +58,7 @@ gjc --mcp-config /absolute/path/to/mcp.json
 
 The path must be absolute and identify a regular file directly; symbolic links and other indirection are rejected. GJC reads the file through one open handle and rejects it if the path, file identity, size, or modification metadata changes during the read. Exact-file mode **replaces** conventional autoload: it exposes only that file's MCP tools and does not overlay `.gjc/mcp.json` registrations from either scope. GJC owns the server processes for that session. It does not load server prompts, resources, instructions, sampling, or other config files. Expected read, parse, validation, and connection failures emit one sanitized warning and continue. Unexpected errors and final-catalog tool-name collisions clean up and abort startup.
 
-There is no MCP config reload while the session runs except `/mcp reload` in sessions without plugin-bundle MCP servers, and no subagent inheritance of exact-file tools beyond the parent session's exposed catalog.
+There is no public MCP config reload while the session runs; edit the config and start a new session. There is no subagent inheritance of exact-file tools beyond the parent session's exposed catalog.
 
 ## Supported integrations
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - File-lock acquisition now fences retained `.removing` transitions on macOS as well as Linux, preventing successor publication from racing predecessor cleanup and wedging session-index locking with `quarantine_collision`. Raced publications roll back only after exact-identity verification; unowned transitions remain untouched and produce bounded contention diagnostics.
 - A failing `gjc --smoke-test` no longer leaves its isolated-shell worker behind. The readiness bail-out ran a `finally` that only removed marker files, so the probe shell stayed alive and its abandoned run went unobserved; the wider readiness/run deadlines made that window long. Teardown now aborts the probe, retires the worker, and observes the run on every exit path — graceful close alone would have waited out the command’s own sleep.
+- Public MCP guidance now states the shipped boundary precisely: ordinary standalone interactive and ACP sessions do not expose `/mcp` OAuth, test, reconnect, or reload commands; `--mcp-config` and the SDK's `mcpConfigPath` consume trusted connection configs but do not initiate MCP OAuth authorization, while existing `auth` bindings remain runtime-owned for refresh. `gjc customize doctor` now reports that MCP changes require a new session instead of contradicting that startup-only contract.
 
 ## [0.16.6] - 2026-09-07
 ### Fixed

--- a/packages/coding-agent/src/cli/customize-doctor.ts
+++ b/packages/coding-agent/src/cli/customize-doctor.ts
@@ -297,10 +297,11 @@ const TRUST_BY_KIND: Record<CustomizeSurfaceKind, string> = {
 };
 
 /** Whether a restart/new session is required for changes to take effect. */
-function restartRequiredFor(kind: CustomizeSurfaceKind): boolean {
-	// MCP startup set is fixed when the session starts; every other surface is
-	// also fixed at session startup.
-	return kind !== "mcp";
+function restartRequiredFor(_kind: CustomizeSurfaceKind): boolean {
+	// Every customization projection describes startup-owned state. MCP is not
+	// an in-session public reload surface, so it follows the same contract as
+	// every other customization kind.
+	return true;
 }
 
 function sourceClassFor(provider: string): CustomizeSourceClass {
@@ -1406,7 +1407,7 @@ function foreignMcpItem(
 		scope: "project",
 		path: server._source.path,
 		trust: TRUST_BY_KIND.mcp,
-		restartRequired: false,
+		restartRequired: restartRequiredFor("mcp"),
 		precedence: { priority: 0, shadowedBy },
 	};
 	return {

--- a/packages/coding-agent/src/config/mcp-schema.json
+++ b/packages/coding-agent/src/config/mcp-schema.json
@@ -92,7 +92,7 @@
           "type": "string"
         }
       },
-      "description": "Client settings consumed by the interactive OAuth authorization flow (for example /mcp reauth). Refreshing an already-stored credential does not read these: it uses the separate `auth` binding's clientId/clientSecret."
+      "description": "Client settings for an explicit MCP OAuth authorization consumer. These fields do not define a public standalone or ACP slash-command flow: those sessions do not expose /mcp reauth, /mcp test, or /mcp reconnect, and no public MCP OAuth authorization or reauthorization entry path is provided. Refreshing an already-stored credential does not read these: it uses the separate `auth` binding's clientId/clientSecret."
     },
     "serverBase": {
       "type": "object",

--- a/packages/coding-agent/test/customize-doctor.test.ts
+++ b/packages/coding-agent/test/customize-doctor.test.ts
@@ -124,6 +124,7 @@ describe("customize doctor (#4288)", () => {
 			status: "ignored",
 			reason: "source-ignored",
 		});
+		expect(mcps.get("fixture-claude-mcp")?.restartRequired).toBe(true);
 		// Import candidates are never active runtime authority.
 		expect(mcps.get("fixture-claude-mcp")?.mcp?.connectable).toBe(false);
 
@@ -431,7 +432,10 @@ describe("customize doctor (#4288)", () => {
 		);
 		await makeSkill(path.join(cwd, ".claude", "skills"), "fixture-foreign", "Never loaded by startup");
 		await writeJson(path.join(cwd, ".gjc", "mcp.json"), {
-			mcpServers: { "fixture-connectable": { command: "true" } },
+			mcpServers: {
+				"fixture-connectable": { command: "true" },
+				"fixture-autoload-off": { command: "true", autoload: false },
+			},
 		});
 
 		const settings = Settings.isolated({});
@@ -477,6 +481,8 @@ describe("customize doctor (#4288)", () => {
 		expect(Object.keys(projection.configs)).toContain("fixture-connectable");
 		expect(fixture?.mcp?.connectable).toBe(true);
 		expect(fixture?.status).toBe("stored-only");
+		expect(fixture?.restartRequired).toBe(true);
+		expect(mcps.get("fixture-autoload-off")?.restartRequired).toBe(true);
 	});
 	it("disabled native provider does not shadow an enabled lower-priority source (bug A)", async () => {
 		const cwd = await makeTempProject();

--- a/packages/coding-agent/test/mcp-quarantine-surface.test.ts
+++ b/packages/coding-agent/test/mcp-quarantine-surface.test.ts
@@ -50,4 +50,22 @@ describe("GJC MCP quarantine surface", () => {
 		expect(systemPrompt).not.toContain("mcp://");
 		expect(interactiveMode).not.toContain("MCPCommandController");
 	});
+
+	it("keeps public MCP guidance aligned with the slash-command quarantine", async () => {
+		const schema = await Bun.file(
+			path.join(repoRoot, "packages", "coding-agent", "src", "config", "mcp-schema.json"),
+		).text();
+		const standaloneMcp = await Bun.file(path.join(repoRoot, "docs", "standalone-mcp.md")).text();
+		const normalizedStandaloneMcp = standaloneMcp.replace(/\s+/g, " ");
+
+		expect(schema).not.toContain("for example /mcp reauth");
+		expect(schema).toContain("no public MCP OAuth authorization or reauthorization entry path is provided");
+		expect(normalizedStandaloneMcp).toContain("do not register a top-level `/mcp` command");
+		expect(normalizedStandaloneMcp).toContain("they do not initiate MCP OAuth authorization");
+		expect(normalizedStandaloneMcp).toContain(
+			"there is no public MCP OAuth authorization or reauthorization entry path",
+		);
+		expect(normalizedStandaloneMcp).toContain("nor a public `/mcp` reconnection or reload contract");
+		expect(normalizedStandaloneMcp).not.toContain("except `/mcp reload`");
+	});
 });


### PR DESCRIPTION
## What

Align MCP schema, standalone documentation, and customize-doctor metadata with the shipped public boundary: ordinary interactive and ACP sessions do not expose `/mcp` commands, and startup-owned MCP changes require a new session. Add regression coverage without wiring the quarantined controller or changing runtime connection policy.

## Why

Fixes #5406. The merged #5400 guidance described `/mcp reauth` as a live path even though the interactive dispatcher warns that MCP commands are unavailable and ACP intentionally falls through. The correction names the supported config/connection consumers while explicitly stating that they do not initiate MCP OAuth authorization.

## Testing

- `bun test packages/coding-agent/test/mcp-quarantine-surface.test.ts packages/coding-agent/test/acp-builtins.test.ts packages/coding-agent/test/customize-doctor.test.ts` — 94 passed.
- `bun test packages/coding-agent/test/mcp-cli.test.ts packages/coding-agent/test/runtime-mcp/mcp-autoload-precedence.test.ts` — 27 passed.
- `bun run check:schemas`, `bun run check:public-sync`, Bun-native TypeScript checks, and Bun Biome check passed.
- The 3 failing cases in `mcp-autoload-redteam.test.ts` reproduce on clean current `dev` (`d2f30f5c2d198e5dee6240428b5407f7d59ea989`) and are unrelated baseline failures; no green claim is made for that suite.

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

gajae.pr-review-verdict.v1 merge-self-approved sha256:0ed0024da6f3b98492d5db323f0036230a176660126f2221e6c1ef5e2bce03c3 reviewer:human reviewer-id:Yeachan-Heo evidence:focused Bun tests; schema/public-sync checks; exact-head GitHub CI pending

---

- [x] Target branch is `dev`
- [ ] `bun check` passes — the checkout's system Node 12 shebang cannot launch the repository Biome/tsc wrappers; equivalent Bun-native checks pass locally and CI runs on Node 20.
- [x] Tested locally
- [x] CHANGELOG updated
- [x] Verdict above matches the exact PR head `fa277994b779fe8912eec191fa7637f6a7672229` and base `d2f30f5c2d198e5dee6240428b5407f7d59ea989`
- [x] Risk classification above matches the actual review path taken

Signed exact-head self-review comment: https://github.com/Yeachan-Heo/gajae-code/pull/5414#issuecomment-5580003497

Contract record corrected and revalidated against the canonical signed-payload format.