### PR TITLE
fix(coordinator): preserve null errors in public responses

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Fixed
 
+- Coordinator responses now preserve `error: null` instead of replacing it with an `unavailable` error. Non-null errors still use fixed public messages, and unknown error codes remain mapped to `unavailable`.
 - File-lock acquisition now fences retained `.removing` transitions on macOS as well as Linux, preventing successor publication from racing predecessor cleanup and wedging session-index locking with `quarantine_collision`. Raced publications roll back only after exact-identity verification; unowned transitions remain untouched and produce bounded contention diagnostics.
 - A failing `gjc --smoke-test` no longer leaves its isolated-shell worker behind. The readiness bail-out ran a `finally` that only removed marker files, so the probe shell stayed alive and its abandoned run went unobserved; the wider readiness/run deadlines made that window long. Teardown now aborts the probe, retires the worker, and observes the run on every exit path — graceful close alone would have waited out the command’s own sleep.
 - Public MCP guidance now states the shipped boundary precisely: ordinary standalone interactive and ACP sessions do not expose `/mcp` OAuth, test, reconnect, or reload commands; `--mcp-config` and the SDK's `mcpConfigPath` consume trusted connection configs but do not initiate MCP OAuth authorization, while existing `auth` bindings remain runtime-owned for refresh. `gjc customize doctor` now reports that MCP changes require a new session instead of contradicting that startup-only contract.

--- a/packages/coding-agent/src/coordinator-mcp/server.ts
+++ b/packages/coding-agent/src/coordinator-mcp/server.ts
@@ -1377,7 +1377,7 @@ function boundedPublicValue(value: unknown, budget: { remaining: number }, depth
 	const output: Record<string, unknown> = {};
 	for (const key of Object.keys(value as Record<string, unknown>).slice(0, 128)) {
 		const field = (value as Record<string, unknown>)[key];
-		if (key === "error") {
+		if (key === "error" && field !== null) {
 			const rawCode =
 				field && typeof field === "object" && !Array.isArray(field)
 					? (field as Record<string, unknown>).code

--- a/packages/coding-agent/test/coordinator-mcp-server.test.ts
+++ b/packages/coding-agent/test/coordinator-mcp-server.test.ts
@@ -9232,6 +9232,51 @@ describe("Coordinator MCP deep-audit regressions", () => {
 		expect(JSON.stringify(scoped)).toContain("audit-evidence.txt");
 	});
 
+	it.each([
+		{ code: null, expectedError: null },
+		{
+			code: "timeout",
+			expectedError: { code: "timeout", message: "Coordinator request timed out." },
+		},
+		{
+			code: "hostile_sdk_code",
+			expectedError: { code: "unavailable", message: "Coordinator service is unavailable." },
+		},
+	])("preserves null and sanitizes public turn errors ($code)", async ({ code, expectedError }) => {
+		const root = await tempRoot();
+		const server = await createSdkControlServer(root, []);
+		await registerSdkSession(server, root);
+		const sent = await server.callTool("gjc_coordinator_send_prompt", {
+			session_id: "visible-session",
+			prompt: "public error serialization",
+			idempotency_key: "public-error-serialization",
+			allow_mutation: true,
+		});
+		expect(sent).toMatchObject({ ok: true });
+		if (code === null) {
+			expect((sent.turn as Record<string, unknown>).error).toBeNull();
+		} else {
+			const paths = coordinatorStatePaths(server.config.stateRoot, server.config.namespace.identity);
+			await withSessionTransaction(paths, "visible-session", async transaction => {
+				const turn = transaction.canonical.turns[String(sent.turn_id)];
+				if (!turn) throw new Error("missing turn");
+				turn.error = {
+					code,
+					message: "Bearer secret-token https://controller.example.test/private /Users/secret/project",
+					recoverable: true,
+				};
+			});
+		}
+		const read = await server.callTool("gjc_coordinator_read_turn", { turn_id: sent.turn_id });
+		expect(read).toMatchObject({ ok: true, turn: { turn_id: sent.turn_id } });
+		expect((read.turn as Record<string, unknown>).error).toEqual(expectedError);
+		const status = await server.callTool("gjc_coordinator_read_coordination_status", {
+			session_id: "visible-session",
+		});
+		expect(status).toMatchObject({ ok: true, turns: [{ turn_id: sent.turn_id }] });
+		expect((status.turns as Array<Record<string, unknown>>)[0]!.error).toEqual(expectedError);
+	});
+
 	it("maps hostile SDK failures to fixed public errors", async () => {
 		const root = await tempRoot();
 		const hostile = "Bearer secret-token https://controller.example.test/private /Users/secret/project";


### PR DESCRIPTION
## What

Preserve `error: null` in public Coordinator responses instead of converting it to `{ code: "unavailable", message: "Coordinator service is unavailable." }`.

The production change is one conditional. Add three regression cases through the public send/read/status response paths covering null, known errors and unknown error codes.

## Why

Successful Coordinator calls could contain a fabricated nested `unavailable` error even when the underlying turn had no error. Real error-code allowlisting and fixed public messages must remain unchanged.

This does not fix broker startup, turn completion reconciliation, or relay delivery.

## Testing

Exact head: `10e3f35552e6c4916c43c39c7fc836e0c432607f`; base: `411b7f3809cec3949edeb6a60a767495c5639a96`.

- `bun run build:native`: passed (matching 0.16.6 native module).
- `bun test packages/coding-agent/test/coordinator-mcp-server.test.ts`: 313 passed, 2 existing platform-specific skips, 0 failed.
- Focused null/error cases plus hostile SDK error regression: 4 passed, 0 failed.
- `bun scripts/verify-gjc-state-writers.ts --fail`: passed; no writers outside allowlist.
- `git diff --check`: passed.
- Before the fix, the null regression failed because it received a fabricated unavailable error.

Limitations: full `bun check`, packaged-binary/live Coordinator E2E and non-macOS runs are not claimed. The final companion commit adds only an Unreleased changelog line; production/test bytes are unchanged from the full-suite-tested head 77c14a6f4, and the focused tests were rerun on the final head.

## Risk classification

- [x] `low-risk` — narrow correction preserving the existing null error value; real error sanitization is unchanged.
- [ ] `regression-risk`
- [ ] `high-risk`

## GJC verdict

Needs independent maintainer review; no self-approval or merge authorization is claimed.

```text
gajae.pr-review-verdict.v1 merge-approved sha256:c157410b19a96d9b7f799fd0984cd78382b79083253d0bea475a6b71ddab0a96 reviewer:architect reviewer-id:snowykr evidence:https://github.com/Yeachan-Heo/gajae-code/pull/5416#pullrequestreview-5142141819
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken
