### PR TITLE
fix(agent): render thinking and tool streams before completion

### DIFF
--- a/docs/provider-streaming-internals.md
+++ b/docs/provider-streaming-internals.md
@@ -73,7 +73,7 @@ Sources: `packages/ai/src/providers/openai-responses.ts`, `openai-code-responses
 Normalization points:
 
 - `response.output_item.added` starts reasoning/text/function-call blocks
-- reasoning summary events (`response.reasoning_summary_text.delta`) become `thinking_delta`
+- reasoning summary events (`response.reasoning_summary_text.delta`) become `reasoning_summary_delta` and update the message's thinking block
 - output/refusal deltas become `text_delta`
 - `response.function_call_arguments.delta` becomes `toolcall_delta`
 - `response.output_item.done` emits `thinking_end` / `text_end` / `toolcall_end`
@@ -177,8 +177,18 @@ Current design favors responsiveness and simple ordering over bounded-buffer flo
 `agentLoop.streamAssistantResponse()` bridges `AssistantMessageEvent` to `AgentEvent`:
 
 - on `start`: pushes placeholder assistant message and emits `message_start`
-- on block events (`text_*`, `thinking_*`, `toolcall_*`): updates last assistant message, emits `message_update` with raw `assistantMessageEvent`
+- on block events (`text_*`, `thinking_*`, `reasoning_summary_*`, `toolcall_*`): updates last assistant message, emits `message_update` with raw `assistantMessageEvent`
 - on terminal (`done`/`error`): resolves final message from `response.result()`, emits `message_end`
+
+For ordinary unmanaged turns, the first content event publishes the provisional
+nonterminal lifecycle, including reasoning-only and tool-only streams. Subsequent
+updates are delivered live without waiting for text, response completion, or an
+interrupt. This is presentation, not tool acceptance: terminal validation and the
+consumer drain still precede execution. A legacy guarded call that has already
+been published receives an explicit rejection instead of silently disappearing
+through same-turn resampling; unpublished terminal-only attempts can still retry.
+Managed fallback attempts retain atomic publication/discard semantics and do not
+use this unmanaged early-publication path.
 
 `AgentSession` then consumes those events for session-level behaviors:
 

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Publish reasoning summaries, thinking, and tool-call updates during ordinary unmanaged streaming instead of holding them until text, response completion, or interruption. Tool execution still waits for terminal validation; already-published legacy guarded calls receive explicit rejection instead of silent resampling. Managed fallback attempts remain atomic.
+
 ## [0.16.6] - 2026-09-07
 
 ## [0.16.5] - 2026-09-07

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -4869,13 +4869,11 @@ async function streamAssistantResponse(
 									message: { ...partialMessage },
 									scope,
 								});
-								// Preserve ordinary text streaming. Once visible text is
-								// published, this response can no longer be silently resampled;
-								// a later escaped tool call therefore falls through to the
-								// existing terminal per-call rejection instead.
-								if (event.type === "text_start" || event.type === "text_delta" || event.type === "text_end") {
-									provisionalToolTransaction?.commitCallbacksAndUpdates();
-								}
+								// Publish unmanaged content as it arrives, including reasoning and
+								// tool arguments. Publication does not accept or execute tools:
+								// terminal validation and the consumer drain still precede dispatch.
+								// A published escaped call is rejected rather than silently resampled.
+								provisionalToolTransaction?.commitCallbacksAndUpdates();
 							}
 							break;
 

--- a/packages/agent/test/agent-loop-escaped-nonascii-toolcall.test.ts
+++ b/packages/agent/test/agent-loop-escaped-nonascii-toolcall.test.ts
@@ -10,7 +10,7 @@ import type {
 	ManagedAttemptOutcome,
 } from "@gajae-code/agent-core/types";
 import type { AssistantMessage, Message, ToolCall } from "@gajae-code/ai";
-import { createMockModel } from "@gajae-code/ai/providers/mock";
+import { createMockModel, type MockModel } from "@gajae-code/ai/providers/mock";
 import { AssistantMessageEventStream } from "@gajae-code/ai/utils/event-stream";
 import { captureUnicodeEscapeEvidence, collectUnicodeEscapeEvidence } from "@gajae-code/ai/utils/json-parse";
 import * as logger from "@gajae-code/utils/logger";
@@ -154,7 +154,7 @@ function thinkingToolTurn(id: string, escaped = false) {
 }
 
 /** Only for unpublished recovery: this provider exposes no content before its terminal response. */
-function terminalOnlyStream(stream: ReturnType<typeof createMockModel>["stream"]): typeof stream {
+function terminalOnlyStream(stream: MockModel["stream"]): MockModel["stream"] {
 	return (model, context, options) => {
 		const upstream = stream(model, context, options);
 		const terminal = new AssistantMessageEventStream();
@@ -189,7 +189,7 @@ describe("agentLoop: ASCII-escaped non-ASCII argument guard", () => {
 				for await (const event of upstream) {
 					if (event.type === "done" || event.type === "error") {
 						// Give the consumer a turn while the provider has not yet completed.
-						await new Promise(resolve => setTimeout(resolve, 0));
+						await Bun.sleep(0);
 						if (!terminalSent) executionsBeforeDone.push(executed.length);
 						terminalSent = true;
 					}

--- a/packages/agent/test/agent-loop-escaped-nonascii-toolcall.test.ts
+++ b/packages/agent/test/agent-loop-escaped-nonascii-toolcall.test.ts
@@ -153,7 +153,97 @@ function thinkingToolTurn(id: string, escaped = false) {
 	};
 }
 
+/** Only for unpublished recovery: this provider exposes no content before its terminal response. */
+function terminalOnlyStream(stream: ReturnType<typeof createMockModel>["stream"]): typeof stream {
+	return (model, context, options) => {
+		const upstream = stream(model, context, options);
+		const terminal = new AssistantMessageEventStream();
+		void (async () => {
+			for await (const event of upstream) {
+				if (event.type === "done" || event.type === "error") terminal.push(event);
+			}
+			terminal.end();
+		})().catch(error => terminal.fail(error));
+		return terminal;
+	};
+}
+
 describe("agentLoop: ASCII-escaped non-ASCII argument guard", () => {
+	it.each([
+		["reasoning and clean tool", true, false, false],
+		["tool only", false, false, false],
+		["reasoning and rejected tool", true, true, false],
+		["reasoning and callback abort", true, false, true],
+	] as const)("publishes %s callbacks before done without premature execution", async (_label, reasoning, escaped, abort) => {
+		const executed: Array<Record<string, unknown>> = [];
+		const turn = reasoning ? thinkingToolTurn("tc-streamed", escaped) : literalTurn("tc-streamed");
+		const mock = createMockModel({ responses: [turn, { content: ["done"] }] });
+		const controller = new AbortController();
+		let terminalSent = false;
+		const callbacksBeforeDone: string[] = [];
+		const executionsBeforeDone: number[] = [];
+		const streamFn: typeof mock.stream = (model, context, options) => {
+			const upstream = mock.stream(model, context, options);
+			const live = new AssistantMessageEventStream();
+			void (async () => {
+				for await (const event of upstream) {
+					if (event.type === "done" || event.type === "error") {
+						// Give the consumer a turn while the provider has not yet completed.
+						await new Promise(resolve => setTimeout(resolve, 0));
+						if (!terminalSent) executionsBeforeDone.push(executed.length);
+						terminalSent = true;
+					}
+					live.push(event);
+				}
+				live.end();
+			})().catch(error => live.fail(error));
+			return live;
+		};
+		const events: AgentEvent[] = [];
+		const stream = agentLoop(
+			[createUserMessage("ask me")],
+			{ systemPrompt: [""], messages: [], tools: [askTool(executed)] },
+			{
+				model: mock.model,
+				convertToLlm: identityConverter,
+				onAssistantMessageEvent: (_message, event) => {
+					if (!terminalSent) {
+						callbacksBeforeDone.push(event.type);
+						executionsBeforeDone.push(executed.length);
+					}
+					if (abort && event.type === "toolcall_end") controller.abort();
+				},
+			},
+			controller.signal,
+			streamFn,
+		);
+		for await (const event of stream) events.push(event);
+		expect(callbacksBeforeDone).toEqual([
+			...(reasoning ? ["thinking_start", "thinking_delta", "thinking_end"] : []),
+			"toolcall_start",
+			"toolcall_delta",
+			"toolcall_end",
+		]);
+		expect(executionsBeforeDone.every(count => count === 0)).toBe(true);
+		expect(executed).toEqual(escaped || abort ? [] : [{ question: QUESTION }]);
+		const toolEnds = events.filter(
+			(event): event is Extract<AgentEvent, { type: "tool_execution_end" }> => event.type === "tool_execution_end",
+		);
+		expect(toolEnds.map(event => [event.toolCallId, event.isError])).toEqual([["tc-streamed", escaped || abort]]);
+		if (escaped) {
+			const first = toolEnds[0]?.result.content[0];
+			expect(first?.type === "text" ? first.text : "").toContain("\\uXXXX");
+		}
+		if (abort) {
+			expect(mock.calls).toHaveLength(1);
+			const terminal = events.findLast(event => event.type === "message_end" && event.message.role === "assistant");
+			expect(
+				terminal?.type === "message_end" && terminal.message.role === "assistant"
+					? terminal.message.stopReason
+					: undefined,
+			).toBe("aborted");
+		}
+	});
 	it("executes canonical valid escapes without a resample, including mutating tools", async () => {
 		const executed: Array<Record<string, unknown>> = [];
 		const call: ToolCall = {
@@ -210,7 +300,7 @@ describe("agentLoop: ASCII-escaped non-ASCII argument guard", () => {
 				context,
 				{ model: mock.model, convertToLlm: identityConverter },
 				undefined,
-				mock.stream,
+				terminalOnlyStream(mock.stream),
 			);
 			for await (const _event of stream) {
 				// drain
@@ -352,7 +442,7 @@ describe("agentLoop: ASCII-escaped non-ASCII argument guard", () => {
 				context,
 				{ model: mock.model, convertToLlm: identityConverter },
 				undefined,
-				mock.stream,
+				terminalOnlyStream(mock.stream),
 			);
 			for await (const _event of stream) {
 				// drain
@@ -368,17 +458,26 @@ describe("agentLoop: ASCII-escaped non-ASCII argument guard", () => {
 		}
 	});
 
-	it("resamples the turn instead of executing or reporting escaped arguments", async () => {
+	it("silently resamples unpublished reasoning and escaped arguments without replaying the discarded turn", async () => {
 		const executed: Array<Record<string, unknown>> = [];
 		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [askTool(executed)] };
 		const mock = createMockModel({
-			responses: [escapedTurn("tc-1"), literalTurn("tc-2"), { content: ["done"] }],
+			responses: [thinkingToolTurn("tc-1", true), literalTurn("tc-2"), { content: ["done"] }],
 		});
 		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
 
 		const toolResults: Array<{ isError?: boolean; text: string }> = [];
-		const stream = agentLoop([createUserMessage("ask me")], context, config, undefined, mock.stream);
+		const publishedAssistants: AssistantMessage[] = [];
+		const stream = agentLoop(
+			[createUserMessage("ask me")],
+			context,
+			config,
+			undefined,
+			terminalOnlyStream(mock.stream),
+		);
 		for await (const event of stream) {
+			if (event.type === "message_end" && event.message.role === "assistant")
+				publishedAssistants.push(event.message);
 			if (event.type === "tool_execution_end") {
 				const first = event.result.content?.[0];
 				toolResults.push({ isError: event.isError, text: first?.type === "text" ? first.text : "" });
@@ -393,6 +492,15 @@ describe("agentLoop: ASCII-escaped non-ASCII argument guard", () => {
 		const resampleRequest = mock.model.calls[1];
 		expect(resampleRequest).toBeDefined();
 		expect(resampleRequest.context.messages.some(message => message.role === "assistant")).toBe(false);
+		expect(publishedAssistants).toHaveLength(2);
+		expect(publishedAssistants.some(message => message.content.some(block => block.type === "thinking"))).toBe(false);
+		expect(
+			context.messages.some(
+				message =>
+					message.role === "assistant" &&
+					message.content.some(block => block.type === "toolCall" && block.id === "tc-1"),
+			),
+		).toBe(false);
 	});
 
 	it("steers the resample with a transient synthetic instruction and keeps tools enabled", async () => {
@@ -403,7 +511,13 @@ describe("agentLoop: ASCII-escaped non-ASCII argument guard", () => {
 		});
 		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
 
-		const stream = agentLoop([createUserMessage("ask me")], context, config, undefined, mock.stream);
+		const stream = agentLoop(
+			[createUserMessage("ask me")],
+			context,
+			config,
+			undefined,
+			terminalOnlyStream(mock.stream),
+		);
 		for await (const _event of stream) {
 			// drain
 		}
@@ -445,7 +559,7 @@ describe("agentLoop: ASCII-escaped non-ASCII argument guard", () => {
 		).toHaveLength(0);
 	});
 
-	it("publishes and stores only the accepted assistant lifecycle", async () => {
+	it("publishes and stores rejected streamed turns with paired errors before a clean turn", async () => {
 		const executed: Array<Record<string, unknown>> = [];
 		const mock = createMockModel({
 			responses: [escapedTurn("tc-defective"), literalTurn("tc-accepted"), { content: ["done"] }],
@@ -469,29 +583,37 @@ describe("agentLoop: ASCII-escaped non-ASCII argument guard", () => {
 			(event): event is Extract<AgentEvent, { type: "message_end" }> =>
 				event.type === "message_end" && event.message.role === "assistant",
 		);
-		expect(assistantEnds).toHaveLength(2);
+		expect(assistantEnds).toHaveLength(3);
 		expect(
 			assistantEnds.some(event =>
 				event.message.role === "assistant"
 					? event.message.content.some(block => block.type === "toolCall" && block.id === "tc-defective")
 					: false,
 			),
-		).toBe(false);
+		).toBe(true);
 		expect(
 			agent.state.messages.some(
 				message =>
 					message.role === "assistant" &&
 					message.content.some(block => block.type === "toolCall" && block.id === "tc-defective"),
 			),
-		).toBe(false);
+		).toBe(true);
 		expect(events.filter(event => event.type === "turn_start")).toHaveLength(3);
-		expect(events.filter(event => event.type === "turn_end")).toHaveLength(2);
+		expect(events.filter(event => event.type === "turn_end")).toHaveLength(3);
+		expect(executed).toEqual([{ question: QUESTION }]);
+		const toolEnds = events.filter(
+			(event): event is Extract<AgentEvent, { type: "tool_execution_end" }> => event.type === "tool_execution_end",
+		);
+		expect(toolEnds.map(event => [event.toolCallId, event.isError])).toEqual([
+			["tc-defective", true],
+			["tc-accepted", false],
+		]);
 	});
 
 	it("preserves provider-native thinking and usage metadata through accepted Agent state and replay", async () => {
 		const executed: Array<Record<string, unknown>> = [];
 		const mock = createMockModel({
-			responses: [thinkingToolTurn("tc-defective", true), thinkingToolTurn("tc-accepted"), { content: ["done"] }],
+			responses: [thinkingToolTurn("tc-accepted"), { content: ["done"] }],
 		});
 		const agent = new Agent({
 			initialState: { systemPrompt: [""], model: mock.model, tools: [askTool(executed)], messages: [] },
@@ -508,6 +630,7 @@ describe("agentLoop: ASCII-escaped non-ASCII argument guard", () => {
 		);
 		expect(accepted).toBeDefined();
 		expect(accepted?.content[0]).toEqual(thinkingToolTurn("unused").content[0]);
+		expect(accepted?.content[1]).toEqual(thinkingToolTurn("tc-accepted").content[1]);
 		expect(accepted?.usage).toEqual(PROVIDER_USAGE);
 		expect(accepted?.responseId).toBe("provider-response-id");
 		expect(accepted?.disabledFeatures).toEqual(["priority"]);
@@ -516,14 +639,8 @@ describe("agentLoop: ASCII-escaped non-ASCII argument guard", () => {
 			provider: "mock",
 			items: [{ id: "native-item" }],
 		});
-		expect(
-			agent.state.messages.some(
-				message =>
-					message.role === "assistant" &&
-					message.content.some(block => block.type === "toolCall" && block.id === "tc-defective"),
-			),
-		).toBe(false);
-		const replayed = mock.calls[2]?.context.messages.find(
+		expect(executed).toEqual([{ question: QUESTION }]);
+		const replayed = mock.calls[1]?.context.messages.find(
 			(message): message is AssistantMessage =>
 				message.role === "assistant" &&
 				message.content.some(block => block.type === "toolCall" && block.id === "tc-accepted"),
@@ -559,7 +676,13 @@ describe("agentLoop: ASCII-escaped non-ASCII argument guard", () => {
 		const mock = createMockModel({ responses: [escapedTurn("tc-1"), literalTurn("tc-2"), { content: ["done"] }] });
 		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
 
-		const stream = agentLoop([createUserMessage("ask me")], context, config, undefined, mock.stream);
+		const stream = agentLoop(
+			[createUserMessage("ask me")],
+			context,
+			config,
+			undefined,
+			terminalOnlyStream(mock.stream),
+		);
 		for await (const _event of stream) {
 			// drain
 		}
@@ -669,8 +792,17 @@ describe("agentLoop: ASCII-escaped non-ASCII argument guard", () => {
 
 		expect(executed).toEqual([{ question: QUESTION }]);
 		expect(toolEvents.map(event => ("toolCallId" in event ? event.toolCallId : undefined))).toEqual([
+			"tc-clean-never",
+			"tc-clean-never",
+			"tc-escaped",
+			"tc-escaped",
 			"tc-retry",
 			"tc-retry",
+		]);
+		expect(toolEvents.filter(event => event.type === "tool_execution_end").map(event => event.isError)).toEqual([
+			true,
+			true,
+			false,
 		]);
 	});
 
@@ -722,7 +854,13 @@ describe("agentLoop: ASCII-escaped non-ASCII argument guard", () => {
 		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
 		const toolEnds: AgentEvent[] = [];
 
-		const stream = agentLoop([createUserMessage("ask me")], context, config, undefined, mock.stream);
+		const stream = agentLoop(
+			[createUserMessage("ask me")],
+			context,
+			config,
+			undefined,
+			terminalOnlyStream(mock.stream),
+		);
 		for await (const event of stream) if (event.type === "tool_execution_end") toolEnds.push(event);
 
 		expect(mock.calls).toHaveLength(4);
@@ -747,7 +885,13 @@ describe("agentLoop: ASCII-escaped non-ASCII argument guard", () => {
 		});
 		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
 
-		const stream = agentLoop([createUserMessage("ask twice")], context, config, undefined, mock.stream);
+		const stream = agentLoop(
+			[createUserMessage("ask twice")],
+			context,
+			config,
+			undefined,
+			terminalOnlyStream(mock.stream),
+		);
 		for await (const _event of stream) {
 			// drain
 		}
@@ -773,7 +917,13 @@ describe("agentLoop: ASCII-escaped non-ASCII argument guard", () => {
 			},
 		};
 
-		const stream = agentLoop([createUserMessage("ask me")], context, config, undefined, mock.stream);
+		const stream = agentLoop(
+			[createUserMessage("ask me")],
+			context,
+			config,
+			undefined,
+			terminalOnlyStream(mock.stream),
+		);
 		for await (const _event of stream) {
 			// drain
 		}
@@ -1074,7 +1224,13 @@ describe("agentLoop: ASCII-escaped non-ASCII argument guard", () => {
 		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
 
 		const toolResults: Array<{ isError?: boolean; text: string }> = [];
-		const stream = agentLoop([createUserMessage("ask me")], context, config, undefined, mock.stream);
+		const stream = agentLoop(
+			[createUserMessage("ask me")],
+			context,
+			config,
+			undefined,
+			terminalOnlyStream(mock.stream),
+		);
 		for await (const event of stream) {
 			if (event.type === "tool_execution_end") {
 				const first = event.result.content?.[0];
@@ -1401,7 +1557,13 @@ describe("agentLoop: ASCII-escaped non-ASCII argument guard", () => {
 		});
 		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
 
-		const stream = agentLoop([createUserMessage("ask me")], context, config, undefined, mock.stream);
+		const stream = agentLoop(
+			[createUserMessage("ask me")],
+			context,
+			config,
+			undefined,
+			terminalOnlyStream(mock.stream),
+		);
 		for await (const _event of stream) {
 			// drain
 		}
@@ -1478,7 +1640,7 @@ describe("agentLoop: ASCII-escaped non-ASCII argument guard", () => {
 	it.each([
 		["U+00B7 one-nibble ASCII landing", String.raw`{"question":"\u0077"}`, "w"],
 		["U+2026 one-nibble ASCII landing", String.raw`{"question":"\u0026"}`, "&"],
-	])("rejects %s after the full resample budget", async (_label, rawArguments, decodedQuestion) => {
+	])("rejects each published %s turn without executing", async (_label, rawArguments, decodedQuestion) => {
 		const executed: Array<Record<string, unknown>> = [];
 		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [displaySafeAskTool(executed)] };
 		const turn = (id: string) => ({
@@ -1513,9 +1675,13 @@ describe("agentLoop: ASCII-escaped non-ASCII argument guard", () => {
 
 		expect(mock.calls).toHaveLength(4);
 		expect(executed).toHaveLength(0);
-		expect(toolResults).toHaveLength(1);
-		expect(toolResults[0]).toMatchObject({ isError: true });
+		expect(toolResults).toHaveLength(3);
+		expect(toolResults.map(result => result.isError)).toEqual([true, true, true]);
 		expect(toolResults[0].text).toContain("\\uXXXX");
+		expect(toolResults[1].text).toContain("\\uXXXX");
+		expect(toolResults[2].text).toBe(
+			"Tool execution failed due to an error: Tool calls are disabled during repeated malformed tool-call recovery.",
+		);
 	});
 
 	it("allows exact U+2014 evidence at duplicate nested array/object display positions", async () => {
@@ -1902,9 +2068,13 @@ describe("agentLoop: ASCII-escaped non-ASCII argument guard", () => {
 		}
 
 		expect(executed).toHaveLength(0);
-		expect(toolResults).toHaveLength(1);
-		expect(toolResults[0].isError).toBe(true);
+		expect(toolResults).toHaveLength(3);
+		expect(toolResults.map(result => result.isError)).toEqual([true, true, true]);
 		expect(toolResults[0].text).toContain("\\uXXXX");
+		expect(toolResults[1].text).toContain("\\uXXXX");
+		expect(toolResults[2].text).toBe(
+			"Tool execution failed due to an error: Tool calls are disabled during repeated malformed tool-call recovery.",
+		);
 	});
 
 	it("never executes the same em-dash payload when the tool is not display-safe", async () => {
@@ -1929,11 +2099,15 @@ describe("agentLoop: ASCII-escaped non-ASCII argument guard", () => {
 			}
 		}
 
-		// Mutating tools stay fail-closed: budget spent, then terminal rejection.
+		// Mutating tools stay fail-closed: every published turn receives a terminal rejection.
 		expect(executed).toHaveLength(0);
-		expect(toolResults).toHaveLength(1);
-		expect(toolResults[0].isError).toBe(true);
+		expect(toolResults).toHaveLength(3);
+		expect(toolResults.map(result => result.isError)).toEqual([true, true, true]);
 		expect(toolResults[0].text).toContain("\\uXXXX");
+		expect(toolResults[1].text).toContain("\\uXXXX");
+		expect(toolResults[2].text).toBe(
+			"Tool execution failed due to an error: Tool calls are disabled during repeated malformed tool-call recovery.",
+		);
 	});
 
 	it("rejects an uncorroborated symbol escape even on a display-safe tool", async () => {
@@ -1969,9 +2143,13 @@ describe("agentLoop: ASCII-escaped non-ASCII argument guard", () => {
 		// Without corroborating raw evidence even display-field text keeps the
 		// fail-closed rejection — the decode can never be verified.
 		expect(executed).toHaveLength(0);
-		expect(toolResults).toHaveLength(1);
-		expect(toolResults[0].isError).toBe(true);
+		expect(toolResults).toHaveLength(3);
+		expect(toolResults.map(result => result.isError)).toEqual([true, true, true]);
 		expect(toolResults[0].text).toContain("\\uXXXX");
+		expect(toolResults[1].text).toContain("\\uXXXX");
+		expect(toolResults[2].text).toBe(
+			"Tool execution failed due to an error: Tool calls are disabled during repeated malformed tool-call recovery.",
+		);
 	});
 
 	it("rejects uncorroborated currency, math, full-width, separator, letter, and emoji escapes on a display-safe tool", async () => {
@@ -2012,9 +2190,13 @@ describe("agentLoop: ASCII-escaped non-ASCII argument guard", () => {
 			}
 
 			expect(executed).toHaveLength(0);
-			expect(toolResults).toHaveLength(1);
-			expect(toolResults[0].isError).toBe(true);
+			expect(toolResults).toHaveLength(3);
+			expect(toolResults.map(result => result.isError)).toEqual([true, true, true]);
 			expect(toolResults[0].text).toContain("\\uXXXX");
+			expect(toolResults[1].text).toContain("\\uXXXX");
+			expect(toolResults[2].text).toBe(
+				"Tool execution failed due to an error: Tool calls are disabled during repeated malformed tool-call recovery.",
+			);
 			expect(label).toBeTruthy();
 		}
 	});

--- a/packages/coding-agent/test/responses-tool-visibility.test.ts
+++ b/packages/coding-agent/test/responses-tool-visibility.test.ts
@@ -1,0 +1,534 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { agentLoop } from "@gajae-code/agent-core/agent-loop";
+import { isNonDispatchedToolEvent } from "@gajae-code/agent-core/tool-dispatch-identity";
+import type { AgentTool } from "@gajae-code/agent-core/types";
+import { processResponsesStream } from "@gajae-code/ai/providers/openai-responses-shared";
+import type { AssistantMessage, AssistantMessageEvent, Message, Model } from "@gajae-code/ai/types";
+import { AssistantMessageEventStream } from "@gajae-code/ai/utils/event-stream";
+import { Container, Text, TUI } from "@gajae-code/tui";
+import type { ResponseStreamEvent } from "openai/resources/responses/responses";
+import * as z from "zod/v4";
+import { VirtualTerminal } from "../../tui/test/virtual-terminal";
+import { resetSettingsForTest, Settings } from "../src/config/settings";
+import { EventController } from "../src/modes/controllers/event-controller";
+import { initTheme } from "../src/modes/theme/theme";
+import type { InteractiveModeContext } from "../src/modes/types";
+
+beforeEach(async () => {
+	resetSettingsForTest();
+	await Settings.init({ inMemory: true });
+	await initTheme(false);
+});
+afterEach(() => resetSettingsForTest());
+
+const model: Model<"openai-responses"> = {
+	id: "visibility-test",
+	name: "Visibility test",
+	api: "openai-responses",
+	provider: "openai",
+	baseUrl: "https://example.invalid/v1",
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 128000,
+	maxTokens: 8192,
+};
+
+function makeMessage(): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [],
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		stopReason: "stop",
+		timestamp: 1,
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+	};
+}
+
+// Only drain scheduled frames; never request a render, send input, resize, or
+// force a full repaint here. A missing controller render must remain observable.
+async function expectVisible(terminal: VirtualTerminal, ...needles: string[]): Promise<void> {
+	let viewport = "";
+	for (let frame = 0; frame < 5; frame++) {
+		await terminal.waitForRender();
+		viewport = terminal.getViewport().join("\n");
+		if (needles.every(needle => viewport.includes(needle))) return;
+	}
+	for (const needle of needles) expect(viewport).toContain(needle);
+}
+
+function createFixture(historyRows: number) {
+	const terminal = new VirtualTerminal(100, 32, { isProcessTerminal: true });
+	const ui = new TUI(terminal);
+	const chatContainer = new Container();
+	if (historyRows > 0) {
+		chatContainer.addChild(
+			new Text(Array.from({ length: historyRows }, (_, index) => `history-row-${index}`).join("\n"), 0, 0),
+		);
+	}
+	const statusLine = new Text("STATUS-PINNED", 0, 0);
+	ui.addChild(chatContainer);
+	ui.setViewportAnchorComponent(chatContainer);
+	ui.addChild(statusLine);
+	ui.addChild(new Text("> EDITOR-PINNED", 0, 0));
+	ui.setBottomPinnedComponent(statusLine);
+	const identity = "session:responses-visibility";
+	let revision = 0n;
+	ui.setViewportOutputSource({ identity, revision });
+	const ctx = {
+		isInitialized: true,
+		isBackgrounded: false,
+		ui,
+		chatContainer,
+		statusLine,
+		pendingTools: new Map(),
+		pendingBashComponents: [],
+		pendingPythonComponents: [],
+		hideThinkingBlock: false,
+		toolOutputExpanded: true,
+		session: {
+			getToolByName: () => undefined,
+			isTtsrAbortPending: false,
+			retryAttempt: 0,
+		},
+		sessionManager: { getCwd: () => process.cwd() },
+		updateEditorTopBorder() {},
+		recordVisibleTranscriptMutation() {
+			revision += 1n;
+			ui.setViewportOutputSource({ identity, revision });
+		},
+	} as unknown as InteractiveModeContext;
+	const controller = new EventController(ctx);
+	return { terminal, ui, chatContainer, ctx, controller };
+}
+
+describe("Responses tools remain visible during uninterrupted reasoning", () => {
+	for (const historyRows of [0, 10000]) {
+		it(`paints streamed calls and execution results before interruption (${historyRows} history rows)`, async () => {
+			const { terminal, ui, chatContainer, ctx, controller } = createFixture(historyRows);
+			const output = makeMessage();
+			const pending: AssistantMessageEvent[] = [];
+			const emittedTypes: string[] = [];
+			// Snapshot at the provider boundary: processResponsesStream mutates its
+			// output in place. Delivery is serialized like the session event bridge,
+			// rather than letting later deltas overwrite earlier test observations.
+			const sink = {
+				push(event: AssistantMessageEvent) {
+					pending.push(structuredClone(event));
+					emittedTypes.push(event.type);
+				},
+			} as unknown as AssistantMessageEventStream;
+			async function deliver() {
+				for (const event of pending.splice(0)) {
+					if (!("partial" in event)) throw new Error(`Unexpected terminal provider event: ${event.type}`);
+					await controller.handleEvent({
+						type: "message_update",
+						message: event.partial,
+						assistantMessageEvent: event,
+					});
+				}
+			}
+			const toolItem = {
+				type: "function_call",
+				id: "fc_visibility",
+				call_id: "call_visibility",
+				name: "bash",
+				arguments: "",
+			};
+			const args = { command: "printf TOOL-CALL-VISIBLE" };
+			let toolCallId = "";
+			const result = (text: string) => ({ content: [{ type: "text" as const, text }], details: {} });
+			// Checkpoints run while the converter is still consuming the wire stream.
+			// No response.completed, message_end, agent_end, or keyboard event can
+			// rescue a stale frame before these assertions.
+			const steps: Array<object | (() => Promise<void>)> = [
+				{
+					type: "response.output_item.added",
+					output_index: 0,
+					item: { type: "reasoning", id: "rs_first", summary: [] },
+				},
+				{
+					type: "response.reasoning_summary_part.added",
+					item_id: "rs_first",
+					output_index: 0,
+					summary_index: 0,
+					part: { type: "summary_text", text: "" },
+				},
+				{
+					type: "response.reasoning_summary_text.delta",
+					item_id: "rs_first",
+					output_index: 0,
+					summary_index: 0,
+					delta: "**Inspecting tools**\n\nChecking the visible stream.",
+				},
+				async () => {
+					await expectVisible(terminal, "Inspecting tools", "STATUS-PINNED", "EDITOR-PINNED");
+					if (historyRows > 0) expect(terminal.getViewport().join("\n")).not.toContain("history-row-0\n");
+				},
+				{ type: "response.output_item.added", output_index: 1, item: toolItem },
+				{
+					type: "response.function_call_arguments.delta",
+					item_id: toolItem.id,
+					output_index: 1,
+					delta: '{"command":"printf TOOL-',
+				},
+				{
+					type: "response.function_call_arguments.delta",
+					item_id: toolItem.id,
+					output_index: 1,
+					delta: 'CALL-VISIBLE"}',
+				},
+				async () => {
+					await expectVisible(terminal, "TOOL-CALL-VISIBLE", "STATUS-PINNED");
+				},
+				{
+					type: "response.output_item.done",
+					output_index: 1,
+					item: { ...toolItem, arguments: JSON.stringify(args), status: "completed" },
+				},
+				async () => {
+					const call = output.content.find(block => block.type === "toolCall");
+					if (call?.type !== "toolCall") throw new Error("Converter did not emit the tool call");
+					toolCallId = call.id;
+					await controller.handleEvent({ type: "tool_execution_start", toolCallId, toolName: "bash", args });
+					await expectVisible(terminal, "TOOL-CALL-VISIBLE");
+					await controller.handleEvent({
+						type: "tool_execution_update",
+						toolCallId,
+						toolName: "bash",
+						args,
+						partialResult: result("RESULT-PARTIAL-VISIBLE"),
+					});
+					await expectVisible(terminal, "TOOL-CALL-VISIBLE", "RESULT-PARTIAL-VISIBLE");
+					await controller.handleEvent({
+						type: "tool_execution_end",
+						toolCallId,
+						toolName: "bash",
+						result: result("RESULT-FINAL-VISIBLE"),
+						isError: false,
+					});
+					await expectVisible(terminal, "TOOL-CALL-VISIBLE", "RESULT-FINAL-VISIBLE");
+				},
+				{
+					type: "response.output_item.added",
+					output_index: 2,
+					item: { type: "reasoning", id: "rs_next", summary: [] },
+				},
+				{
+					type: "response.reasoning_summary_part.added",
+					item_id: "rs_next",
+					output_index: 2,
+					summary_index: 0,
+					part: { type: "summary_text", text: "" },
+				},
+				{
+					type: "response.reasoning_summary_text.delta",
+					item_id: "rs_next",
+					output_index: 2,
+					summary_index: 0,
+					delta: "**Reviewing results**\n\nContinuing without input.",
+				},
+				async () => {
+					await expectVisible(
+						terminal,
+						"Reviewing results",
+						"TOOL-CALL-VISIBLE",
+						"RESULT-FINAL-VISIBLE",
+						"EDITOR-PINNED",
+					);
+					expect(ctx.streamingComponent).toBeDefined();
+					expect(ctx.pendingTools.size).toBe(0);
+				},
+			];
+			async function* wire(): AsyncIterable<ResponseStreamEvent> {
+				for (const step of steps) {
+					await deliver();
+					if (typeof step === "function") await step();
+					else yield step as ResponseStreamEvent;
+				}
+				await deliver();
+			}
+			try {
+				ui.start();
+				await controller.handleEvent({ type: "message_start", message: output });
+				await processResponsesStream(wire(), output, sink, model);
+				expect(emittedTypes).toContain("reasoning_summary_delta");
+				expect(emittedTypes).toContain("toolcall_delta");
+				expect(emittedTypes).toContain("toolcall_end");
+
+				// Only now simulate interruption. Queue an unpainted text delta and
+				// immediately replace it with the authoritative aborted message.
+				const draft = structuredClone(output);
+				const contentIndex = draft.content.length;
+				draft.content.push({ type: "text", text: "STALE-DRAFT-MUST-NOT-APPEAR" });
+				await controller.handleEvent({
+					type: "message_update",
+					message: draft,
+					assistantMessageEvent: {
+						type: "text_delta",
+						contentIndex,
+						delta: "STALE-DRAFT-MUST-NOT-APPEAR",
+						partial: draft,
+					},
+				});
+				await controller.handleEvent({
+					type: "message_end",
+					message: { ...structuredClone(output), stopReason: "aborted" },
+				});
+				await expectVisible(terminal, "Reviewing results", "RESULT-FINAL-VISIBLE");
+				expect(ctx.streamingComponent).toBeUndefined();
+				expect(ctx.streamingMessage).toBeUndefined();
+				controller.resumeAssistantTextPresentation();
+				await terminal.waitForRender();
+				expect(terminal.getScrollBuffer().join("\n")).not.toContain("STALE-DRAFT-MUST-NOT-APPEAR");
+			} finally {
+				controller.dispose();
+				chatContainer.clear();
+				ui.stop();
+				await terminal.flush();
+			}
+		});
+	}
+});
+
+async function within<T>(promise: Promise<T>, label: string): Promise<T> {
+	const timeout = Promise.withResolvers<never>();
+	const timer: NodeJS.Timeout = setTimeout(() => timeout.reject(new Error(`Timed out: ${label}`)), 2000);
+	try {
+		return await Promise.race([promise, timeout.promise]);
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
+for (const [abortBeforeDone, toolOnly, description] of [
+	[
+		false,
+		false,
+		"publishes reasoning/tool-only updates before provider done and results before the next response ends",
+	],
+	[true, false, "abort before provider done retains visible reasoning and tool call without execution"],
+	[false, true, "publishes tool-only response before provider done"],
+] as const) {
+	it(`agentLoop ${description}`, async () => {
+		const { terminal, ui, chatContainer, ctx, controller } = createFixture(10000);
+		const abort = new AbortController();
+		const firstReady = Promise.withResolvers<void>();
+		const firstRelease = Promise.withResolvers<void>();
+		const secondReady = Promise.withResolvers<void>();
+		const secondRelease = Promise.withResolvers<void>();
+		const toolReady = Promise.withResolvers<void>();
+		const toolRelease = Promise.withResolvers<void>();
+		const providerTasks: Promise<void>[] = [];
+		const seen: string[] = [];
+		const cancelledPair: Array<{ type: string; nonDispatched: boolean }> = [];
+		let executions = 0;
+		const schema = z.object({ command: z.string() });
+		const tool: AgentTool<typeof schema> = {
+			name: "bash",
+			label: "Bash",
+			description: "Deterministic visibility fixture; never executes a shell",
+			parameters: schema,
+			async execute(_id, _args, _signal, onUpdate) {
+				executions += 1;
+				onUpdate?.({ content: [{ type: "text", text: "LOOP-PARTIAL-VISIBLE" }], details: {} });
+				toolReady.resolve();
+				await toolRelease.promise;
+				return { content: [{ type: "text", text: "LOOP-FINAL-VISIBLE" }], details: {} };
+			},
+		};
+		let calls = 0;
+		let consumerError: unknown;
+		let consume: Promise<void> | undefined;
+		try {
+			ui.start();
+			const events = agentLoop(
+				[{ role: "user", content: "Check tool visibility", timestamp: 1 }],
+				{ systemPrompt: [""], messages: [], tools: [tool] },
+				{ model, convertToLlm: messages => messages as Message[], fallbackManaged: false },
+				abort.signal,
+				() => {
+					const response = ++calls;
+					const stream = new AssistantMessageEventStream();
+					const output = makeMessage();
+					const task = (async () => {
+						try {
+							const reasoningId = `rs_loop_${response}`;
+							async function* wire(): AsyncIterable<ResponseStreamEvent> {
+								const events: object[] = [
+									{
+										type: "response.output_item.added",
+										output_index: 0,
+										item: { type: "reasoning", id: reasoningId, summary: [] },
+									},
+									{
+										type: "response.reasoning_summary_part.added",
+										item_id: reasoningId,
+										output_index: 0,
+										summary_index: 0,
+										part: { type: "summary_text", text: "" },
+									},
+									{
+										type: "response.reasoning_summary_text.delta",
+										item_id: reasoningId,
+										output_index: 0,
+										summary_index: 0,
+										delta: response === 1 ? "**Loop inspecting tools**" : "**Loop reviewing results**",
+									},
+								];
+								if (toolOnly && response === 1) events.length = 0;
+								if (response === 1) {
+									const item = {
+										type: "function_call",
+										id: "fc_loop",
+										call_id: "call_loop",
+										name: "bash",
+										arguments: "",
+									};
+									const outputIndex = toolOnly ? 0 : 1;
+									events.push(
+										{ type: "response.output_item.added", output_index: outputIndex, item },
+										{
+											type: "response.function_call_arguments.delta",
+											item_id: item.id,
+											output_index: outputIndex,
+											delta: '{"command":"printf LOOP-CALL-VISIBLE"}',
+										},
+										{
+											type: "response.output_item.done",
+											output_index: outputIndex,
+											item: {
+												...item,
+												arguments: '{"command":"printf LOOP-CALL-VISIBLE"}',
+												status: "completed",
+											},
+										},
+									);
+								}
+								for (const event of events) yield event as ResponseStreamEvent;
+							}
+							stream.push({ type: "start", partial: output });
+							await processResponsesStream(wire(), output, stream, model);
+							const ready = response === 1 ? firstReady : secondReady;
+							const release = response === 1 ? firstRelease : secondRelease;
+							ready.resolve();
+							await release.promise;
+							if (abort.signal.aborted) {
+								output.stopReason = "aborted";
+								stream.push({ type: "error", reason: "aborted", error: output });
+							} else {
+								output.stopReason = response === 1 ? "toolUse" : "stop";
+								stream.push({ type: "done", reason: output.stopReason, message: output });
+							}
+						} catch (error) {
+							output.stopReason = "error";
+							output.errorMessage = String(error);
+							stream.push({ type: "error", reason: "error", error: output });
+							firstReady.reject(error);
+							secondReady.resolve();
+						} finally {
+							stream.end();
+						}
+					})();
+					providerTasks.push(task);
+					return stream;
+				},
+			);
+			consume = (async () => {
+				for await (const event of events) {
+					seen.push(
+						event.type === "message_start" || event.type === "message_end"
+							? `${event.message.role}:${event.type}`
+							: event.type,
+					);
+					if (event.type === "tool_execution_start" || event.type === "tool_execution_end") {
+						cancelledPair.push({ type: event.type, nonDispatched: isNonDispatchedToolEvent(event) });
+					}
+					// The full loop and tool dispatcher are real. Only unrelated root-mode
+					// activity/user-message chrome is omitted from this focused bridge.
+					if (
+						((event.type === "message_start" || event.type === "message_end") &&
+							event.message.role === "assistant") ||
+						event.type === "message_update" ||
+						event.type === "tool_execution_start" ||
+						event.type === "tool_execution_update" ||
+						event.type === "tool_execution_end"
+					)
+						await controller.handleEvent(event);
+				}
+			})().catch(error => {
+				consumerError = error;
+			});
+
+			await within(firstReady.promise, "first provider deltas");
+			const firstVisible = toolOnly
+				? ["LOOP-CALL-VISIBLE", "EDITOR-PINNED"]
+				: ["Loop inspecting tools", "LOOP-CALL-VISIBLE", "EDITOR-PINNED"];
+			await expectVisible(terminal, ...firstVisible);
+			expect(executions).toBe(0);
+			if (abortBeforeDone) {
+				// Publication precedes interruption; abort must retain that output
+				// without accepting or executing the still-unfinished response.
+				expect(seen).not.toContain("assistant:message_end");
+				expect(seen).not.toContain("tool_execution_start");
+				expect(executions).toBe(0);
+				abort.abort();
+				firstRelease.resolve();
+				await within(consume, "abort before provider completion");
+				expect(consumerError).toBeUndefined();
+				await expectVisible(terminal, ...firstVisible);
+				expect(executions).toBe(0);
+				expect(cancelledPair).toEqual([
+					{ type: "tool_execution_start", nonDispatched: true },
+					{ type: "tool_execution_end", nonDispatched: true },
+				]);
+				expect(seen).toContain("agent_end");
+				expect(ctx.streamingComponent).toBeUndefined();
+				expect(ctx.streamingMessage).toBeUndefined();
+				return;
+			}
+			// A tool cannot execute before response acceptance. Its *streamed call*
+			// must nevertheless be visible before provider done releases the loop.
+			expect(seen).not.toContain("assistant:message_end");
+			expect(seen).not.toContain("tool_execution_start");
+			firstRelease.resolve();
+			await within(toolReady.promise, "tool partial update");
+			await expectVisible(terminal, "LOOP-CALL-VISIBLE", "LOOP-PARTIAL-VISIBLE");
+			toolRelease.resolve();
+			await within(secondReady.promise, "next reasoning response");
+			await expectVisible(terminal, "Loop reviewing results", "LOOP-FINAL-VISIBLE", "EDITOR-PINNED");
+			expect(seen).not.toContain("agent_end");
+			expect(ctx.pendingTools.size).toBe(0);
+			// Abort the still-open second response only after all live visibility checks.
+			abort.abort();
+			secondRelease.resolve();
+			await within(consume, "interrupted loop cleanup");
+			expect(consumerError).toBeUndefined();
+			expect(ctx.streamingComponent).toBeUndefined();
+			expect(ctx.streamingMessage).toBeUndefined();
+			await expectVisible(terminal, "Operation aborted", "LOOP-FINAL-VISIBLE");
+		} finally {
+			abort.abort();
+			firstRelease.resolve();
+			secondRelease.resolve();
+			toolRelease.resolve();
+			try {
+				await within(Promise.all([consume, ...providerTasks]), "fixture teardown");
+			} finally {
+				controller.dispose();
+				chatContainer.clear();
+				ui.stop();
+				await terminal.flush();
+			}
+		}
+	});
+}


### PR DESCRIPTION
## Summary

Fix ordinary **unmanaged** thinking/tool-only streams remaining invisible until text, provider completion, or interruption. Publish nonterminal content events through the existing transaction commit path; tool acceptance and execution still wait for terminal validation and the consumer drain.

### Confirmed cause

The Responses parser and TUI were not buffering the output in the reproduced case. Direct Responses converter → EventController → TUI tests passed with both empty and 10,000-row history. The same gated stream through the real `agentLoop` failed before provider completion because `escapedToolTransaction` committed early only for `text_*` events.

The fix publishes thinking, reasoning summaries, and tool-call events too. It does **not** force redraws, clear caches, execute tools early, or change managed fallback atomicity. Already-published legacy guarded calls receive explicit rejection rather than silently disappearing into a retry. Unpublished terminal-only recovery remains bounded and tested.

## Verification

- Before fix: direct-to-TUI controls **2 passed**; real-agentLoop live-visibility regression **failed** with missing reasoning/call output before provider done.
- After rebase onto current `dev`: **1033 passed, 0 failed** across 75 files, including agent, streaming edit abort/cache/output, and TUI regressions.
- `bun --cwd=packages/agent run check` passed.
- `bun --cwd=packages/coding-agent run check:types` passed.
- Real PTY replay at **48×24, 100×32, 140×40** passed without keyboard input. Byte-arrival checkpoints prove call/reasoning visibility before provider completion and partial/final results before interruption. Zero executions before acceptance, exactly one afterward.
- Cleanup, architecture/product/code, and QA/red-team review joined clean on the implementation; final durable review rebinds the committed change-set hash.

### Captured PTY stages

```text
Before provider completion (executions = 0):
  REASONING-PTY-VISIBLE
  중간 도구 출력을 확인합니다.
  Bash
  $ printf CALL-PTY-VISIBLE
  RUNNING — no keyboard input
  > Editor remains available

