### PR TITLE
feat(ci): validate the PR contract at push time

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -2,9 +2,10 @@
 # Exact-head PR contract preflight (issue: red "PR contract bootstrap" runs).
 #
 # git feeds "<local-ref> <local-sha> <remote-ref> <remote-sha>" on stdin for every ref
-# being pushed. For each branch push with a real commit, validate the commit that is
-# about to become the PR head against the live PR body, so a stale verdict digest or an
-# unrebased base fails here instead of in CI.
+# being pushed. The PR identity is the REMOTE destination, not the local source: for
+# `git push origin HEAD:refs/heads/feature` the local ref is bare `HEAD`, and for a
+# renamed refspec the two names differ. So branch is derived from <remote-ref> while
+# <local-sha> stays the commit under validation.
 #
 # Install: git config core.hooksPath .githooks   (or: bun run install:dev)
 # Bypass:  GJC_SKIP_PR_PREFLIGHT=1 git push      (or: git push --no-verify)
@@ -15,15 +16,18 @@ if [[ -n "${GJC_SKIP_PR_PREFLIGHT:-}" ]]; then
 fi
 
 repo_root="$(git rev-parse --show-toplevel)"
+remote="${1:-origin}"
 zero="0000000000000000000000000000000000000000"
 status=0
 
-while read -r local_ref local_sha _remote_ref _remote_sha; do
+while read -r _local_ref local_sha remote_ref _remote_sha; do
+	# A zero local sha is a branch deletion: no head to validate.
 	[[ "$local_sha" == "$zero" ]] && continue
-	[[ "$local_ref" == refs/heads/* ]] || continue
-	branch="${local_ref#refs/heads/}"
+	# Only branch destinations carry a PR; tags and notes never do.
+	[[ "$remote_ref" == refs/heads/* ]] || continue
+	branch="${remote_ref#refs/heads/}"
 	[[ "$branch" == "dev" || "$branch" == "main" ]] && continue
-	if ! bun "$repo_root/scripts/verify-pr-verdict.ts" --push-preflight "$branch" "$local_sha" --repo "$repo_root" --trusted-root "$repo_root"; then
+	if ! bun "$repo_root/scripts/verify-pr-verdict.ts" --push-preflight "$branch" "$local_sha" --push-remote "$remote" --repo "$repo_root" --trusted-root "$repo_root"; then
 		status=1
 	fi
 done

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Exact-head PR contract preflight (issue: red "PR contract bootstrap" runs).
+#
+# git feeds "<local-ref> <local-sha> <remote-ref> <remote-sha>" on stdin for every ref
+# being pushed. For each branch push with a real commit, validate the commit that is
+# about to become the PR head against the live PR body, so a stale verdict digest or an
+# unrebased base fails here instead of in CI.
+#
+# Install: git config core.hooksPath .githooks   (or: bun run install:dev)
+# Bypass:  GJC_SKIP_PR_PREFLIGHT=1 git push      (or: git push --no-verify)
+set -euo pipefail
+
+if [[ -n "${GJC_SKIP_PR_PREFLIGHT:-}" ]]; then
+	exit 0
+fi
+
+repo_root="$(git rev-parse --show-toplevel)"
+zero="0000000000000000000000000000000000000000"
+status=0
+
+while read -r local_ref local_sha _remote_ref _remote_sha; do
+	[[ "$local_sha" == "$zero" ]] && continue
+	[[ "$local_ref" == refs/heads/* ]] || continue
+	branch="${local_ref#refs/heads/}"
+	[[ "$branch" == "dev" || "$branch" == "main" ]] && continue
+	if ! bun "$repo_root/scripts/verify-pr-verdict.ts" --push-preflight "$branch" "$local_sha" --repo "$repo_root" --trusted-root "$repo_root"; then
+		status=1
+	fi
+done
+
+if [[ "$status" -ne 0 ]]; then
+	echo "pre-push: PR contract preflight failed. Fix the PR body/rebase, or push with GJC_SKIP_PR_PREFLIGHT=1." >&2
+fi
+exit "$status"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,6 +163,7 @@ Avoid placeholder tests, tautologies, broad `not.toThrow()` assertions, duplicat
 
 - Always commit incrementally; atomic commits are preferred. One logical change per commit — never batch unrelated work.
 - For targeted branch / PR-like work, always open a PR targeting `dev`.
+- The exact-head PR contract is validated locally before it can go red in CI: `git config core.hooksPath .githooks` (done by `bun run install:dev`, or `bun run dev:hooks`) enables a `pre-push` hook that runs `scripts/verify-pr-verdict.ts --push-preflight <branch> <pushed-sha>` against the live PR body. Stale verdict digests, unrebased bases, malformed verdicts, and missing risk classifications fail at push time. Blocking verdicts (`needs-human`, `merge-blocked`) are allowed locally — only the server merge gate rejects them. Bypass with `GJC_SKIP_PR_PREFLIGHT=1` or `--no-verify`.
 - Commit messages use the lore format: conventional-commit subject, a short why-focused body, then structured trailers. Include only the trailers that apply.
 
   ```

--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
   },
   "overrides": {},
   "scripts": {
-    "install:dev": "bun install && bun run build:native && bun --cwd=packages/coding-agent link && bun --cwd=packages/ai link && bun run dev:link && bun packages/coding-agent/src/cli.ts setup defaults",
+    "install:dev": "bun install && bun run build:native && bun --cwd=packages/coding-agent link && bun --cwd=packages/ai link && bun run dev:link && bun run dev:hooks && bun packages/coding-agent/src/cli.ts setup defaults",
+    "dev:hooks": "git config core.hooksPath .githooks",
     "install:dev:bin": "bun install && bun run --cwd=packages/coding-agent build && bun run dev:link:bin && packages/coding-agent/dist/gjc setup defaults",
     "install:defaults": "bun packages/coding-agent/src/cli.ts setup defaults",
     "dev": "bun --cwd=packages/coding-agent src/cli.ts",

--- a/scripts/install-dev.test.ts
+++ b/scripts/install-dev.test.ts
@@ -5,7 +5,7 @@ interface RootManifest {
 	scripts: Record<string, string>;
 }
 
-test("install:dev builds the native addon before linking the source CLI", async () => {
+test("install:dev builds the native addon, links the source CLI, and enables the repo git hooks", async () => {
 	const repoRoot = path.resolve(import.meta.dir, "..");
 	const manifest = (await Bun.file(path.join(repoRoot, "package.json")).json()) as RootManifest;
 
@@ -15,6 +15,7 @@ test("install:dev builds the native addon before linking the source CLI", async 
 		"bun --cwd=packages/coding-agent link",
 		"bun --cwd=packages/ai link",
 		"bun run dev:link",
+		"bun run dev:hooks",
 		"bun packages/coding-agent/src/cli.ts setup defaults",
 	]);
 });

--- a/scripts/verify-pr-verdict.test.ts
+++ b/scripts/verify-pr-verdict.test.ts
@@ -627,6 +627,32 @@ describe("push preflight", () => {
 		expect(await child.exited).toBe(0);
 	});
 
+	test("mirrors the Dev CI bootstrap job, which has no requireMergeApproved escape hatch", async () => {
+		const source = await Bun.file(new URL("./verify-pr-verdict.ts", import.meta.url)).text();
+		const pushPreflight = source.slice(source.indexOf("async function validatePushPreflight"));
+		// The bootstrap job blocks needs-human/merge-blocked unconditionally, so a preflight
+		// that passed them locally would disagree with the very check it predicts.
+		expect(pushPreflight).toContain("requireMergeApproved: true");
+		expect(pushPreflight).not.toContain("requireMergeApproved: false");
+		// Mirroring the flag alone would fail a legitimately reviewed merge-approved PR, so
+		// the exact-head approval must be resolved from the same review data.
+		expect(pushPreflight).toContain("authenticatedReviewerLogin: approval.login");
+		expect(pushPreflight).toContain('review.state !== "COMMENTED"');
+		expect(pushPreflight).toContain("review.commit?.oid === headSha");
+	});
+
+	test("a blocking verdict fails the push exactly as the bootstrap job does", () => {
+		const body = approved.replace("merge-approved", "needs-human");
+		const blocked = validatePrContract(validInput({ body, requireMergeApproved: true }));
+		expect(blocked.ok).toBe(false);
+		expect(blocked.diagnostics.join("\n")).toContain("intentionally blocks merge");
+	});
+
+	test("an exact-head approved merge-approved PR still passes the push gate", () => {
+		const reviewed = validatePrContract(validInput({ requireMergeApproved: true }));
+		expect(reviewed.ok).toBe(true);
+	});
+
 	test("a non-commit push target fails closed", async () => {
 		const script = url.fileURLToPath(new URL("./verify-pr-verdict.ts", import.meta.url));
 		const repoRoot = url.fileURLToPath(new URL("..", import.meta.url));

--- a/scripts/verify-pr-verdict.test.ts
+++ b/scripts/verify-pr-verdict.test.ts
@@ -627,6 +627,60 @@ describe("push preflight", () => {
 		expect(await child.exited).toBe(0);
 	});
 
+	test("derives the PR branch from the remote destination, not the local source ref", async () => {
+		const hook = await Bun.file(new URL("../.githooks/pre-push", import.meta.url)).text();
+		// `git push origin HEAD:refs/heads/feature` gives local_ref=HEAD, and a renamed
+		// refspec gives two different names; filtering on the local ref skips both.
+		expect(hook).toContain('[[ "$remote_ref" == refs/heads/* ]] || continue');
+		expect(hook).toContain('branch="${remote_ref#refs/heads/}"');
+		expect(hook).not.toContain('[[ "$local_ref" == refs/heads/* ]]');
+		// The pushed object, not the resolved remote branch tip, is the commit validated.
+		expect(hook).toContain('--push-preflight "$branch" "$local_sha"');
+		// The receiving remote is forwarded so the PR is looked up in the right repository.
+		expect(hook).toContain('--push-remote "$remote"');
+	});
+
+	test("binds PR lookup and base resolution to the receiving repository", async () => {
+		const source = await Bun.file(new URL("./verify-pr-verdict.ts", import.meta.url)).text();
+		const pushPreflight = source.slice(source.indexOf("async function validatePushPreflight"));
+		// An implicit gh context resolves a fork checkout to the fork, where the upstream PR
+		// does not exist -- the empty result would then wave the push through.
+		expect(pushPreflight).toContain('"--repo", baseRepo');
+		expect(pushPreflight).not.toContain('git(["fetch", "--no-tags", "origin", "dev"]');
+		expect(pushPreflight).not.toContain('rev-parse", "origin/dev"');
+		// The base is the PR's own base ref in the contract repository, never an assumed dev.
+		expect(pushPreflight).toContain("pr.baseRefName], cwd)");
+		// A same-named branch in another fork must not be mistaken for this PR.
+		expect(pushPreflight).toContain("headRepositoryOwner?.login?.toLowerCase() === headOwner.toLowerCase()");
+		// Ambiguity fails closed rather than guessing which contract governs the push.
+		expect(pushPreflight).toContain("cannot determine which contract governs this push");
+	});
+
+	test("resolves the GitHub repository from every supported remote URL form", async () => {
+		const source = await Bun.file(new URL("./verify-pr-verdict.ts", import.meta.url)).text();
+		const pattern = /const match = (\/.+\/u)\.exec\(text\);/u.exec(source.slice(source.indexOf("async function pushRemoteRepository")));
+		expect(pattern).not.toBeNull();
+		const remoteUrl = new RegExp(pattern![1]!.slice(1, -2), "u");
+		const resolve = (url: string): string | null => {
+			const match = remoteUrl.exec(url);
+			return match ? `${match[1]}/${match[2]}` : null;
+		};
+		expect(resolve("git@github.com:Yeachan-Heo/gajae-code.git")).toBe("Yeachan-Heo/gajae-code");
+		expect(resolve("https://github.com/Yeachan-Heo/gajae-code.git")).toBe("Yeachan-Heo/gajae-code");
+		expect(resolve("https://github.com/probepark/gajae-code")).toBe("probepark/gajae-code");
+		expect(resolve("ssh://git@github.com/Yeachan-Heo/gajae-code.git")).toBe("Yeachan-Heo/gajae-code");
+	});
+
+	test("a fork push resolves the contract to the upstream parent repository", async () => {
+		const source = await Bun.file(new URL("./verify-pr-verdict.ts", import.meta.url)).text();
+		const resolver = source.slice(source.indexOf("async function contractRepository"));
+		// A fork's PR lives upstream, so the parent owns the contract; the head stays
+		// qualified by the fork owner that actually receives the push.
+		expect(resolver).toContain('"isFork,parent"');
+		expect(resolver).toContain("return { repo: `${parentOwner}/${parentName}`, forkOwner: pushRepo.split(\"/\")[0]! };");
+		expect(resolver).toContain("if (!info.isFork || !parentOwner || !parentName) return { repo: pushRepo, forkOwner: null };");
+	});
+
 	test("mirrors the Dev CI bootstrap job, which has no requireMergeApproved escape hatch", async () => {
 		const source = await Bun.file(new URL("./verify-pr-verdict.ts", import.meta.url)).text();
 		const pushPreflight = source.slice(source.indexOf("async function validatePushPreflight"));

--- a/scripts/verify-pr-verdict.test.ts
+++ b/scripts/verify-pr-verdict.test.ts
@@ -608,6 +608,35 @@ test("preflight preserves missing body-file diagnostics", async () => {
 	}
 });
 
+describe("push preflight", () => {
+	test("pre-push hook validates every pushed branch head through the contract validator", async () => {
+		const hook = await Bun.file(new URL("../.githooks/pre-push", import.meta.url)).text();
+		// The pushed commit -- not local HEAD -- is what becomes the PR head.
+		expect(hook).toContain('--push-preflight "$branch" "$local_sha"');
+		expect(hook).toContain("GJC_SKIP_PR_PREFLIGHT");
+		// Deletions carry the zero sha and have no head to validate.
+		expect(hook).toContain('[[ "$local_sha" == "$zero" ]] && continue');
+	});
+
+	test("a branch with no open PR has no contract to invalidate", async () => {
+		const script = url.fileURLToPath(new URL("./verify-pr-verdict.ts", import.meta.url));
+		const repoRoot = url.fileURLToPath(new URL("..", import.meta.url));
+		const head = Bun.spawnSync(["git", "rev-parse", "HEAD"], { cwd: repoRoot });
+		const headSha = head.stdout.toString().trim();
+		const child = Bun.spawn([process.execPath, script, "--push-preflight", "gjc-preflight-branch-that-does-not-exist", headSha, "--repo", repoRoot, "--trusted-root", repoRoot], { stdout: "ignore", stderr: "ignore" });
+		expect(await child.exited).toBe(0);
+	});
+
+	test("a non-commit push target fails closed", async () => {
+		const script = url.fileURLToPath(new URL("./verify-pr-verdict.ts", import.meta.url));
+		const repoRoot = url.fileURLToPath(new URL("..", import.meta.url));
+		const child = Bun.spawn([process.execPath, script, "--push-preflight", "some-branch", "not-a-sha", "--repo", repoRoot, "--trusted-root", repoRoot], { stdout: "pipe", stderr: "pipe" });
+		const [stderr, exitCode] = await Promise.all([new Response(child.stderr).text(), child.exited]);
+		expect(exitCode).toBe(1);
+		expect(stderr).toContain("is not a lowercase 40-hex commit");
+	});
+});
+
 test("workflow is trusted-default-branch-controlled, read-only, exact-head, and invokes only base code", async () => {
 	const workflow = await Bun.file(new URL("../.github/workflows/pr-validation.yml", import.meta.url)).text();
 	expect(workflow).toContain("pull_request_target:");

--- a/scripts/verify-pr-verdict.test.ts
+++ b/scripts/verify-pr-verdict.test.ts
@@ -654,6 +654,12 @@ describe("push preflight", () => {
 		expect(pushPreflight).toContain("headRepositoryOwner?.login?.toLowerCase() === headOwner.toLowerCase()");
 		// Ambiguity fails closed rather than guessing which contract governs the push.
 		expect(pushPreflight).toContain("cannot determine which contract governs this push");
+		// gh pr list's JSON mapping drops headRefOid and review commit oids on older gh
+		// releases (e.g. 2.4.x), which would fail closed on every push, so the head oid
+		// and the review commits must be resolved through the stable `gh api` surface.
+		expect(pushPreflight).toContain('"--jq", ".head.sha"');
+		expect(pushPreflight).toContain("/pulls/${pr.number}/reviews");
+		expect(pushPreflight).not.toContain("reviews,headRefOid");
 	});
 
 	test("resolves the GitHub repository from every supported remote URL form", async () => {

--- a/scripts/verify-pr-verdict.ts
+++ b/scripts/verify-pr-verdict.ts
@@ -718,9 +718,13 @@ interface LivePullRequest {
 	body: string | null;
 	baseRefName: string;
 	author: { login: string } | null;
-	headRefOid: string;
 	headRepositoryOwner: { login: string } | null;
-	reviews: { author: { login: string } | null; state: string; commit: { oid: string } | null }[];
+}
+
+interface LiveReview {
+	author: { login: string } | null;
+	state: string;
+	commit: { oid: string } | null;
 }
 
 /**
@@ -776,7 +780,7 @@ async function validatePushPreflight(branch: string, headSha: string, remote: st
 	// The head is qualified by the owner actually receiving the push, so a same-named
 	// branch in another fork can never be mistaken for this PR.
 	const headOwner = forkOwner ?? pushRepo.split("/")[0]!;
-	const listed = await gh(["pr", "list", "--repo", baseRepo, "--head", branch, "--state", "open", "--json", "number,body,baseRefName,author,reviews,headRefOid,headRepositoryOwner"], cwd);
+	const listed = await gh(["pr", "list", "--repo", baseRepo, "--head", branch, "--state", "open", "--json", "number,body,baseRefName,author,headRepositoryOwner"], cwd);
 	if (listed.exitCode !== 0) {
 		return { ok: false, diagnostics: [`Could not resolve the open PR for ${branch} in ${baseRepo}: ${listed.stderr || `gh exited ${listed.exitCode}`}. Authenticate with gh auth login, or set GJC_SKIP_PR_PREFLIGHT=1 to push without the contract check.`] };
 	}
@@ -792,6 +796,15 @@ async function validatePushPreflight(branch: string, headSha: string, remote: st
 	}
 	const pr = candidates[0];
 	if (!pr) return { ok: true, diagnostics: [] };
+	// gh pr list's JSON mapping omits headRefOid and review commit oids on older gh
+	// releases (e.g. 2.4.x), which would fail closed on every push, so the head and
+	// the review commits are resolved through the stable `gh api` surface instead.
+	const currentHead = await gh(["api", `repos/${baseRepo}/pulls/${pr.number}`, "--jq", ".head.sha"], cwd);
+	if (currentHead.exitCode !== 0) {
+		return { ok: false, diagnostics: [`Could not resolve the current head of ${baseRepo}#${pr.number}: ${currentHead.stderr || `gh exited ${currentHead.exitCode}`}.`] };
+	}
+	const prHeadSha = currentHead.stdout.trim();
+	if (!SHA40.test(prHeadSha)) return { ok: false, diagnostics: [`Current head of ${baseRepo}#${pr.number} (${prHeadSha}) is not a lowercase 40-hex commit.`] };
 	// The base is the repository the PR was queried in -- for a fork push that is the
 	// upstream, never the contributor's local origin/dev. The ref is the PR's own base
 	// branch rather than an assumed "dev".
@@ -811,9 +824,22 @@ async function validatePushPreflight(branch: string, headSha: string, remote: st
 	// Latest non-COMMENTED review per identity on the exact head, matching the server's
 	// "effective review" semantics: a later CHANGES_REQUESTED supersedes an earlier APPROVED.
 	const parsedVerdict = parsePrVerdict(body).verdict;
+	// Review commit oids come from `gh api` because `gh pr list` omits them on older gh.
+	let reviews: LiveReview[] = [];
+	if (parsedVerdict?.verdict === "merge-approved") {
+		const liveReviews = await gh(["api", `repos/${baseRepo}/pulls/${pr.number}/reviews`, "--jq", "[.[] | {author: {login: .user.login}, state, commit: {oid: .commit_id}}]"], cwd);
+		if (liveReviews.exitCode !== 0) {
+			return { ok: false, diagnostics: [`Could not fetch the reviews of ${baseRepo}#${pr.number} to verify the exact-head approval: ${liveReviews.stderr || `gh exited ${liveReviews.exitCode}`}.`] };
+		}
+		try {
+			reviews = JSON.parse(liveReviews.stdout) as LiveReview[];
+		} catch (error) {
+			return { ok: false, diagnostics: [`Could not parse the review list of ${baseRepo}#${pr.number}: ${error instanceof Error ? error.message : String(error)}`] };
+		}
+	}
 	const approval = ((): { login?: string; headSha?: string } => {
 		if (parsedVerdict?.verdict !== "merge-approved") return {};
-		const effective = (pr.reviews ?? [])
+		const effective = reviews
 			.filter(review =>
 				review.author?.login?.toLowerCase() === parsedVerdict.reviewerId.toLowerCase()
 				&& review.state !== "COMMENTED"
@@ -827,7 +853,7 @@ async function validatePushPreflight(branch: string, headSha: string, remote: st
 		baseRef: pr.baseRefName,
 		baseSha,
 		headSha,
-		// The push is what MAKES headSha the PR head, so pr.headRefOid is the pre-push
+		// The push is what MAKES headSha the PR head, so prHeadSha is the pre-push
 		// value and is expected to differ; it is reported, never used as the contract head.
 		authorLogin: pr.author?.login ?? "",
 		computedDiffSha256: canonicalDiffSha256(diff.stdout),
@@ -840,7 +866,7 @@ async function validatePushPreflight(branch: string, headSha: string, remote: st
 	});
 	const diagnostics = [...bodyRiskParsed.diagnostics, ...result.diagnostics];
 	if (diagnostics.length > 0) {
-		diagnostics.push(`This is exactly what the Dev CI "PR contract bootstrap" job will report for ${baseRepo}#${pr.number} once ${headSha} lands (currently ${pr.headRefOid}); the exact ${baseSha}...${headSha} digest is ${canonicalDiffSha256(diff.stdout)}.`);
+		diagnostics.push(`This is exactly what the Dev CI "PR contract bootstrap" job will report for ${baseRepo}#${pr.number} once ${headSha} lands (currently ${prHeadSha}); the exact ${baseSha}...${headSha} digest is ${canonicalDiffSha256(diff.stdout)}.`);
 		diagnostics.push("Fix the PR body, or push anyway with GJC_SKIP_PR_PREFLIGHT=1 (or --no-verify) while the change is still awaiting review.");
 	}
 	return { ok: diagnostics.length === 0, verdict: result.verdict, diagnostics };

--- a/scripts/verify-pr-verdict.ts
+++ b/scripts/verify-pr-verdict.ts
@@ -718,7 +718,40 @@ interface LivePullRequest {
 	body: string | null;
 	baseRefName: string;
 	author: { login: string } | null;
+	headRefOid: string;
+	headRepositoryOwner: { login: string } | null;
 	reviews: { author: { login: string } | null; state: string; commit: { oid: string } | null }[];
+}
+
+/**
+ * Resolve the GitHub `owner/repo` actually receiving the push. A fork checkout's `origin`
+ * is the fork while the open PR lives upstream, so the implicit `gh` context would query
+ * the wrong repository (or none) and wave the push through.
+ */
+async function pushRemoteRepository(remote: string, cwd: string): Promise<string | null> {
+	const url = await git(["remote", "get-url", remote], cwd);
+	if (url.exitCode !== 0) return null;
+	const text = new TextDecoder().decode(url.stdout).trim();
+	const match = /(?:[:/])([^/:]+)\/([^/]+?)(?:\.git)?$/u.exec(text);
+	return match ? `${match[1]}/${match[2]}` : null;
+}
+
+/**
+ * The repository whose PRs govern a push to `pushRepo`. Pushing a fork branch opens the
+ * PR upstream, so a fork resolves to its parent; a non-fork is its own authority.
+ */
+async function contractRepository(pushRepo: string, cwd: string): Promise<{ repo: string; forkOwner: string | null }> {
+	const viewed = await gh(["repo", "view", pushRepo, "--json", "isFork,parent"], cwd);
+	if (viewed.exitCode !== 0) return { repo: pushRepo, forkOwner: null };
+	try {
+		const info = JSON.parse(viewed.stdout) as { isFork?: boolean; parent?: { owner?: { login?: string }; name?: string } | null };
+		const parentOwner = info.parent?.owner?.login;
+		const parentName = info.parent?.name;
+		if (!info.isFork || !parentOwner || !parentName) return { repo: pushRepo, forkOwner: null };
+		return { repo: `${parentOwner}/${parentName}`, forkOwner: pushRepo.split("/")[0]! };
+	} catch {
+		return { repo: pushRepo, forkOwner: null };
+	}
 }
 
 /**
@@ -734,11 +767,18 @@ interface LivePullRequest {
  *
  * A branch with no open PR has no contract to invalidate and passes.
  */
-async function validatePushPreflight(branch: string, headSha: string, cwd: string, trustedRoot: string): Promise<PrValidationResult> {
+async function validatePushPreflight(branch: string, headSha: string, remote: string, cwd: string, trustedRoot: string): Promise<PrValidationResult> {
 	if (!SHA40.test(headSha)) return { ok: false, diagnostics: [`Pushed commit ${headSha} is not a lowercase 40-hex commit.`] };
-	const listed = await gh(["pr", "list", "--head", branch, "--state", "open", "--json", "number,body,baseRefName,author,reviews"], cwd);
+	const pushRepo = await pushRemoteRepository(remote, cwd);
+	if (!pushRepo) return { ok: false, diagnostics: [`Could not resolve the GitHub repository behind push remote ${remote}; refusing to validate against an unknown repository.`] };
+	// A fork push opens its PR upstream, so the contract lives in the parent repository.
+	const { repo: baseRepo, forkOwner } = await contractRepository(pushRepo, cwd);
+	// The head is qualified by the owner actually receiving the push, so a same-named
+	// branch in another fork can never be mistaken for this PR.
+	const headOwner = forkOwner ?? pushRepo.split("/")[0]!;
+	const listed = await gh(["pr", "list", "--repo", baseRepo, "--head", branch, "--state", "open", "--json", "number,body,baseRefName,author,reviews,headRefOid,headRepositoryOwner"], cwd);
 	if (listed.exitCode !== 0) {
-		return { ok: false, diagnostics: [`Could not resolve the open PR for ${branch}: ${listed.stderr || `gh exited ${listed.exitCode}`}. Authenticate with gh auth login, or set GJC_SKIP_PR_PREFLIGHT=1 to push without the contract check.`] };
+		return { ok: false, diagnostics: [`Could not resolve the open PR for ${branch} in ${baseRepo}: ${listed.stderr || `gh exited ${listed.exitCode}`}. Authenticate with gh auth login, or set GJC_SKIP_PR_PREFLIGHT=1 to push without the contract check.`] };
 	}
 	let pulls: LivePullRequest[];
 	try {
@@ -746,15 +786,23 @@ async function validatePushPreflight(branch: string, headSha: string, cwd: strin
 	} catch (error) {
 		return { ok: false, diagnostics: [`Could not parse the gh pr list response for ${branch}: ${error instanceof Error ? error.message : String(error)}`] };
 	}
-	const pr = pulls[0];
-	if (!pr) return { ok: true, diagnostics: [] };
-	const refreshBase = await git(["fetch", "--no-tags", "origin", "dev"], cwd);
-	if (refreshBase.exitCode !== 0) {
-		return { ok: false, diagnostics: [`Could not refresh origin/dev before the push preflight: ${refreshBase.stderr}. Run git fetch origin dev and retry.`] };
+	const candidates = pulls.filter(candidate => candidate.headRepositoryOwner?.login?.toLowerCase() === headOwner.toLowerCase());
+	if (candidates.length > 1) {
+		return { ok: false, diagnostics: [`Branch ${branch} matches ${candidates.length} open PRs in ${baseRepo} from ${headOwner} (#${candidates.map(candidate => candidate.number).join(", #")}); cannot determine which contract governs this push.`] };
 	}
-	const base = await git(["rev-parse", "origin/dev"], cwd);
+	const pr = candidates[0];
+	if (!pr) return { ok: true, diagnostics: [] };
+	// The base is the repository the PR was queried in -- for a fork push that is the
+	// upstream, never the contributor's local origin/dev. The ref is the PR's own base
+	// branch rather than an assumed "dev".
+	const baseRemoteUrl = `https://github.com/${baseRepo}.git`;
+	const refreshBase = await git(["fetch", "--no-tags", baseRemoteUrl, pr.baseRefName], cwd);
+	if (refreshBase.exitCode !== 0) {
+		return { ok: false, diagnostics: [`Could not fetch the PR base ${baseRepo}#${pr.baseRefName} before the push preflight: ${refreshBase.stderr}`] };
+	}
+	const base = await git(["rev-parse", "FETCH_HEAD"], cwd);
 	const baseSha = new TextDecoder().decode(base.stdout).trim();
-	if (!SHA40.test(baseSha)) return { ok: false, diagnostics: [`Could not resolve origin/dev to a commit: ${base.stderr}`] };
+	if (!SHA40.test(baseSha)) return { ok: false, diagnostics: [`Could not resolve ${baseRepo}#${pr.baseRefName} to a commit: ${base.stderr}`] };
 	const ancestry = await git(["merge-base", "--is-ancestor", baseSha, headSha], cwd);
 	const diff = await git(["diff", "--binary", "--full-index", "--no-ext-diff", `${baseSha}...${headSha}`], cwd);
 	if (diff.exitCode !== 0) return { ok: false, diagnostics: [`Could not compute the exact ${baseSha}...${headSha} diff: ${diff.stderr}`] };
@@ -779,6 +827,8 @@ async function validatePushPreflight(branch: string, headSha: string, cwd: strin
 		baseRef: pr.baseRefName,
 		baseSha,
 		headSha,
+		// The push is what MAKES headSha the PR head, so pr.headRefOid is the pre-push
+		// value and is expected to differ; it is reported, never used as the contract head.
 		authorLogin: pr.author?.login ?? "",
 		computedDiffSha256: canonicalDiffSha256(diff.stdout),
 		baseIsAncestor: ancestry.exitCode === 0,
@@ -790,7 +840,7 @@ async function validatePushPreflight(branch: string, headSha: string, cwd: strin
 	});
 	const diagnostics = [...bodyRiskParsed.diagnostics, ...result.diagnostics];
 	if (diagnostics.length > 0) {
-		diagnostics.push(`This is exactly what the Dev CI "PR contract bootstrap" job will report for PR #${pr.number} at head ${headSha}; the current ${baseSha}...${headSha} digest is ${canonicalDiffSha256(diff.stdout)}.`);
+		diagnostics.push(`This is exactly what the Dev CI "PR contract bootstrap" job will report for ${baseRepo}#${pr.number} once ${headSha} lands (currently ${pr.headRefOid}); the exact ${baseSha}...${headSha} digest is ${canonicalDiffSha256(diff.stdout)}.`);
 		diagnostics.push("Fix the PR body, or push anyway with GJC_SKIP_PR_PREFLIGHT=1 (or --no-verify) while the change is still awaiting review.");
 	}
 	return { ok: diagnostics.length === 0, verdict: result.verdict, diagnostics };
@@ -806,6 +856,8 @@ export async function main(argv: string[]): Promise<number> {
 	const eventIndex = argv.indexOf("--event");
 	const preflightIndex = argv.indexOf("--preflight-command");
 	const pushIndex = argv.indexOf("--push-preflight");
+	const pushRemoteIndex = argv.indexOf("--push-remote");
+	const pushRemote = pushRemoteIndex >= 0 && argv[pushRemoteIndex + 1] ? argv[pushRemoteIndex + 1]! : "origin";
 	const signIndex = argv.indexOf("--self-review-sign");
 	if (signIndex >= 0) {
 		const args = argv.slice(signIndex + 1);
@@ -830,10 +882,10 @@ export async function main(argv: string[]): Promise<number> {
 	const result = eventIndex >= 0 && argv[eventIndex + 1]
 		? await validateEvent(path.resolve(process.cwd(), argv[eventIndex + 1]!), cwd, trustedRoot)
 		: pushIndex >= 0 && argv[pushIndex + 1] && argv[pushIndex + 2]
-			? await validatePushPreflight(argv[pushIndex + 1]!, argv[pushIndex + 2]!, cwd, trustedRoot)
+			? await validatePushPreflight(argv[pushIndex + 1]!, argv[pushIndex + 2]!, pushRemote, cwd, trustedRoot)
 			: preflightIndex >= 0 && argv[preflightIndex + 1]
 				? await validatePreflight(argv[preflightIndex + 1]!, cwd, trustedRoot, invocationCwd)
-				: { ok: false, diagnostics: ["Usage: bun scripts/verify-pr-verdict.ts --event <github-event.json> | --preflight-command <command> | --push-preflight <branch> <head-sha> | --self-review-sign <verdict> <base> <head> <digest> <reviewer-id> <risk> <extra> <evidence>"] };
+				: { ok: false, diagnostics: ["Usage: bun scripts/verify-pr-verdict.ts --event <github-event.json> | --preflight-command <command> | --push-preflight <branch> <head-sha> [--push-remote <remote>] | --self-review-sign <verdict> <base> <head> <digest> <reviewer-id> <risk> <extra> <evidence>"] };
 	for (const diagnostic of result.diagnostics) console.error(`::error::${diagnostic}`);
 	if (result.ok && result.verdict) console.log(`PR contract valid: ${result.verdict.verdict} ${result.verdict.diffSha256}`);
 	return result.ok ? 0 : 1;

--- a/scripts/verify-pr-verdict.ts
+++ b/scripts/verify-pr-verdict.ts
@@ -718,21 +718,25 @@ interface LivePullRequest {
 	body: string | null;
 	baseRefName: string;
 	author: { login: string } | null;
+	reviews: { author: { login: string } | null; state: string; commit: { oid: string } | null }[];
 }
 
 /**
- * Pre-push gate: validate the exact commit about to be published against the live PR
- * body for `branch`, so a stale verdict digest, an unrebased base, a malformed verdict,
- * or a missing risk classification is caught locally instead of burning a red CI run.
+ * Reproduce the Dev CI "PR contract bootstrap" judgement for the exact commit being
+ * pushed. That job runs with NO requireMergeApproved escape hatch, so this gate must
+ * mirror it exactly (requireMergeApproved: true): a stale verdict digest, an unrebased
+ * base, a missing risk classification, AND a blocking verdict (needs-human,
+ * merge-blocked) all fail here, because all of them turn the required check red.
  *
- * Blocking verdicts (needs-human, merge-blocked) are NOT failures here: they are
- * legitimate pre-review states and only the server merge gate rejects them, exactly as
- * in the `gh pr create` preflight. A branch with no open PR has nothing to invalidate
- * and passes.
+ * A preflight that disagrees with CI is worthless, so the authenticated exact-head
+ * approval is resolved from the same GitHub review data the server reads; otherwise a
+ * legitimately reviewed merge-approved PR would fail locally while passing in CI.
+ *
+ * A branch with no open PR has no contract to invalidate and passes.
  */
 async function validatePushPreflight(branch: string, headSha: string, cwd: string, trustedRoot: string): Promise<PrValidationResult> {
 	if (!SHA40.test(headSha)) return { ok: false, diagnostics: [`Pushed commit ${headSha} is not a lowercase 40-hex commit.`] };
-	const listed = await gh(["pr", "list", "--head", branch, "--state", "open", "--json", "number,body,baseRefName,author"], cwd);
+	const listed = await gh(["pr", "list", "--head", branch, "--state", "open", "--json", "number,body,baseRefName,author,reviews"], cwd);
 	if (listed.exitCode !== 0) {
 		return { ok: false, diagnostics: [`Could not resolve the open PR for ${branch}: ${listed.stderr || `gh exited ${listed.exitCode}`}. Authenticate with gh auth login, or set GJC_SKIP_PR_PREFLIGHT=1 to push without the contract check.`] };
 	}
@@ -756,6 +760,20 @@ async function validatePushPreflight(branch: string, headSha: string, cwd: strin
 	if (diff.exitCode !== 0) return { ok: false, diagnostics: [`Could not compute the exact ${baseSha}...${headSha} diff: ${diff.stderr}`] };
 	const body = pr.body ?? "";
 	const bodyRiskParsed = parseBodyRisk(body);
+	// Latest non-COMMENTED review per identity on the exact head, matching the server's
+	// "effective review" semantics: a later CHANGES_REQUESTED supersedes an earlier APPROVED.
+	const parsedVerdict = parsePrVerdict(body).verdict;
+	const approval = ((): { login?: string; headSha?: string } => {
+		if (parsedVerdict?.verdict !== "merge-approved") return {};
+		const effective = (pr.reviews ?? [])
+			.filter(review =>
+				review.author?.login?.toLowerCase() === parsedVerdict.reviewerId.toLowerCase()
+				&& review.state !== "COMMENTED"
+				&& review.commit?.oid === headSha,
+			)
+			.at(-1);
+		return effective?.state === "APPROVED" ? { login: effective.author?.login, headSha: effective.commit?.oid } : {};
+	})();
 	const result = validatePrContract({
 		body,
 		baseRef: pr.baseRefName,
@@ -766,11 +784,14 @@ async function validatePushPreflight(branch: string, headSha: string, cwd: strin
 		baseIsAncestor: ancestry.exitCode === 0,
 		fastGatePassed: await runFastGate(cwd, trustedRoot),
 		bodyRisk: bodyRiskParsed.risk,
-		requireMergeApproved: false,
+		authenticatedReviewerLogin: approval.login,
+		authenticatedReviewHeadSha: approval.headSha,
+		requireMergeApproved: true,
 	});
 	const diagnostics = [...bodyRiskParsed.diagnostics, ...result.diagnostics];
 	if (diagnostics.length > 0) {
-		diagnostics.push(`Update PR #${pr.number} for exact head ${headSha} before pushing; the current ${baseSha}...${headSha} digest is ${canonicalDiffSha256(diff.stdout)}.`);
+		diagnostics.push(`This is exactly what the Dev CI "PR contract bootstrap" job will report for PR #${pr.number} at head ${headSha}; the current ${baseSha}...${headSha} digest is ${canonicalDiffSha256(diff.stdout)}.`);
+		diagnostics.push("Fix the PR body, or push anyway with GJC_SKIP_PR_PREFLIGHT=1 (or --no-verify) while the change is still awaiting review.");
 	}
 	return { ok: diagnostics.length === 0, verdict: result.verdict, diagnostics };
 }

--- a/scripts/verify-pr-verdict.ts
+++ b/scripts/verify-pr-verdict.ts
@@ -703,6 +703,78 @@ async function validatePreflight(command: string, cwd: string, trustedRoot: stri
 	return validatePrContract({ body, baseRef, baseSha, headSha, authorLogin: author, computedDiffSha256: diff.exitCode === 0 ? canonicalDiffSha256(diff.stdout) : "", baseIsAncestor: ancestry.exitCode === 0, fastGatePassed: await runFastGate(cwd, trustedRoot), requireMergeApproved: false });
 }
 
+async function gh(args: string[], cwd: string): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+	const child = Bun.spawn(["gh", ...args], { cwd, stdout: "pipe", stderr: "pipe" });
+	const [stdout, stderr, exitCode] = await Promise.all([
+		new Response(child.stdout).text(),
+		new Response(child.stderr).text(),
+		child.exited,
+	]);
+	return { exitCode, stdout, stderr: stderr.trim() };
+}
+
+interface LivePullRequest {
+	number: number;
+	body: string | null;
+	baseRefName: string;
+	author: { login: string } | null;
+}
+
+/**
+ * Pre-push gate: validate the exact commit about to be published against the live PR
+ * body for `branch`, so a stale verdict digest, an unrebased base, a malformed verdict,
+ * or a missing risk classification is caught locally instead of burning a red CI run.
+ *
+ * Blocking verdicts (needs-human, merge-blocked) are NOT failures here: they are
+ * legitimate pre-review states and only the server merge gate rejects them, exactly as
+ * in the `gh pr create` preflight. A branch with no open PR has nothing to invalidate
+ * and passes.
+ */
+async function validatePushPreflight(branch: string, headSha: string, cwd: string, trustedRoot: string): Promise<PrValidationResult> {
+	if (!SHA40.test(headSha)) return { ok: false, diagnostics: [`Pushed commit ${headSha} is not a lowercase 40-hex commit.`] };
+	const listed = await gh(["pr", "list", "--head", branch, "--state", "open", "--json", "number,body,baseRefName,author"], cwd);
+	if (listed.exitCode !== 0) {
+		return { ok: false, diagnostics: [`Could not resolve the open PR for ${branch}: ${listed.stderr || `gh exited ${listed.exitCode}`}. Authenticate with gh auth login, or set GJC_SKIP_PR_PREFLIGHT=1 to push without the contract check.`] };
+	}
+	let pulls: LivePullRequest[];
+	try {
+		pulls = JSON.parse(listed.stdout) as LivePullRequest[];
+	} catch (error) {
+		return { ok: false, diagnostics: [`Could not parse the gh pr list response for ${branch}: ${error instanceof Error ? error.message : String(error)}`] };
+	}
+	const pr = pulls[0];
+	if (!pr) return { ok: true, diagnostics: [] };
+	const refreshBase = await git(["fetch", "--no-tags", "origin", "dev"], cwd);
+	if (refreshBase.exitCode !== 0) {
+		return { ok: false, diagnostics: [`Could not refresh origin/dev before the push preflight: ${refreshBase.stderr}. Run git fetch origin dev and retry.`] };
+	}
+	const base = await git(["rev-parse", "origin/dev"], cwd);
+	const baseSha = new TextDecoder().decode(base.stdout).trim();
+	if (!SHA40.test(baseSha)) return { ok: false, diagnostics: [`Could not resolve origin/dev to a commit: ${base.stderr}`] };
+	const ancestry = await git(["merge-base", "--is-ancestor", baseSha, headSha], cwd);
+	const diff = await git(["diff", "--binary", "--full-index", "--no-ext-diff", `${baseSha}...${headSha}`], cwd);
+	if (diff.exitCode !== 0) return { ok: false, diagnostics: [`Could not compute the exact ${baseSha}...${headSha} diff: ${diff.stderr}`] };
+	const body = pr.body ?? "";
+	const bodyRiskParsed = parseBodyRisk(body);
+	const result = validatePrContract({
+		body,
+		baseRef: pr.baseRefName,
+		baseSha,
+		headSha,
+		authorLogin: pr.author?.login ?? "",
+		computedDiffSha256: canonicalDiffSha256(diff.stdout),
+		baseIsAncestor: ancestry.exitCode === 0,
+		fastGatePassed: await runFastGate(cwd, trustedRoot),
+		bodyRisk: bodyRiskParsed.risk,
+		requireMergeApproved: false,
+	});
+	const diagnostics = [...bodyRiskParsed.diagnostics, ...result.diagnostics];
+	if (diagnostics.length > 0) {
+		diagnostics.push(`Update PR #${pr.number} for exact head ${headSha} before pushing; the current ${baseSha}...${headSha} digest is ${canonicalDiffSha256(diff.stdout)}.`);
+	}
+	return { ok: diagnostics.length === 0, verdict: result.verdict, diagnostics };
+}
+
 export async function main(argv: string[]): Promise<number> {
 	const repoIndex = argv.indexOf("--repo");
 	const trustedRootIndex = argv.indexOf("--trusted-root");
@@ -712,6 +784,7 @@ export async function main(argv: string[]): Promise<number> {
 	const invocationCwd = path.resolve(process.cwd(), invocationCwdIndex >= 0 && argv[invocationCwdIndex + 1] ? argv[invocationCwdIndex + 1]! : cwd);
 	const eventIndex = argv.indexOf("--event");
 	const preflightIndex = argv.indexOf("--preflight-command");
+	const pushIndex = argv.indexOf("--push-preflight");
 	const signIndex = argv.indexOf("--self-review-sign");
 	if (signIndex >= 0) {
 		const args = argv.slice(signIndex + 1);
@@ -735,9 +808,11 @@ export async function main(argv: string[]): Promise<number> {
 	}
 	const result = eventIndex >= 0 && argv[eventIndex + 1]
 		? await validateEvent(path.resolve(process.cwd(), argv[eventIndex + 1]!), cwd, trustedRoot)
-		: preflightIndex >= 0 && argv[preflightIndex + 1]
-			? await validatePreflight(argv[preflightIndex + 1]!, cwd, trustedRoot, invocationCwd)
-			: { ok: false, diagnostics: ["Usage: bun scripts/verify-pr-verdict.ts --event <github-event.json> | --preflight-command <command> | --self-review-sign <verdict> <base> <head> <digest> <reviewer-id> <risk> <extra> <evidence>"] };
+		: pushIndex >= 0 && argv[pushIndex + 1] && argv[pushIndex + 2]
+			? await validatePushPreflight(argv[pushIndex + 1]!, argv[pushIndex + 2]!, cwd, trustedRoot)
+			: preflightIndex >= 0 && argv[preflightIndex + 1]
+				? await validatePreflight(argv[preflightIndex + 1]!, cwd, trustedRoot, invocationCwd)
+				: { ok: false, diagnostics: ["Usage: bun scripts/verify-pr-verdict.ts --event <github-event.json> | --preflight-command <command> | --push-preflight <branch> <head-sha> | --self-review-sign <verdict> <base> <head> <digest> <reviewer-id> <risk> <extra> <evidence>"] };
 	for (const diagnostic of result.diagnostics) console.error(`::error::${diagnostic}`);
 	if (result.ok && result.verdict) console.log(`PR contract valid: ${result.verdict.verdict} ${result.verdict.diffSha256}`);
 	return result.ok ? 0 : 1;


### PR DESCRIPTION
## What

Validate the exact-head PR contract at `git push` time, reproducing the Dev CI `PR contract bootstrap` judgement locally instead of discovering it in a red run.

- `scripts/verify-pr-verdict.ts --push-preflight <branch> <pushed-sha>` resolves the open PR for the branch via `gh pr list` and runs `validatePrContract` against **the commit being pushed** (not local `HEAD`), including the writer fast gate.
- `.githooks/pre-push` runs it for every pushed branch ref. `dev`/`main` and ref deletions (zero sha) are skipped.
- `bun run dev:hooks` sets `core.hooksPath`; it is now part of the `install:dev` chain.

The gate runs with `requireMergeApproved: true`, mirroring the bootstrap job, which has **no** such escape hatch. A stale digest, an unrebased base, a missing risk classification, **and** a blocking verdict (`needs-human`, `merge-blocked`) all fail — because all of them turn the required check red. Mirroring that flag alone would fail a legitimately reviewed `merge-approved` PR, so the exact-head approval is resolved from the same review data the server reads.

Bypass while a change is still awaiting review: `GJC_SKIP_PR_PREFLIGHT=1` or `git push --no-verify`.

## Why

Every recent red `PR contract bootstrap` run failed on a fact fully knowable locally before the push:

| run | failure |
|---|---|
| 34221821814 | `Verdict needs-human intentionally blocks merge.` |
| 34227437219 | `Verdict needs-human intentionally blocks merge.` |
| 34225047340 | `Verdict needs-human intentionally blocks merge.` |
| 34223932649 | `Stale verdict digest 8538ced0…; exact digest is cbe7bcd6…` |
| 34221721961 | `Stale verdict digest a588110b…; exact digest is ea1af096…` |

The existing `--preflight-command` hook only fires on `gh pr create`. Once a PR exists, every later push can invalidate the verdict digest with nobody noticing until CI goes red.

The first version of this branch got the policy wrong: it ran `requireMergeApproved: false`, which passed `needs-human` and `merge-blocked` — the cause of 3 of the 5 runs above. It was silent on the majority of real failures. The third commit fixes that; see the commit body for the rejected alternatives.

Note this gate is a *predictor*, not a second authority: it reproduces the server's judgement locally and can always be bypassed. The authoritative decision stays in CI.

## Testing

`--push-preflight` against real remote state:

| case | result |
|---|---|
| PR #5425 `needs-human` (this PR) | exit 1, matching CI's `[eval]:73` |
| PR #5424 stale digest | exit 1, correct digest emitted |
| PR #5420 valid contract | exit 0 |
| branch with no open PR | exit 0 |
| non-40-hex push target | exit 1 (fails closed) |
| `dev` / ref deletion / `GJC_SKIP_PR_PREFLIGHT=1` | exit 0 (skipped) |

Reviewed-path correctness, so the stricter flag adds no false positives:

| case | result |
|---|---|
| `merge-approved` + exact-head `APPROVED` review | PASS |
| `merge-approved` with no such review | FAIL (correct) |

The `.githooks/pre-push` hook was driven end-to-end by piping git's real stdin format (`<local-ref> <local-sha> <remote-ref> <remote-sha>`) into it, not just by calling the script directly.

- `bun test scripts/verify-pr-verdict.test.ts scripts/install-dev.test.ts` — 147 pass, 0 fail
- `bun run check:tools` — clean
- The CI-parity test was mutation-checked: flipping `requireMergeApproved` back to `false` fails it.

### Review round 1 (`snowykr`, `CHANGES_REQUESTED`) — both findings fixed

Both were reproduced before fixing, and both regression tests were mutation-checked against the original defect.

**P1 — branch derived from the local ref.** git's pre-push input allows `HEAD` or a raw sha as the source, so `git push origin HEAD:refs/heads/feature` left `local_ref` as `HEAD` and the hook skipped validation entirely. Reproduced against this PR's own `needs-human` branch: exit 0, silently waved through. Branch now comes from `<remote-ref>`; `<local-sha>` stays the validated commit.

**P2 — PR lookup and base not bound to the receiving repository.** `gh pr list` ran without `--repo` and the base was hardcoded to `origin/dev`; in a fork checkout both point at the fork while the PR lives upstream, so the lookup found nothing and returned success. The push remote now resolves the receiving repository, a fork resolves to its parent via `gh repo view --json isFork,parent`, the head is qualified by the owner receiving the push, ambiguous matches fail closed, and the base is the PR's own base ref fetched from the contract repository.

| refspec | before | after |
|---|---|---|
| `HEAD:refs/heads/<pr>` | exit 0 (skipped) | exit 1 (validated) |
| renamed local→remote | exit 0 (skipped) | exit 1 (validated) |
| tag / `dev` / deletion | exit 0 | exit 0 (still skipped) |

Not covered: a live fork-to-upstream push, since no fork of this repo is available to test against.

## Risk classification

<!-- Classify honestly; exactly one box must be checked — the exact-head gate fails closed on zero or multiple. The checked class selects the merge path (issue #4703). -->

- [ ] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [x] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

`regression-risk`, not `low-risk`: this can block a developer's `git push` and it edits the pinned `install:dev` chain. It cannot weaken the server contract — the new path is local-only and read-only with respect to the merge gate — but a false positive costs a blocked push, so it deserves a real reviewer.

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:58fa8058a3c28ebfad80598b12aab2f4348d1306f298e164f204aa8bc57939d7 reviewer:human reviewer-id:Yeachan-Heo evidence:exact-head-adversarial-review;git-diff-check;git-diff-sha256;bun-test-73-pass;coding-agent-check-clean;live-contract-reproduction
```

`needs-human`: the author is not the repository owner, so `merge-self-approved` is unavailable, and `merge-approved` requires an authenticated exact-head `APPROVED` review from a distinct identity.

This PR's own check is therefore red on purpose — the gate correctly refuses to green-light an unreviewed change, including its own.

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken

No CHANGELOG entry: repository developer tooling, not a shipped `gjc` surface.


<!-- gjc-maintenance-01a083b2 -->
Current maintenance snapshot: base `323ea1d51291443d32c1e011f3e26cba3789ad99`, head `ecc1ba859e09eabd46b6dd85bf396039c763cee8`. Exact-head review evidence: `git diff --check origin/dev...HEAD`, `bun test scripts/verify-pr-verdict.test.ts scripts/install-dev.test.ts` (73 pass), and `bun --cwd=packages/coding-agent run check` (clean). The canonical `323ea1d51291443d32c1e011f3e26cba3789ad99...ecc1ba859e09eabd46b6dd85bf396039c763cee8` digest is `58fa8058a3c28ebfad80598b12aab2f4348d1306f298e164f204aa8bc57939d7`. Earlier narrative/test evidence is historical unless explicitly rebound to this head.
<!-- /gjc-maintenance-01a083b2 -->