### PR TITLE
fix(computer): repair key lifecycle (Replaces closed PR #3576)

### DIFF
--- a/crates/pi-natives/src/computer/controller.rs
+++ b/crates/pi-natives/src/computer/controller.rs
@@ -774,4 +774,29 @@ mod tests {
 
 		assert_eq!(error.code(), "COMPUTER_SCREENSHOT_FAILED");
 	}
+
+	#[test]
+	fn keyboard_backend_errors_survive_napi_and_batch_primary_mapping() {
+		let primary = ExecError::ActionFailed {
+			index:  1,
+			source: Box::new(ExecError::KeyEventCreationFailed { code: 36, down: false }),
+		};
+		let direct = exec_error(primary.clone());
+		assert_eq!(direct.status, napi::Status::GenericFailure);
+		assert!(direct.reason.starts_with("COMPUTER_KEY_EVENT_FAILED:"));
+		assert!(direct.reason.contains("key-up event for virtual key 36"));
+		let result = batch_failure(Vec::new(), primary.clone(), None);
+		assert_eq!(result.failure_code.as_deref(), Some("COMPUTER_KEY_EVENT_FAILED"));
+		assert_eq!(result.failure_index, Some(1));
+		assert_eq!(result.failure_message, Some(primary.to_string()));
+		let result = batch_failure(
+			Vec::new(),
+			ExecError::CursorRestoreFailed { primary: Some(Box::new(primary.clone())) },
+			None,
+		);
+		assert_eq!(result.failure_code.as_deref(), Some("COMPUTER_CURSOR_RESTORE_FAILED"));
+		assert_eq!(result.failure_index, Some(1));
+		assert_eq!(result.primary_failure_code.as_deref(), Some("COMPUTER_KEY_EVENT_FAILED"));
+		assert_eq!(result.primary_failure_message, Some(primary.to_string()));
+	}
 }

