### PR TITLE
fix(ai): hash Cursor wire tool definitions

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -18,6 +18,8 @@
 - Cursor Connect exec handlers now receive a per-exec AbortSignal. The caller abort and the local exec deadline both abort it, and the coding-agent bridge threads it into `tool.execute`, so timed-out or caller-cancelled Cursor-local tools can actually stop instead of running to completion after the turn terminalizes. The transport abort fence is also installed before payload setup and rechecked immediately before proxy connect and request creation, closing the race where cancellation won after the check while bearer credentials were still transmitted (#4834 review).
 - A started non-abortable Cursor mutation now keeps stream/run terminal publication behind the mutation's actual settlement. Caller abort and the local exec deadline still determine the eventual terminal reason, but neither can publish while an archive write may still commit, preventing post-terminal filesystem mutation (#4834 review).
 - Cursor `delete` is now part of the non-abortable settlement fence: its dispatch forwards `markNonAbortable` through the Agent run guard and the coding-agent bridge marks before the unlink runs, so a caller abort or deadline can no longer publish the exec terminal while the deletion is still in flight (#4834 review).
+- Cursor usage-context caching now hashes only normalized wire-visible tool definitions instead of complete class-backed tool instances. Session state containing filesystem `bigint` identities can no longer fail requests during preflight serialization, while tool name, description, and schema changes still invalidate cached conversation state.
+
 ## [0.16.6] - 2026-09-07
 
 ## [0.16.5] - 2026-09-07

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -4527,26 +4527,40 @@ function readCursorBlob(blobStore: Map<string, Uint8Array>, blobId: Uint8Array):
 
 const CURSOR_NATIVE_TOOL_NAMES = new Set(["bash", "read", "write", "delete", "ls", "grep", "lsp", "todo_write"]);
 
+interface CursorWireToolIdentity {
+	name: string;
+	description: string;
+	inputSchema: JsonValue;
+}
+
+function buildCursorWireToolIdentities(tools: Tool[] | undefined): CursorWireToolIdentity[] {
+	if (!tools || tools.length === 0) return [];
+
+	return tools
+		.filter(tool => !CURSOR_NATIVE_TOOL_NAMES.has(tool.name))
+		.map(tool => {
+			const jsonSchema = flattenToolRootCombinators(toolWireSchema(tool));
+			return {
+				name: tool.name,
+				description: tool.description || "",
+				inputSchema:
+					jsonSchema && typeof jsonSchema === "object"
+						? (jsonSchema as JsonValue)
+						: { type: "object", properties: {}, required: [] },
+			};
+		});
+}
+
+function buildCursorUsageToolsKey(tools: Tool[] | undefined): string {
+	return hashCursorConversationValue(buildCursorWireToolIdentities(tools));
+}
+
 function buildMcpToolDefinitions(tools: Tool[] | undefined): McpToolDefinition[] {
-	if (!tools || tools.length === 0) {
-		return [];
-	}
-
-	const advertisedTools = tools.filter(tool => !CURSOR_NATIVE_TOOL_NAMES.has(tool.name));
-	if (advertisedTools.length === 0) {
-		return [];
-	}
-
-	return advertisedTools.map(tool => {
-		const jsonSchema = flattenToolRootCombinators(toolWireSchema(tool));
-		const schemaValue: JsonValue =
-			jsonSchema && typeof jsonSchema === "object"
-				? (jsonSchema as JsonValue)
-				: { type: "object", properties: {}, required: [] };
-		const inputSchema = toBinary(ValueSchema, fromJson(ValueSchema, schemaValue));
+	return buildCursorWireToolIdentities(tools).map(tool => {
+		const inputSchema = toBinary(ValueSchema, fromJson(ValueSchema, tool.inputSchema));
 		return create(McpToolDefinitionSchema, {
 			name: tool.name,
-			description: tool.description || "",
+			description: tool.description,
 			providerIdentifier: "pi-agent",
 			toolName: tool.name,
 			inputSchema,
@@ -4827,6 +4841,11 @@ function buildConversationTurns(messages: Message[], blobStore: Map<string, Uint
 	return turns;
 }
 
+/** Exported for regression coverage of the tool usage-cache identity boundary. */
+export function buildCursorUsageToolsKeyForTest(tools: Tool[]): string {
+	return buildCursorUsageToolsKey(tools);
+}
+
 /** Exported for tests: decodes Cursor history blobs built from conversation messages. */
 export function buildCursorHistoryForTest(messages: Message[]): {
 	rootPromptMessagesJson: unknown[];
@@ -4898,16 +4917,7 @@ function buildCursorConversationContext(
 		}),
 		systemPromptKey: hashCursorConversationValue(context.systemPrompt ?? []),
 		customSystemPromptKey: hashCursorConversationValue(options?.customSystemPrompt ?? ""),
-		toolsKey: hashCursorConversationValue(
-			(context.tools ?? []).map(tool => ({
-				name: tool.name,
-				description: tool.description,
-				parameters: toolWireSchema(tool),
-				strict: tool.strict,
-				customFormat: tool.customFormat,
-				customWireName: tool.customWireName,
-			})),
-		),
+		toolsKey: buildCursorUsageToolsKey(context.tools),
 		messageKeys: context.messages.map(hashCursorConversationMessage),
 	};
 }

--- a/packages/ai/test/cursor-usage-context.test.ts
+++ b/packages/ai/test/cursor-usage-context.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "bun:test";
+
+import { buildCursorUsageToolsKeyForTest } from "../src/providers/cursor";
+import type { Tool } from "../src/types";
+
+class SessionBackedTool implements Tool {
+	readonly name = "ast_grep";
+	readonly description = "Search code with AST patterns";
+	readonly parameters = {
+		type: "object" as const,
+		properties: {
+			pattern: { type: "string" },
+		},
+		required: ["pattern"],
+	};
+
+	constructor(
+		readonly session: {
+			fileIdentity: { dev: bigint; ino: bigint; mtimeNs: bigint };
+		},
+	) {}
+}
+
+describe("Cursor usage-context tool identity", () => {
+	it("hashes the wire tool definition without traversing session-backed runtime state", () => {
+		const sessionBackedTool = new SessionBackedTool({
+			fileIdentity: {
+				dev: 1n,
+				ino: 2n,
+				mtimeNs: 3n,
+			},
+		});
+		const equivalentWireTool: Tool = {
+			name: sessionBackedTool.name,
+			description: sessionBackedTool.description,
+			parameters: sessionBackedTool.parameters,
+		};
+
+		expect(buildCursorUsageToolsKeyForTest([sessionBackedTool])).toBe(
+			buildCursorUsageToolsKeyForTest([equivalentWireTool]),
+		);
+	});
+
+	it("changes when an advertised wire definition changes", () => {
+		const baseTool: Tool = {
+			name: "ast_grep",
+			description: "Search code with AST patterns",
+			parameters: { type: "object", properties: { pattern: { type: "string" } } },
+		};
+		const baseKey = buildCursorUsageToolsKeyForTest([baseTool]);
+
+		expect(buildCursorUsageToolsKeyForTest([{ ...baseTool, name: "irc" }])).not.toBe(baseKey);
+		expect(buildCursorUsageToolsKeyForTest([{ ...baseTool, description: "Different description" }])).not.toBe(
+			baseKey,
+		);
+		expect(
+			buildCursorUsageToolsKeyForTest([
+				{ ...baseTool, parameters: { type: "object", properties: { pattern: { type: "number" } } } },
+			]),
+		).not.toBe(baseKey);
+	});
+
+	it("ignores native tools that are not advertised through the MCP wire context", () => {
+		const astGrepTool: Tool = {
+			name: "ast_grep",
+			description: "Search code with AST patterns",
+			parameters: { type: "object", properties: { pattern: { type: "string" } } },
+		};
+		const nativeReadTool: Tool = {
+			name: "read",
+			description: "Read files",
+			parameters: { type: "object", properties: { path: { type: "string" } } },
+		};
+
+		expect(buildCursorUsageToolsKeyForTest([astGrepTool, nativeReadTool])).toBe(
+			buildCursorUsageToolsKeyForTest([astGrepTool]),
+		);
+	});
+});


### PR DESCRIPTION
## Summary

- derive Cursor usage-context tool cache keys from normalized wire-visible definitions
- share the same projection with MCP tool advertisement to prevent semantic drift
- avoid traversing class-backed runtime session state containing `bigint` file identities
- add regression coverage for session state, wire-field invalidation, and native-tool filtering

## Problem

Cursor usage caching hashed complete `Tool` instances with `JSON.stringify`. Coding-agent tools retain live `ToolSession` objects, which can contain filesystem identities such as `dev`, `ino`, and `mtimeNs` represented as `bigint`. The request therefore failed locally before transport with `JSON.stringify cannot serialize BigInt`.

## Verification

- `bun test packages/ai/test/cursor-exec-handlers.test.ts packages/ai/test/cursor-requested-model.test.ts packages/ai/test/cursor-proxy.test.ts packages/ai/test/cursor-conversation-usage.test.ts packages/ai/test/cursor-discovery-context-window.test.ts packages/ai/test/cursor-native-toolcall-json-safety.test.ts packages/ai/test/cursor-client-version.test.ts packages/ai/test/cursor-usage-context.test.ts` — 106 passed, 0 failed
- `bun --cwd=packages/ai run check` — passed; two existing informational `String.raw` lint notices remain in `openai-codex-responses.ts`
- `bun --cwd=packages/coding-agent run check` — passed


## GJC verdict

gajae.pr-review-verdict.v1 merge-approved sha256:b8f1ecbe3bbf94b652d5d5c063f3b042469b23c8dc5172e77ee44b11872a0658 reviewer:architect reviewer-id:Yeachan-Heo evidence:exact-head-review;106-focused-tests-pass;bun---cwd=packages/ai-run-check-pass;bun---cwd=packages/coding-agent-run-check-pass;affected-path-CI-pass

## Risk classification
- [x] `high-risk` — conservative classification pending independent exact-head review.


<!-- gjc-maintenance-01a083b2 -->
Current maintenance snapshot: base `f19e6867547068d1c7eec237c68150c0fd69bcab`, head `15cbd3a87c9ec0d486b72acfdd48634038e716d4`. Earlier narrative/test evidence is historical unless explicitly rebound to this head. Rebase/diff verification does not replace required CI or independent approval.
<!-- /gjc-maintenance-01a083b2 -->