Before interruption (executions = 1):
  Bash / Output
  RESULT-PTY-VISIBLE
  SECOND-REASONING-VISIBLE
  RUNNING — no keyboard input
  > Editor remains available
```

[Committed regression harness](https://github.com/Yeachan-Heo/gajae-code/blob/bb42f5df2a/packages/coding-agent/test/responses-tool-visibility.test.ts) covers tool-only streams, result replacement, abort-before-done non-dispatched pairing, pinned chrome, and long transcript history. [Core guard tests](https://github.com/Yeachan-Heo/gajae-code/blob/bb42f5df2a/packages/agent/test/agent-loop-escaped-nonascii-toolcall.test.ts) retain premature-execution, invalid-call/sibling rejection, managed atomicity, and unpublished-recovery coverage. Follow-up test cleanup uses the explicit mock-stream type and `Bun.sleep(0)`; the full 1033-test union and PTY captures were rerun successfully.

Full local evidence is retained under `artifacts/responses-tool-visibility/`: per-size `terminal-ansi.txt`, full-scrollback `terminal.txt`, styled `terminal.html`, timestamped `metadata.json`, and `checkpoints.json`. These generated files are intentionally not committed; the stage excerpt above is included for PR reviewers.

## Scope and limitations

- Deterministic Responses event replay, not a credentialed request to the remote OpenAI service.
- Managed fallback attempts still publish/discard atomically; retractable managed live previews are not part of this fix.
- Existing TUI visual grammar is unchanged. Narrow/wide terminal and Korean summary readability were reviewed through ANSI-preserving evidence; no renderer or design-system change was necessary.
- No workflow definitions, generated schema, or defaults changed. Do not merge automatically.

## Risk classification

- [ ] `low-risk`
- [x] `regression-risk` — changes live event publication and visible recovery behavior; independent exact-head merge review remains required.
- [ ] `high-risk`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:e93a9e596f2ec9eadaaebae926782d514b2746e3217b59b6b536266c9331b790 reviewer:human reviewer-id:snowykr evidence:https://github.com/Yeachan-Heo/gajae-code/pull/5421#pullrequestreview-5140115718
```

Authenticated exact-head APPROVED review is snowykr 5140115718 at `ef58cd4bbb5b2c0cfbc027d3086b3a2a98f05ea4`. Digest recomputed with `git diff --binary --full-index --no-ext-diff f19e6867547068d1c7eec237c68150c0fd69bcab...ef58cd4bbb5b2c0cfbc027d3086b3a2a98f05ea4 | sha256sum` = `e93a9e596f2ec9eadaaebae926782d514b2746e3217b59b6b536266c9331b790`. Risk remains `regression-risk` (one box).


<!-- gjc-maintenance-01a083b2 -->
Current maintenance snapshot: base `f19e6867547068d1c7eec237c68150c0fd69bcab`, head `ef58cd4bbb5b2c0cfbc027d3086b3a2a98f05ea4`. Earlier narrative/test evidence is historical unless explicitly rebound to this head. Rebase/diff verification does not replace required CI or independent approval.
<!-- /gjc-maintenance-01a083b2 -->

