### PR TITLE
test(ai): assert codex websocket idle timeout has no SSE fallback

### DIFF
--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -4004,6 +4004,7 @@ describe("openai-codex streaming", () => {
 	it("applies each reused websocket request's idle timeout", async () => {
 		const tempDir = TempDir.createSync("@pi-codex-stream-");
 		setAgentDir(tempDir.path());
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("Unexpected SSE fallback"));
 		let sendCount = 0;
 		class RequestScopedIdleWebSocket extends MockWebSocket {
 			constructor(url: string, options?: { headers?: WsHeaders }) {
@@ -4032,9 +4033,14 @@ describe("openai-codex streaming", () => {
 			...options,
 			streamIdleTimeoutMs: 20,
 			streamMaxRetries: 0,
+			// Measure this request's websocket deadline, not an HTTP fallback round trip.
+			disableProviderRetries: true,
 		}).result();
 		expect(stalled.stopReason).toBe("error");
 		expect(Date.now() - startedAt).toBeLessThan(600);
+		expect(stalled.errorMessage).toContain("idle timeout waiting for websocket");
+		expect(sendCount).toBe(2);
+		expect(fetchSpy).not.toHaveBeenCalled();
 	});
 
 	it("replays x-codex-turn-state on subsequent SSE requests", async () => {


### PR DESCRIPTION
## What

Salvage the remaining test-only follow-up from this branch: isolate the reused Codex WebSocket idle-deadline regression test from the HTTP fallback path. The six-line change disables provider replay for this deadline-only case and asserts the idle error, the two WebSocket sends, and zero HTTP dispatches.

The original product-policy change in this PR is already superseded by merged PR #5412 (`323ea1d51291443d32c1e011f3e26cba3789ad99`, `fix(ai): remove Codex account entitlement validation`), which includes provider-authoritative model access and the bounded account-specific credential rotation requested in review. This branch now contains only the unique test hardening above.

## Why

The prior test's unchanged 600 ms assertion could include an unintended HTTP fallback round trip. Keeping the assertion focused on the reused WebSocket deadline makes the regression test deterministic without changing production behavior.

## Testing

At exact head `354b385775412d9d99c51b827cf63ba75dfbd1c0`:

- `bun test packages/ai/test/openai-codex-stream.test.ts` — 76 passed, 0 failed.
- The targeted `applies each reused websocket request's idle timeout` test — 20 consecutive runs passed; each run reported 1 passed, 75 filtered, 0 failed.
- `bun --cwd=packages/ai run check` — passed.
- `git diff --check a123cc514bfc1cea3e7200698c7d38b78538fe67...HEAD` — passed.

This is test-only; no changelog entry is required.

## Risk classification

- [x] `low-risk` — test-only maintenance; the owner's explicit `merge-self-approved` low-risk path authorizes this exact head.
- [ ] `regression-risk`
- [ ] `high-risk`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:a791c5e8f2cb03d64df7905e0d19bcf7fc410371c3f4e0111e3cc4009f748da9 reviewer:human reviewer-id:probepark evidence:ci-green;test-only;fetch-spy-restored-via-vi-restoreAllMocks;sendCount-asserted-2;no-http-fallback-checked
```

- [x] Target branch is `dev`
- [ ] `bun check` passes (the touched package check passes; the full repository aggregate was not run)
- [x] Tested locally
- [ ] CHANGELOG updated (test-only change)
- [x] Verdict above matches exact head `354b385775412d9d99c51b827cf63ba75dfbd1c0`
- [x] Risk classification above matches the actual review path taken

## Exact base/head evidence

- Current GitHub base: `a123cc514bfc1cea3e7200698c7d38b78538fe67` (`dev`).
- Historical immutable event base supplied for the original PR: `4b5ec3fcc284f6226f3150f10c182b6f740d8d9c`.
- Current canonical verdict digest is the binary full-index diff of current base `a123cc514bfc1cea3e7200698c7d38b78538fe67...354b385775412d9d99c51b827cf63ba75dfbd1c0`.
- The original product request is already present in merged PR #5412; this PR is not a second product implementation.