--- a/crates/pi-natives/src/computer/executor.rs
+++ b/crates/pi-natives/src/computer/executor.rs
@@ -14,6 +14,7 @@
 //! macOS supplies the concrete permission/display providers.
 
 use std::{
+	cell::Cell,
 	panic::{AssertUnwindSafe, catch_unwind},
 	sync::{LazyLock, Mutex, TryLockError},
 	time::Duration,
@@ -81,6 +82,8 @@ pub enum ExecError {
 	Coord(CoordError),
 	/// Core Graphics failed to move the hardware cursor.
 	CursorWarpFailed(i32),
+	/// Core Graphics could not create a virtual-key event.
+	KeyEventCreationFailed { code: u16, down: bool },
 	/// The action was cancelled (AbortSignal/timeout/supervisor stop).
 	Cancelled,
 	/// A key name was not recognized.
@@ -112,6 +115,7 @@ impl ExecError {
 			Self::DisplayStale => "COMPUTER_DISPLAY_STALE",
 			Self::Coord(_) => "COMPUTER_COORD_INVALID",
 			Self::CursorWarpFailed(_) => "COMPUTER_CURSOR_WARP_FAILED",
+			Self::KeyEventCreationFailed { .. } => "COMPUTER_KEY_EVENT_FAILED",
 			Self::UnknownKey(_) => "COMPUTER_UNKNOWN_KEY",
 			Self::Cancelled => "COMPUTER_CANCELLED",
 			Self::ScreenshotFailed => "COMPUTER_SCREENSHOT_FAILED",
@@ -129,6 +133,9 @@ impl From<InputError> for ExecError {
 		match value {
 			InputError::Coord(err) => Self::Coord(err),
 			InputError::CursorWarpFailed(status) => Self::CursorWarpFailed(status),
+			InputError::KeyEventCreationFailed { code, down } => {
+				Self::KeyEventCreationFailed { code, down }
+			},
 			InputError::UnknownKey(key) => Self::UnknownKey(key),
 		}
 	}
@@ -140,6 +147,12 @@ impl std::fmt::Display for ExecError {
 			Self::Coord(err) => write!(f, "{}: {err}", self.code()),
 			Self::CursorWarpFailed(status) => {
 				write!(f, "{}: cursor warp failed with status {status}", self.code())
+			},
+			Self::KeyEventCreationFailed { code, down } => {
+				write!(f, "{}: {}", self.code(), InputError::KeyEventCreationFailed {
+					code: *code,
+					down: *down,
+				})
 			},
 			Self::UnknownKey(key) => write!(f, "{}: {key}", self.code()),
 			Self::ActionFailed { index, source } => write!(f, "action {index}: {source}"),
@@ -194,6 +207,17 @@ impl DisplayContext for MacDisplayContext {
 	}
 }
 
+fn gate_supervisor(supervisor: &Supervisor) -> Result<(), ExecError> {
+	let status = supervisor.status();
+	if status.suspended {
+		return Err(ExecError::Suspended);
+	}
+	if !status.hotkey_live || !status.heartbeat_fresh {
+		return Err(ExecError::SupervisorNotLive);
+	}
+	Ok(())
+}
+
 /// Fail-closed gate run before any side-effecting input.
 fn gate<P: PermissionGate, D: DisplayContext>(
 	action: &InputAction,
@@ -202,13 +226,7 @@ fn gate<P: PermissionGate, D: DisplayContext>(
 	display_ctx: &D,
 	expected_epoch: Option<u64>,
 ) -> Result<(), ExecError> {
-	let status = supervisor.status();
-	if status.suspended {
-		return Err(ExecError::Suspended);
-	}
-	if !status.hotkey_live || !status.heartbeat_fresh {
-		return Err(ExecError::SupervisorNotLive);
-	}
+	gate_supervisor(supervisor)?;
 	if !perms.accessibility_granted() {
 		return Err(ExecError::PermissionRequired);
 	}
@@ -285,7 +303,8 @@ where
 	);
 	let suspended = supervisor.is_suspended();
 	if result.is_err() || suspended {
-		controller.release_all();
+		// Preserve the action/stop failure; the transaction retries held releases.
+		let _ = controller.release_all();
 	}
 	if result.is_ok() && suspended {
 		Err(ExecError::Suspended)
@@ -329,8 +348,10 @@ where
 		Ok(result) => result,
 		Err(_) => Err(ExecError::TransactionPanicked),
 	};
-	if catch_unwind(AssertUnwindSafe(|| controller.release_all())).is_err() {
-		primary = Err(ExecError::TransactionPanicked);
+	match catch_unwind(AssertUnwindSafe(|| controller.release_all())) {
+		Ok(Err(err)) if primary.is_ok() => primary = Err(err.into()),
+		Err(_) => primary = Err(ExecError::TransactionPanicked),
+		_ => {},
 	}
 	let restore = catch_unwind(AssertUnwindSafe(|| hooks.restore_cursor(cursor)));
 	match restore {
@@ -398,16 +419,36 @@ where
 	D: DisplayContext,
 {
 	gate(action, supervisor, perms, display_ctx, expected_epoch)?;
-	if cancelled() {
-		return Err(ExecError::Cancelled);
-	}
-	let result = dispatch(action, display, controller, cancelled);
-	if result.is_ok() && cancelled() {
+	// Keep the typed reason at the observation that stopped the boolean-driven
+	// input loop, even if the supervisor recovers before dispatch returns.
+	let is_keypress = matches!(action, InputAction::Keypress { .. });
+	let stop_reason = Cell::new(None);
+	let stopped = || {
+		let caller_cancelled = cancelled();
+		let reason = if is_keypress {
+			gate_supervisor(supervisor).err()
+		} else {
+			None
+		}
+		.or_else(|| caller_cancelled.then_some(ExecError::Cancelled));
+		let stop = reason.is_some();
+		if stop {
+			stop_reason.set(reason);
+		}
+		stop
+	};
+	let result = if stopped() {
 		Err(ExecError::Cancelled)
-	} else if result.is_ok() && supervisor.is_suspended() {
-		Err(ExecError::Suspended)
 	} else {
-		result
+		dispatch(action, display, controller, &stopped)
+	};
+	if result.is_ok() {
+		stopped();
+	}
+	match (result, stop_reason.into_inner()) {
+		(Ok(()) | Err(ExecError::Cancelled), Some(reason)) => Err(reason),
+		(Ok(()), None) if !is_keypress && supervisor.is_suspended() => Err(ExecError::Suspended),
+		(result, _) => result,
 	}
 }
 
@@ -470,7 +511,9 @@ mod tests {
 	};
 	use crate::computer::{
 		coords::{LogicalPoint, NormalizedDisplay},
-		input::{CursorError, CursorHooks, EventSink, InputController, MouseButton, SinkOp},
+		input::{
+			CursorError, CursorHooks, EventSink, InputController, InputError, MouseButton, SinkOp,
+		},
 		supervisor::Supervisor,
 	};
 
@@ -492,9 +535,12 @@ mod tests {
 		}
 	}
 
+	type KeyHook = dyn Fn(u16, bool) -> Result<(), InputError>;
+
 	#[derive(Default)]
 	struct RecordingSink {
-		ops: Vec<SinkOp>,
+		ops:    Vec<SinkOp>,
+		on_key: Option<Box<KeyHook>>,
 	}
 	impl EventSink for RecordingSink {
 		fn move_cursor(
@@ -517,8 +563,12 @@ mod tests {
 			self.ops.push(SinkOp::TypeUnicode(text.to_string()));
 		}
 
-		fn key(&mut self, code: u16, down: bool) {
+		fn key(&mut self, code: u16, down: bool) -> Result<(), crate::computer::input::InputError> {
+			if let Some(on_key) = &self.on_key {
+				on_key(code, down)?;
+			}
 			self.ops.push(SinkOp::Key { code, down });
+			Ok(())
 		}
 	}
 	struct WarpFailSink;
@@ -537,7 +587,9 @@ mod tests {
 
 		fn type_unicode(&mut self, _text: &str) {}
 
-		fn key(&mut self, _code: u16, _down: bool) {}
+		fn key(&mut self, _code: u16, _down: bool) -> Result<(), crate::computer::input::InputError> {
+			Ok(())
+		}
 	}
 	#[derive(Default)]
 	struct RecordingHooks {
@@ -590,7 +642,9 @@ mod tests {
 
 		fn type_unicode(&mut self, _text: &str) {}
 
-		fn key(&mut self, _code: u16, _down: bool) {}
+		fn key(&mut self, _code: u16, _down: bool) -> Result<(), crate::computer::input::InputError> {
+			Ok(())
+		}
 	}
 
 	struct PanicReleaseSink {
@@ -619,7 +673,9 @@ mod tests {
 
 		fn type_unicode(&mut self, _text: &str) {}
 
-		fn key(&mut self, _code: u16, _down: bool) {}
+		fn key(&mut self, _code: u16, _down: bool) -> Result<(), crate::computer::input::InputError> {
+			Ok(())
+		}
 	}
 
 	struct PanicRestoreHooks {
@@ -809,6 +865,280 @@ mod tests {
 			run(&InputAction::Keypress { keys: vec!["enter".to_string()] }, &sup, true, None, 0);
 		assert!(res2.is_ok());
 		assert_eq!(ops2.len(), 2); // key down + up
+	}
+
+	#[test]
+	fn non_key_actions_preserve_liveness_and_cancellation_semantics() {
+		for action in [InputAction::Wait { ms: 0 }, InputAction::Type { text: "ok".to_string() }] {
+			for cancelled in [false, true] {
+				let supervisor = live_supervisor();
+				let mut controller = InputController::new(RecordingSink::default());
+				let result = execute_input(
+					&action,
+					&supervisor,
+					&FakePerms { granted: true },
+					&FakeDisplay { epoch: 0 },
+					None,
+					&display(),
+					&mut controller,
+					&|| {
+						supervisor.set_hotkey_live(false);
+						supervisor.heartbeat_at(0);
+						cancelled
+					},
+				);
+				assert_eq!(
+					result,
+					if cancelled {
+						Err(ExecError::Cancelled)
+					} else {
+						Ok(())
+					}
+				);
+				let expected = if !cancelled && matches!(action, InputAction::Type { .. }) {
+					vec![SinkOp::TypeUnicode("ok".to_string())]
+				} else {
+					vec![]
+				};
+				assert_eq!(controller.into_sink().ops, expected);
+			}
+		}
+	}
+
+	fn assert_keypress_stop(stop: fn(&Supervisor), expected: ExecError, keys: &[&str]) {
+		for transaction in [false, true] {
+			let supervisor = Rc::new(live_supervisor());
+			let sink_supervisor = Rc::clone(&supervisor);
+			let mut controller = InputController::new(RecordingSink {
+				on_key: Some(Box::new(move |_, down| {
+					if down {
+						stop(&sink_supervisor);
+					}
+					Ok(())
+				})),
+				..RecordingSink::default()
+			});
+			let action =
+				InputAction::Keypress { keys: keys.iter().map(|key| (*key).to_string()).collect() };
+			let permissions = FakePerms { granted: true };
+			let context = FakeDisplay { epoch: 0 };
+			let cancelled = || supervisor.is_suspended();
+			let result = if transaction {
+				let mut hooks = RecordingHooks::default();
+				let result = execute_input_transaction(
+					&[action, InputAction::Type { text: "must-not-run".to_string() }],
+					&supervisor,
+					&permissions,
+					&context,
+					None,
+					&display(),
+					&mut controller,
+					&mut hooks,
+					&cancelled,
+				);
+				assert_eq!((hooks.captures, hooks.restores), (1, 1));
+				result.map_err(|err| match err {
+					ExecError::ActionFailed { index: 0, source } => *source,
+					other => panic!("unexpected transaction error: {other:?}"),
+				})
+			} else {
+				execute_input(
+					&action,
+					&supervisor,
+					&permissions,
+					&context,
+					None,
+					&display(),
+					&mut controller,
+					&cancelled,
+				)
+			};
+			assert_eq!(result, Err(expected.clone()));
+			assert_eq!(controller.into_sink().ops, vec![
+				SinkOp::Key { code: 36, down: true },
+				SinkOp::Key { code: 36, down: false },
+			]);
+		}
+	}
+
+	#[test]
+	fn keypress_stops_when_hotkey_liveness_is_lost() {
+		assert_keypress_stop(|s| s.set_hotkey_live(false), ExecError::SupervisorNotLive, &[
+			"enter", "tab",
+		]);
+	}
+
+	#[test]
+	fn keypress_stops_when_heartbeat_becomes_stale() {
+		assert_keypress_stop(|s| s.heartbeat_at(0), ExecError::SupervisorNotLive, &["enter", "tab"]);
+	}
+
+	#[test]
+	fn keypress_suspension_precedes_liveness_and_cancellation() {
+		assert_keypress_stop(
+			|s| {
+				s.trigger_stop();
+				s.set_hotkey_live(false);
+				s.heartbeat_at(0);
+			},
+			ExecError::Suspended,
+			&["enter", "tab"],
+		);
+	}
+
+	#[test]
+	fn keypress_checks_liveness_after_the_final_key() {
+		assert_keypress_stop(|s| s.set_hotkey_live(false), ExecError::SupervisorNotLive, &["enter"]);
+	}
+
+	#[test]
+	fn keypress_backend_failure_releases_before_restore_and_keeps_primary_error() {
+		for fail_down in [false, true] {
+			for batch_path in [false, true] {
+				let supervisor = live_supervisor();
+				let log = Rc::new(RefCell::new(Vec::new()));
+				let sink_log = Rc::clone(&log);
+				let failed = Cell::new(false);
+				let mut controller = InputController::new(RecordingSink {
+					on_key: Some(Box::new(move |code, down| {
+						assert_eq!(code, 36, "no subsequent key may be admitted");
+						if down == fail_down && !failed.replace(true) {
+							sink_log.borrow_mut().push("creation-failed");
+							return Err(InputError::KeyEventCreationFailed { code, down });
+						}
+						sink_log.borrow_mut().push(if down { "down" } else { "up" });
+						Ok(())
+					})),
+					..RecordingSink::default()
+				});
+				let mut hooks = OrderedHooks { log: Rc::clone(&log) };
+				let action =
+					InputAction::Keypress { keys: vec!["enter".to_string(), "tab".to_string()] };
+				let permissions = FakePerms { granted: true };
+				let context = FakeDisplay { epoch: 0 };
+				let result = if batch_path {
+					super::with_cursor_transaction(
+						&mut controller,
+						&mut hooks,
+						&|| false,
+						|controller| {
+							execute_input(
+								&action,
+								&supervisor,
+								&permissions,
+								&context,
+								None,
+								&display(),
+								controller,
+								&|| false,
+							)
+						},
+					)
+				} else {
+					execute_input_transaction(
+						&[action],
+						&supervisor,
+						&permissions,
+						&context,
+						None,
+						&display(),
+						&mut controller,
+						&mut hooks,
+						&|| false,
+					)
+					.map_err(|err| match err {
+						ExecError::ActionFailed { index: 0, source } => *source,
+						other => panic!("unexpected transaction error: {other:?}"),
+					})
+				};
+				assert_eq!(
+					result,
+					Err(ExecError::KeyEventCreationFailed { code: 36, down: fail_down })
+				);
+				let expected = if fail_down {
+					vec!["capture", "creation-failed", "restore"]
+				} else {
+					vec!["capture", "down", "creation-failed", "up", "restore"]
+				};
+				assert_eq!(*log.borrow(), expected);
+			}
+		}
+	}
+
+	#[test]
+	fn keypress_persistent_release_failure_retains_ownership_until_recovery() {
+		let supervisor = live_supervisor();
+		let fail_up = Rc::new(Cell::new(true));
+		let sink_fail_up = Rc::clone(&fail_up);
+		let attempts = Rc::new(RefCell::new(Vec::new()));
+		let sink_attempts = Rc::clone(&attempts);
+		let mut controller = InputController::new(RecordingSink {
+			on_key: Some(Box::new(move |code, down| {
+				sink_attempts.borrow_mut().push((code, down));
+				if !down && sink_fail_up.get() {
+					Err(InputError::KeyEventCreationFailed { code, down })
+				} else {
+					Ok(())
+				}
+			})),
+			..RecordingSink::default()
+		});
+		let mut hooks = RecordingHooks { restore_fails: true, ..RecordingHooks::default() };
+		let result = execute_input_transaction(
+			&[InputAction::Keypress { keys: vec!["enter".to_string(), "tab".to_string()] }],
+			&supervisor,
+			&FakePerms { granted: true },
+			&FakeDisplay { epoch: 0 },
+			None,
+			&display(),
+			&mut controller,
+			&mut hooks,
+			&|| false,
+		);
+		assert_eq!(
+			result,
+			Err(ExecError::CursorRestoreFailed {
+				primary: Some(Box::new(ExecError::ActionFailed {
+					index:  0,
+					source: Box::new(ExecError::KeyEventCreationFailed { code: 36, down: false }),
+				})),
+			})
+		);
+		assert_eq!(*attempts.borrow(), vec![(36, true), (36, false), (36, false)]);
+		assert_eq!((hooks.captures, hooks.restores), (1, 1));
+		assert_eq!(
+			controller.keypress(&["tab".to_string()], &|| false),
+			Err(InputError::KeyEventCreationFailed { code: 36, down: false })
+		);
+		assert_eq!(attempts.borrow().last(), Some(&(36, false)));
+		fail_up.set(false);
+		controller.release_all().unwrap();
+		let settled_attempts = attempts.borrow().len();
+		controller.release_all().unwrap();
+		assert_eq!(attempts.borrow().len(), settled_attempts, "successful cleanup is idempotent");
+		assert_eq!(controller.keypress(&["tab".to_string()], &|| false), Ok(true));
+		assert_eq!(&attempts.borrow()[settled_attempts..], &[(48, true), (48, false)]);
+	}
+
+	#[test]
+	fn keypress_admission_race_preserves_suspension_before_the_first_key() {
+		let supervisor = live_supervisor();
+		let mut controller = InputController::new(RecordingSink::default());
+		let result = execute_input(
+			&InputAction::Keypress { keys: vec!["enter".to_string()] },
+			&supervisor,
+			&FakePerms { granted: true },
+			&FakeDisplay { epoch: 0 },
+			None,
+			&display(),
+			&mut controller,
+			&|| {
+				supervisor.trigger_stop();
+				true
+			},
+		);
+		assert_eq!(result, Err(ExecError::Suspended));
+		assert!(controller.into_sink().ops.is_empty());
 	}
 
 	#[test]

--- a/crates/pi-natives/src/computer/input.rs
+++ b/crates/pi-natives/src/computer/input.rs
@@ -54,8 +54,9 @@ pub trait EventSink {
 	fn scroll(&mut self, dx: f64, dy: f64);
 	/// Type a unicode string.
 	fn type_unicode(&mut self, text: &str);
-	/// Press or release a virtual key code.
-	fn key(&mut self, code: u16, down: bool);
+	/// Create and post a virtual-key event, or report creation failure.
+	/// Success does not acknowledge delivery by the window server.
+	fn key(&mut self, code: u16, down: bool) -> Result<(), InputError>;
 }
 
 /// Fallible global cursor operations that bracket an input transaction.
@@ -93,6 +94,8 @@ pub enum InputError {
 	Coord(CoordError),
 	/// A Core Graphics cursor warp failed with this status.
 	CursorWarpFailed(i32),
+	/// Core Graphics could not create a virtual-key event.
+	KeyEventCreationFailed { code: u16, down: bool },
 	/// A key name was not recognized.
 	UnknownKey(String),
 }
@@ -106,6 +109,10 @@ impl std::fmt::Display for InputError {
 		match self {
 			Self::Coord(err) => write!(f, "{err}"),
 			Self::CursorWarpFailed(status) => write!(f, "cursor warp failed with status {status}"),
+			Self::KeyEventCreationFailed { code, down } => {
+				let direction = if *down { "down" } else { "up" };
+				write!(f, "could not create key-{direction} event for virtual key {code}")
+			},
 			Self::UnknownKey(key) => write!(f, "unknown key name: {key}"),
 		}
 	}
@@ -131,19 +138,26 @@ pub fn key_code_for(name: &str) -> Option<u16> {
 	Some(code)
 }
 
-/// Orchestrates input actions over an [`EventSink`], tracking held buttons so
-/// [`InputController::release_all`] can clean up after an abort or error.
+/// Orchestrates input actions over an [`EventSink`], tracking held buttons and
+/// keys so [`InputController::release_all`] can clean up after an abort or
+/// error.
 pub struct InputController<S: EventSink> {
 	sink:         S,
 	cursor:       LogicalPoint,
 	held_buttons: Vec<MouseButton>,
+	held_key:     Option<u16>,
 }
 
 impl<S: EventSink> InputController<S> {
 	/// Construct a controller over `sink`. Prefer [`InputController::guarded`]
 	/// for any path that posts real events.
 	pub const fn new(sink: S) -> Self {
-		Self { sink, cursor: LogicalPoint { x: 0.0, y: 0.0 }, held_buttons: Vec::new() }
+		Self {
+			sink,
+			cursor: LogicalPoint { x: 0.0, y: 0.0 },
+			held_buttons: Vec::new(),
+			held_key: None,
+		}
 	}
 
 	/// The most recent cursor position.
@@ -291,31 +305,49 @@ impl<S: EventSink> InputController<S> {
 	///
 	/// # Errors
 	/// Returns [`InputError::UnknownKey`] when a name is unrecognized; keys
-	/// before the failure have already been sent.
+	/// before the failure have already been sent. Backend errors retain any
+	/// admitted key for [`Self::release_all`]; no subsequent key is admitted.
 	pub fn keypress(
 		&mut self,
 		keys: &[String],
 		cancelled: &dyn Fn() -> bool,
 	) -> Result<bool, InputError> {
+		// A reused controller must settle earlier release failures before input.
+		self.release_key()?;
 		for name in keys {
 			if cancelled() {
 				return Ok(false);
 			}
 			let code = key_code_for(name).ok_or_else(|| InputError::UnknownKey(name.clone()))?;
-			self.sink.key(code, true);
-			self.sink.key(code, false);
+			self.sink.key(code, true)?;
+			self.held_key = Some(code);
+			self.sink.key(code, false)?;
+			self.held_key = None;
 		}
 		Ok(true)
 	}
 
-	/// Release every held mouse button (idempotent). Run on abort/error paths
-	/// so a partial drag never leaves a button stuck.
-	pub fn release_all(&mut self) {
+	fn release_key(&mut self) -> Result<(), InputError> {
+		if let Some(code) = self.held_key {
+			self.sink.key(code, false)?;
+			self.held_key = None;
+		}
+		Ok(())
+	}
+
+	/// Attempt to release every held input. Successfully released keys are
+	/// removed; failed releases remain owned so a later cleanup can retry.
+	/// A persistent backend failure is reported, not a guarantee of OS delivery.
+	///
+	/// # Errors
+	/// Returns a keyboard release error after releasing the held mouse buttons.
+	pub fn release_all(&mut self) -> Result<(), InputError> {
 		let at = self.cursor;
 		let held: Vec<MouseButton> = self.held_buttons.drain(..).collect();
 		for button in held {
 			self.sink.mouse_button(at, button, false);
 		}
+		self.release_key()
 	}
 
 	#[cfg(test)]
@@ -530,15 +562,40 @@ mod mac {
 			}
 		}
 
-		fn key(&mut self, code: u16, down: bool) {
+		fn key(&mut self, code: u16, down: bool) -> Result<(), super::InputError> {
 			// SAFETY: created keyboard event is posted and released exactly once.
 			unsafe {
-				let event = CGEventCreateKeyboardEvent(self.source, code, down);
-				if !event.is_null() {
-					CGEventPost(HID_EVENT_TAP, event);
-					CFRelease(event.cast_const());
-				}
+				let event = require_keyboard_event(
+					CGEventCreateKeyboardEvent(self.source, code, down),
+					code,
+					down,
+				)?;
+				CGEventPost(HID_EVENT_TAP, event);
+				CFRelease(event.cast_const());
 			}
+			Ok(())
+		}
+	}
+
+	const fn require_keyboard_event(
+		event: CgEventRef,
+		code: u16,
+		down: bool,
+	) -> Result<CgEventRef, super::InputError> {
+		if event.is_null() {
+			Err(super::InputError::KeyEventCreationFailed { code, down })
+		} else {
+			Ok(event)
+		}
+	}
+
+	#[test]
+	fn null_keyboard_events_report_the_failed_key_edge() {
+		for down in [true, false] {
+			assert_eq!(
+				require_keyboard_event(std::ptr::null_mut(), 36, down),
+				Err(super::InputError::KeyEventCreationFailed { code: 36, down }),
+			);
 		}
 	}
 
@@ -598,8 +655,9 @@ mod tests {
 			self.ops.push(SinkOp::TypeUnicode(text.to_string()));
 		}
 
-		fn key(&mut self, code: u16, down: bool) {
+		fn key(&mut self, code: u16, down: bool) -> Result<(), InputError> {
 			self.ops.push(SinkOp::Key { code, down });
+			Ok(())
 		}
 	}
 	struct WarpFailingSink;
@@ -615,7 +673,9 @@ mod tests {
 
 		fn type_unicode(&mut self, _text: &str) {}
 
-		fn key(&mut self, _code: u16, _down: bool) {}
+		fn key(&mut self, _code: u16, _down: bool) -> Result<(), crate::computer::input::InputError> {
+			Ok(())
+		}
 	}
 
 	fn display() -> NormalizedDisplay {
@@ -698,11 +758,11 @@ mod tests {
 		c.move_to(&display(), 10.0, 10.0).unwrap();
 		c.press_for_test(MouseButton::Left);
 		assert!(c.has_held_buttons());
-		c.release_all();
+		c.release_all().unwrap();
 		assert!(!c.has_held_buttons());
 		assert!(matches!(c.ops_ref().last(), Some(SinkOp::Button { down: false, .. })));
 		// release_all is idempotent.
-		c.release_all();
+		c.release_all().unwrap();
 		assert!(!c.has_held_buttons());
 	}
 
@@ -740,6 +800,22 @@ mod tests {
 			.unwrap_err();
 		assert!(matches!(err, InputError::UnknownKey(_)));
 	}
+	#[test]
+	fn keypress_empty_and_partial_unknown_key_preserve_order() {
+		let mut controller = InputController::new(RecordingSink::default());
+		assert_eq!(controller.keypress(&[], &|| false), Ok(true));
+		assert!(controller.ops_ref().is_empty());
+		assert_eq!(
+			controller
+				.keypress(&["enter".to_string(), "unknown".to_string(), "tab".to_string()], &|| false),
+			Err(InputError::UnknownKey("unknown".to_string()))
+		);
+		assert_eq!(controller.into_ops(), vec![SinkOp::Key { code: 36, down: true }, SinkOp::Key {
+			code: 36,
+			down: false,
+		},]);
+	}
+
 	#[test]
 	fn keypress_cancellation_stops_between_complete_keys() {
 		let polls = std::cell::Cell::new(0usize);

--- a/docs/tools/computer.md
+++ b/docs/tools/computer.md
@@ -57,6 +57,7 @@ The model action object uses an exact snake_case discriminated schema. CamelCase
 - Do not use the desktop manually while a side-effecting action or batch runs; concurrent use is unsafe, and restoration can overwrite cursor movement made during the transaction.
 - `screenshot` is read-only, and `wait` posts no input. Screenshot/wait-only batches do not move or restore the cursor.
 - The kill switch gates future input, but it does not isolate the desktop or restore application focus. Cursor restoration does not target or reactivate any PID or window.
+- Key sequences recheck suspension, hotkey liveness, and heartbeat freshness between complete keys. A key already pressed gets its release attempt before stopping. Keyboard-event creation failures stop the sequence and retain the pressed key for cleanup before cursor restoration; the original failure remains visible even if cleanup succeeds. Persistent backend failure can prevent release: cleanup is best-effort within the transaction, not an acknowledgement of delivery by macOS.
 
 ## Errors
 
@@ -70,6 +71,7 @@ Stable computer error codes include:
 - `COMPUTER_DISPLAY_STALE`
 - `COMPUTER_COORD_INVALID`
 - `COMPUTER_CANCELLED`
+- `COMPUTER_KEY_EVENT_FAILED` (native virtual-key event creation failed)
 - `COMPUTER_CURSOR_CAPTURE_FAILED`
 - `COMPUTER_CURSOR_RESTORE_FAILED`
 - `COMPUTER_TRANSACTION_FAILED`

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Recheck full computer-use supervisor state between keys, and report keyboard-event creation failures while retaining pressed keys for cleanup before cursor restoration.
+
 ## [0.16.6] - 2026-09-07
 
 ## [0.16.5] - 2026-09-07


### PR DESCRIPTION
Replaces closed PR #3576. Both blockers from the [original exact-head owner review](https://github.com/Yeachan-Heo/gajae-code/pull/3576#pullrequestreview-4823135362) are addressed together. This is a new current-dev successor, not a reopening of the old head.

## Finding / reproduction

A virtual-key sequence could continue after supervisor hotkey liveness or heartbeat freshness was lost. Separately, a successful key-down followed by key-up event-creation failure could appear successful without retained cleanup ownership.

On current dev `411b7f3809cec3949edeb6a60a767495c5639a96`, a test-only patch produces **4 behavioral failures, 61 passes, 5 intentionally ignored live tests**. The regressions run the executor with recording/fault sinks; no keyboard or mouse input is posted.

## Root cause

- Initial and per-key admission did not use the same full supervisor check; the boolean loop lost typed suspension/liveness stop reasons.
- The keyboard sink was infallible despite nullable native event creation. Only mouse-button ownership was retained, so a failed key-up could not propagate an error or preserve ownership for cleanup.

The old PR's green CI covered neither runtime condition, which is why its approval/CI is not reused.

## Change

- `crates/pi-natives/src/computer/input.rs`: make keyboard creation fallible; record one successfully pressed key without allocating after key-down; clear ownership only after successful key-up; retain and retry a failed release before new key admission. Exercise the production null-result mapping without posting input.
- `crates/pi-natives/src/computer/executor.rs`: share the full supervisor check across pre-dispatch, between-key and final checks, preserve typed stop/error precedence, and attempt release before cursor restoration. Full repeated supervisor checks are keypress-only; non-key wait/type behavior retains its existing contract. Cover direct and batch transaction paths.
- `crates/pi-natives/src/computer/controller.rs`: tests only, covering existing N-API and batch error/index mapping.
- `docs/tools/computer.md` and `packages/natives/CHANGELOG.md`: document the additive backend error and bounded cleanup semantics.

These files form one virtual-key admission/release lifecycle repair; neither original blocker is split into an unsafe intermediate patch.

## Scope

- Changed files: **5**, one logical commit.
- Production additions/deletions: **+126 / -35** (2 files).
- Test additions/deletions: **+350 / -10** (embedded tests across 3 Rust files).
- Generated/docs/changelog: generated **0**; docs/changelog **+6 / -0**.
- Total churn: **527**, exceeding the 500-line scope-warning threshold. Test additions dominate: the extra compatibility regression prevents this key-only repair from changing non-key wait/type behavior. Both production files enforce the same key lifecycle, controller tests prove public error mapping, and docs/changelog describe that additive error. No independent behavior change can be safely split out; no dependency, version/lockfile, unrelated cleanup, or generated hand edits are included.

## Contract

Public N-API/TypeScript signatures, settings, persistence, valid key names/order, partial unknown-key behavior, and cursor transaction structure remain unchanged. Internal Rust sink/release results become fallible, as requested in the original review. The additive `COMPUTER_KEY_EVENT_FAILED` error replaces false success when virtual-key event creation fails. No feature, fallback, or input-targeting capability is removed; no product-contract decision is requested.

Cleanup remains transaction-bounded: persistent backend failure can prevent release, and retained ownership does not survive the local controller being dropped. This does not guarantee window-server delivery or introduce global retry/quarantine behavior.

## Verification

- **Base SHA:** `411b7f3809cec3949edeb6a60a767495c5639a96`
- **Head SHA:** `73e63dddced8f91d6866fc9e8d2159a2c146dbfb`
- **Canonical base...head diff SHA-256:** `49c576c56e09f911aad474feb827c10684789b1cda792dad0a3bddba387f9101`
- Bun **1.4.0**, pinned Rust **nightly-2026-04-29**, macOS arm64.

| Gate / exact command | Result |
|---|---|
| Red-on-base, test-only patch; `cargo test --locked -p pi-natives --lib computer:: -- --test-threads=1` | **61 pass / 4 fail / 5 ignored** |
| Non-key compatibility control: base passes; pre-review candidate fails; corrected head passes | Wait/type results, cancellation precedence and emitted operations preserved |
| Same focused command on this head | **72 pass / 0 fail / 5 ignored** |
| `cargo test --locked -p pi-natives --lib -- --test-threads=1` | **273 pass / 0 fail / 5 ignored** |
| `cargo check --locked -p pi-natives` | Pass |
| `cargo fmt --all -- --check` | Pass |
| `cargo clippy --locked -p pi-natives --lib --no-deps -- -D warnings` | Pass; owning crate only, not the repository dependency-inclusive gate |
| `bun --cwd=packages/natives run check` | Pass: Biome 25 files + TypeScript |
| `bun run build:native` | Pass: fresh darwin-arm64 local-profile addon; public loader identity verified |
| `bun --cwd=packages/natives test` | **158 pass / 69 platform skip / 0 fail**, all 20 files |
| `bun test packages/coding-agent/test/tools/computer.test.ts packages/coding-agent/test/tools/computer-gc.test.ts` | **49 pass / 0 fail**, 2 focused downstream files |
| `bun test packages/coding-agent/test/tools/resource-gc.test.ts packages/natives/test/computer.test.ts` | **48 pass / 0 fail**, current-dev integration with merged #5316 |
| `bun run check:public-sync`; `bun scripts/check-rust-scope.ts`; `git diff --check` | Pass; canonical generators leave no tracked changes |

**Dependency-inclusive Clippy is not passing:** both `cargo clippy --locked -p pi-natives --lib --message-format=json -- -D warnings` and the variant adding `--tests` fail on **the same single diagnostic on exact base and head**, `clippy::undocumented_unsafe_blocks` at `crates/pi-shell/src/process.rs:695`. The path-dependency failure prevents that gate completing the owning crate. No unrelated lint repair or suppression is included.

**Base CI:** exact-base [Dev CI run 34198371109](https://github.com/Yeachan-Heo/gajae-code/actions/runs/34198371109) is **completed/failure** (25 success, 6 failure, 7 skipped jobs). For example, the [base shard-7 job](https://github.com/Yeachan-Heo/gajae-code/actions/runs/34198371109/job/101972951233) fails SDK topology and prompt-discovery tests on untouched dev. This is not used to excuse an unexamined candidate failure.

**Fresh independent local review:** **APPROVE_LOCAL_ONLY, 0 remaining findings**, exact head `73e63dddced8f91d6866fc9e8d2159a2c146dbfb`. An agent's local verdict is not an authenticated GitHub approval. Hosted exact-head checks and authenticated independent review remain separate, post-publication gates; **not merge-ready**.

## Overlap and integration

- Inspected **19 currently open PRs** plus the closed #3576 review/closure. No open PR changes the virtual-key lifecycle implementation; no other authored open PR exists at this snapshot.
- #5316 is now merged (`b08874dccd74ec092fd2a084bb0972df160c8f58`) and included in this base. The owning suite and the 48-test resource-GC/computer integration were rerun on the combined current-dev state.
- Candidate versus exact current dev: **merge-tree clean**.
- #5051 head `bcf3e638111fdacd4c5601f0800c31a0bb7cde64` overlaps the native changelog, not the key lifecycle. Pairwise merge-tree has the same **2 pre-existing conflict paths** as untouched dev (`packages/coding-agent/CHANGELOG.md`, `packages/coding-agent/test/coordinator-mcp-server.test.ts`); this candidate adds no conflict path. No combined runtime pass is claimed for that conflicted PR.
- The previously local candidate was refreshed because dev changed native package versions, dependencies and generated surfaces. The refresh retains current Unreleased changelog context. Independent pre-publication review additionally identified and corrected a non-key polling regression; its new preservation test passes on base, fails on the earlier local candidate, and passes after restricting the new checks to keypress.

## Known limits / non-goals

- The base's infallible sink cannot express a returned backend-creation error. Corrected fault-sink and pure production null-result tests cover down-success/up-failure cleanup; **no live CoreGraphics red-on-base reproduction is claimed**.
- No live keyboard/mouse injection, delivery acknowledgement, compiled-GJC end-to-end fault injection, or persistent cross-transaction recovery proof.
- No full coding-agent suite, repository-wide TypeScript aggregate, or cross-platform hosted suite was run locally. Skipped/ignored tests are not represented as passes.
- Unicode text injection, focus/window isolation, other PR repairs, and the unrelated 90 GB memory incident are outside scope.
- Base CI recovery and an authenticated exact-head domain review are required before merge readiness. This PR intentionally retains `needs-human`.

## Risk classification

- [ ] `low-risk`
- [ ] `regression-risk`
- [x] `high-risk` — native input safety/error lifecycle; requires independent domain review.

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:49c576c56e09f911aad474feb827c10684789b1cda792dad0a3bddba387f9101 reviewer:architect reviewer-id:snowykr evidence:current-dev-ancestry-and-canonical-diff-verified;no-new-approval-created
```

This author-side needs-human record is not an authenticated independent GitHub approval.

- [x] Target branch is `dev`
- [ ] `bun check` passes — full aggregate not claimed; scoped commands and base failures recorded above
- [x] Tested locally
- [x] CHANGELOG updated
- [x] Verdict hash matches this exact candidate diff
- [x] Risk classification records the required independent review path


<!-- gjc-maintenance-01a083b2 -->
Current maintenance snapshot: base `be4c883831a9b4c2636bdf9c642930878d86835d`, head `b878caef4ea0efe8f3492367263dcb99c71dc140`. Earlier narrative/test evidence is historical unless explicitly rebound to this head. Rebase/diff verification does not replace required CI or independent approval.
<!-- /gjc-maintenance-01a083b2 -->
