### PR TITLE
fix(acp): settle cancelled headless asks

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 ### Fixed
+- Headless ACP asks now abort their enclosing foreground turn when the remote client cancels the ask. Previously the ask tool rejected with a cancellation error without releasing foreground ownership, so the next client prompt could be rejected as already active.
+
 - CLI startup now preserves saved account pins when handing authentication to the SDK. Catalog refreshes with a session use its effective credential pin, preventing a cached free OpenAI Codex account catalog from hiding Astra or Sol during paid-account profile startup. Generic injected SDK authentication keeps its existing isolation, and persisted session selections retain precedence over global pins.
 
 - Managed migration-lock release now detects closed or reused Linux descriptors before native security verification and validates ownership through the recovered descriptor. Recovery still requires the original file identity, attempt id, and owner-only security; repeated release cannot change a successor. This fixes the retained-descriptor failure in #5399 without changing test timing or retry policy.

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -872,6 +872,15 @@ export class AskTool implements AgentTool<AskParametersSchema, AskToolDetails> {
 		}
 
 		const extensionUi = context?.ui;
+		const throwRemoteCancellation = (remoteSignal: AbortSignal, toolSignal?: AbortSignal): never => {
+			// A headless remote answer source owns the only interactive surface. When it
+			// explicitly closes the ask, abort the enclosing turn as well; otherwise the
+			// tool throws while the foreground prompt keeps running and the next client
+			// prompt is rejected as already active. An abort already initiated by the
+			// caller must not be reported as a second, remote cancellation.
+			if (!extensionUi && !remoteSignal.aborted && !toolSignal?.aborted) context?.abort();
+			throw new ToolAbortError("Ask was cancelled by the remote client");
+		};
 		const ui: UIContext = {
 			select: (prompt, options, dialogOptions) => {
 				const source = this.session.getAskAnswerSource?.();
@@ -908,7 +917,7 @@ export class AskTool implements AgentTool<AskParametersSchema, AskToolDetails> {
 				)
 					.then((answer): RemoteRaceResult | Promise<RemoteRaceResult> => {
 						if (answer === undefined) {
-							if (!extensionUi) throw new ToolAbortError("Ask was cancelled by the remote client");
+							if (!extensionUi) return throwRemoteCancellation(remoteController.signal, toolSignal);
 							return new Promise<never>(() => {});
 						}
 						const receipt = typeof answer === "string" ? legacyAskReceipt(answer) : answer;
@@ -1041,7 +1050,7 @@ export class AskTool implements AgentTool<AskParametersSchema, AskToolDetails> {
 				)
 					.then((answer): RemoteRaceResult | Promise<RemoteRaceResult> => {
 						if (answer === undefined) {
-							if (!extensionUi) throw new ToolAbortError("Ask was cancelled by the remote client");
+							if (!extensionUi) return throwRemoteCancellation(remoteController.signal, toolSignal);
 							return new Promise<never>(() => {});
 						}
 						const receipt = typeof answer === "string" ? legacyAskReceipt(answer) : answer;

--- a/packages/coding-agent/test/tools/ask.test.ts
+++ b/packages/coding-agent/test/tools/ask.test.ts
@@ -97,6 +97,31 @@ function singleDeepInterviewQuestion() {
 }
 
 describe("AskTool cancellation", () => {
+	it("aborts a headless foreground turn when the remote ask is cancelled", async () => {
+		const tool = new AskTool(
+			createSession({
+				hasUI: false,
+				getAskAnswerSource: () => ({
+					awaitAnswer: async () => undefined,
+					awaitAnswerRequest: async () => undefined,
+				}),
+			}),
+		);
+		const abort = vi.fn();
+		const context = { hasUI: false, abort } as unknown as AgentToolContext;
+
+		await expect(
+			tool.execute(
+				"call-remote-cancel",
+				{ questions: [{ id: "confirm", question: "Proceed?", options: [{ label: "yes" }] }] },
+				undefined,
+				undefined,
+				context,
+			),
+		).rejects.toThrow("Ask was cancelled by the remote client");
+		expect(abort).toHaveBeenCalledTimes(1);
+	});
+
 	it("aborts the turn when the user cancels selection", async () => {
 		const tool = new AskTool(createSession());
 		const abort = vi.fn();


### PR DESCRIPTION
## What

Abort the enclosing foreground turn when a headless ACP ask is explicitly cancelled by its remote answer source.

## Why

Fixes #5442. A cancelled ACP permission response previously made `AskTool` throw `ToolAbortError` without invoking the enclosing turn abort, leaving the foreground turn owned and causing the next client prompt to fail as already active. The change preserves caller-initiated abort handling and adds a regression test.

The reported free-text path is not widened into a private ACP/Paseo protocol: ACP 1.3 `session/request_permission` carries fixed `optionId` outcomes only, while Paseo 0.7.2 does not advertise form elicitation. GJC's form-capable path remains separate and this PR fixes the independently reproducible GJC-owned lifecycle defect.

## Testing

- `bun test ./packages/coding-agent/test/tools/ask.test.ts`
- `bun test ./packages/coding-agent/test/sdk-acp-ask-permission-source.test.ts`
- `bun test ./packages/coding-agent/test/acp/acp-cancel-settlement.test.ts`
- `bun test ./packages/coding-agent/test/acp/acp-fallback-cancel-completion.test.ts`
- `bun test ./packages/coding-agent/test/acp-deep-interview-wire.test.ts`
- `bun test ./packages/coding-agent/test/sdk-host-wiring.test.ts`
- `bun --cwd=packages/coding-agent run check`
- `bun run ci:test:smoke`
- `bun run check` was attempted from the exact head but exceeded the 600-second local observation window after its completed subchecks; GitHub CI is authoritative for the aggregate gate.

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:b33a69e3e3ad78eb02cbf2862acc61d6a3508667cbaa00e31e632943692506b1 reviewer:critic reviewer-id:Yeachan-Heo evidence:bun --cwd=packages/coding-agent run check; focused ACP tests; bun run ci:test:smoke
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken