### PR TITLE
fix(cursor): keep usage-context hashing total for bigint tool identity

### DIFF
--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -3386,10 +3386,39 @@ function hashCursorUsageMessage(message: { role: string; content: unknown }): st
 	return hashCursorUsageValue({ role: message.role, content: message.content });
 }
 
+/**
+ * Serialize an arbitrary value for usage-context hashing.
+ *
+ * The hashed inputs are live runtime objects: tool definitions carry executor
+ * closures and back-references into the session runtime, whose file-identity
+ * fields hold `bigint` values from `fs.stat({ bigint: true })`. A bare
+ * `JSON.stringify` throws on those, which would abort every Cursor request
+ * instead of merely losing a cache key. Normalize the hostile shapes
+ * (`bigint`, functions, cycles) so hashing stays total and deterministic.
+ */
+function hashCursorUsageSerialize(value: unknown): string {
+	const seen = new WeakSet<object>();
+	return (
+		JSON.stringify(value, (_key, item) => {
+			if (typeof item === "bigint") return `[BigInt:${item.toString()}]`;
+			if (typeof item === "function") return `[Function:${item.name || "anonymous"}]`;
+			if (typeof item === "symbol") return `[Symbol:${item.description ?? ""}]`;
+			if (item !== null && typeof item === "object") {
+				if (seen.has(item)) return "[Circular]";
+				seen.add(item);
+			}
+			return item;
+		}) ?? ""
+	);
+}
+
+/** Exported for tests: hashes a usage-context input the way live requests do. */
+export function hashCursorUsageValueForTest(value: unknown): string {
+	return hashCursorUsageValue(value);
+}
+
 function hashCursorUsageValue(value: unknown): string {
-	return createHash("sha256")
-		.update(JSON.stringify(value) ?? "")
-		.digest("hex");
+	return createHash("sha256").update(hashCursorUsageSerialize(value)).digest("hex");
 }
 
 function canReuseCursorUsageContext(previous: CursorUsageContext | undefined, current: CursorUsageContext): boolean {

--- a/packages/ai/test/cursor-conversation-usage.test.ts
+++ b/packages/ai/test/cursor-conversation-usage.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
-import { finalizeCursorUsageForTest } from "../src/providers/cursor";
+import { finalizeCursorUsageForTest, hashCursorUsageValueForTest } from "../src/providers/cursor";
 import type { Usage } from "../src/types";
 
 /**
@@ -128,5 +128,34 @@ describe("cursor conversation usage", () => {
 		expect(firstTurn.totalTokens).toBe(10_000);
 		expect(secondTurn.input).toBe(225);
 		expect(secondTurn.totalTokens).toBe(250);
+	});
+});
+
+describe("cursor usage-context hashing", () => {
+	it("hashes tool definitions that carry bigint runtime identity fields", () => {
+		const tools = [
+			{
+				name: "read",
+				description: "read a file",
+				runner: { sessionManager: { securityContext: { rootAuthority: { dev: 16777234n, ino: 257191361n } } } },
+			},
+		];
+
+		expect(() => hashCursorUsageValueForTest(tools)).not.toThrow();
+		expect(hashCursorUsageValueForTest(tools)).toBe(hashCursorUsageValueForTest(tools));
+	});
+
+	it("still separates tool sets that differ only in a bigint field", () => {
+		const withDev = (dev: bigint) => [{ name: "read", runner: { rootAuthority: { dev } } }];
+
+		expect(hashCursorUsageValueForTest(withDev(1n))).not.toBe(hashCursorUsageValueForTest(withDev(2n)));
+	});
+
+	it("hashes tool definitions holding executor closures and cycles", () => {
+		const tool: Record<string, unknown> = { name: "bash", execute: async () => undefined };
+		tool.self = tool;
+
+		expect(() => hashCursorUsageValueForTest([tool])).not.toThrow();
+		expect(hashCursorUsageValueForTest([tool])).not.toBe(hashCursorUsageValueForTest([{ name: "bash" }]));
 	});
 });


### PR DESCRIPTION
## What

- Serialize Cursor usage-context hash inputs through a replacer that normalizes `bigint`, functions, symbols, and cycles instead of calling a bare `JSON.stringify`.
- Add regression coverage for tool arrays that carry bigint runtime identity fields, executor closures, and self-references.

## Why

Every Cursor model was unusable on 0.16.4/0.16.6 with session persistence enabled:

```
$ gjc -p 'say hi' --model cursor/composer-2.5
JSON.stringify cannot serialize BigInt.
$ gjc -p 'say hi' --model cursor/composer-2.5 --no-session
Hi! How can I help you today?
```

`buildCursorUsageContext()` hashes `context.tools` with `hashCursorUsageValue()`, which used a bare `JSON.stringify`. Tool definitions hold a back-reference into the session runtime (`tool.runner.sessionManager.destination.securityContext.rootAuthority`), whose `dev`/`ino` come from `fs.stat({ bigint: true })`. `JSON.stringify` throws on those values, and the throw escapes `streamCursor`, so the turn dies before any request is sent. Without a session manager there is no bigint in the graph, which is why `--no-session` worked.

This is a different path from #5255 (request payload hooks); the usage-cache hash was never made JSON-safe.

Traced with a `JSON.stringify` shim on `main` (f6b7c475d):

```
at hashCursorUsageValue (packages/ai/src/providers/cursor.ts:3391)
at buildCursorUsageContext (packages/ai/src/providers/cursor.ts:3380)
at streamCursor (packages/ai/src/providers/cursor.ts:1056)
```

A cache key is not worth a dead turn, so the hash is now total: hostile members degrade to stable markers rather than throwing.

## Verification

- `bun test packages/ai/test/cursor-conversation-usage.test.ts` — 15 pass
- `bun test packages/ai/test/` — only the pre-existing `RemoteAuthCredentialStore` broker-network failures remain
- `bun run --cwd packages/ai check:types`, `biome check` on the touched files
- End-to-end against real Cursor: single turn and a `--continue` second turn both succeed with session persistence on