### PR TITLE
fix(utils): redact the vendor tokens the egress guard already refuses

### DIFF
--- a/packages/coding-agent/test/crash-sanitize.test.ts
+++ b/packages/coding-agent/test/crash-sanitize.test.ts
@@ -128,6 +128,37 @@ describe("sanitizeExternalCrashV1 — hostile inputs", () => {
 		sanitized("x".repeat(200_000));
 		expect(performance.now() - startedAt).toBeLessThan(1_000);
 	});
+
+	it("drops the shapes the Sentry egress guard refuses to transmit", () => {
+		// crash/upstream/envelope.ts lists these five as credential-like and
+		// refuses the whole envelope, but that guard only wraps the Sentry frame
+		// fields. `gjc crash report` builds its body through this function alone,
+		// and the user files that body as a public issue. All fixtures are
+		// assembled at runtime so no literal of this shape lands in the repo.
+		const npmToken = ["npm", "a".repeat(36)].join("_");
+		const gitlabToken = ["glpat", "b".repeat(24)].join("-");
+		const stripeKey = ["sk", "live", "c".repeat(24)].join("_");
+		const hfToken = ["hf", "d".repeat(34)].join("_");
+		const output = sanitized(
+			[`registry auth ${npmToken}`, `ci token ${gitlabToken}`, `billing ${stripeKey}`, `inference ${hfToken}`].join(
+				"\n",
+			),
+		);
+
+		for (const secret of [npmToken, gitlabToken, stripeKey, hfToken]) {
+			expect(output).not.toContain(secret);
+		}
+		// The surrounding diagnostic text survives.
+		expect(output).toContain("registry auth");
+		expect(output).toContain("inference");
+	});
+
+	it("keeps prefix lookalikes that are too short to be tokens", () => {
+		const output = sanitized("npm install express and the hf_ prefix and glpat-short");
+		expect(output).toContain("npm install express");
+		expect(output).toContain("hf_ prefix");
+		expect(output).toContain("glpat-short");
+	});
 });
 
 describe("fenceCrashText", () => {

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- `redactCrashSecrets` now recognizes the five vendor token shapes `crash/upstream/envelope.ts` already classifies as credential-like: npm, GitLab PAT, Stripe live/test keys, and Hugging Face tokens. That classification only guards the Sentry frame fields it wraps; the crash log this module persists and the `gjc crash report` body a user files as a public issue both reach egress through this function alone, so four of the five survived verbatim on both paths. Stripe and Hugging Face separate with `_`, which is why the existing `sk-` rule never matched them.
 
 ## [0.16.6] - 2026-09-07
 

--- a/packages/utils/src/crash-redaction.ts
+++ b/packages/utils/src/crash-redaction.ts
@@ -25,6 +25,16 @@ export function redactCrashSecrets(text: string): string {
 	redacted = redacted.replace(/\bgh[opsur]_[A-Za-z0-9]{16,}\b/g, "«redacted-github-token»");
 	redacted = redacted.replace(/\bgithub_pat_[A-Za-z0-9_]{20,}\b/g, "«redacted-github-token»");
 	redacted = redacted.replace(/\bxox[baprs]-[A-Za-z0-9-]{8,}\b/g, "«redacted-slack-token»");
+	// The five shapes below are the ones `crash/upstream/envelope.ts` already
+	// classifies as credential-like and refuses to transmit. That refusal only
+	// guards the Sentry frame fields; the persisted crash log and the
+	// `gjc crash report` body — which the user files as a public issue — reach
+	// egress through this function alone, so the same shapes have to be named here.
+	redacted = redacted.replace(/\bnpm_[A-Za-z0-9]{20,}\b/g, "«redacted-npm-token»");
+	redacted = redacted.replace(/\bglpat-[A-Za-z0-9_-]{20,}\b/g, "«redacted-gitlab-token»");
+	// Stripe separates with `_`, so the `sk-` rule above never matched one.
+	redacted = redacted.replace(/\b(?:sk|rk)_(?:live|test)_[A-Za-z0-9]{16,}\b/g, "«redacted-api-key»");
+	redacted = redacted.replace(/\bhf_[A-Za-z0-9]{20,}\b/g, "«redacted-api-key»");
 	// A PEM block carries the key material itself, so it is redacted whole rather
 	// than line by line. It runs before the narrower rules because they would
 	// otherwise chew on the base64 body and leave a truncated key behind.
@@ -70,6 +80,8 @@ export const CRASH_REDACTION_MARKERS: readonly string[] = [
 	"«redacted-api-key»",
 	"«redacted-github-token»",
 	"«redacted-slack-token»",
+	"«redacted-npm-token»",
+	"«redacted-gitlab-token»",
 	"«redacted-aws-key»",
 	"«redacted-private-key»",
 	"«redacted-google-api-key»",

--- a/packages/utils/test/postmortem-crash-log.test.ts
+++ b/packages/utils/test/postmortem-crash-log.test.ts
@@ -270,6 +270,30 @@ describe("recordFatalCrash", () => {
 		expect(performance.now() - startedAt).toBeLessThan(1_000);
 	});
 
+	it("redacts the vendor tokens the Sentry egress guard already refuses", () => {
+		const target = tempCrashLog();
+		// `crash/upstream/envelope.ts` classifies these five as credential-like and
+		// refuses transmission, but that guard covers only the Sentry frame fields.
+		// This log is the other durable sink and reaches egress through
+		// redactCrashSecrets alone. Fixtures are assembled at runtime so no literal
+		// of this shape is committed.
+		const npmToken = ["npm", "a".repeat(36)].join("_");
+		const gitlabToken = ["glpat", "b".repeat(24)].join("-");
+		const stripeKey = ["rk", "test", "c".repeat(24)].join("_");
+		const hfToken = ["hf", "d".repeat(34)].join("_");
+		const err = new Error(`publish failed: ${npmToken} ${gitlabToken} ${stripeKey} ${hfToken}`);
+
+		recordFatalCrash("Uncaught Exception", err, { path: target });
+
+		const contents = fs.readFileSync(target, "utf8");
+		expect(contents).toContain("publish failed");
+		for (const secret of [npmToken, gitlabToken, stripeKey, hfToken]) {
+			expect(contents).not.toContain(secret);
+		}
+		expect(contents).toContain("«redacted-npm-token»");
+		expect(contents).toContain("«redacted-gitlab-token»");
+	});
+
 	it("enforces owner-only permissions on a pre-existing file", () => {
 		if (process.platform === "win32") return;
 		const target = tempCrashLog();


### PR DESCRIPTION
## What

Teach `redactCrashSecrets` the five vendor token shapes that `crash/upstream/envelope.ts` already classifies as credential-like.

## Why

`envelope.ts` keeps a refuse-list and drops any frame field that matches it:

```js
const CREDENTIAL_LIKE_PATTERNS: readonly RegExp[] = [
  /\bAIza[0-9A-Za-z_-]{20,}\b/,
  /\bnpm_[A-Za-z0-9]{20,}\b/,
  /\bglpat-[A-Za-z0-9_-]{20,}\b/,
  /\b(?:sk|rk)_(?:live|test)_[A-Za-z0-9]{16,}\b/,
  /\bhf_[A-Za-z0-9]{20,}\b/,
  /-----BEGIN [A-Z ]*PRIVATE KEY-----/,
];
```

That list is applied by `sanitizeEgressField`, and `sanitizeEgressField` is used in exactly two places — the Sentry frame `filename` and `function` (`envelope.ts:105,107`).

The two paths that actually carry crash text off the machine never see it:

- `postmortem.ts` calls `redactCrashSecrets` directly for the crash log it keeps indefinitely.
- `crash/report.ts` builds the `gjc crash report` body from `sanitizeExternalCrashV1`, whose credential layer is that same function.

Measured on `dev` (`3253528e`), all fixtures synthetic:

| shape | persisted log | `gjc crash report` body |
| --- | --- | --- |
| `npm_…` | **survives** | **survives** |
| `glpat-…` | **survives** | redacted incidentally |
| `sk_live_…` | **survives** | **survives** |
| `rk_test_…` | **survives** | **survives** |
| `hf_…` | **survives** | **survives** |
| `AIza…` (control) | redacted | redacted |

The control confirms the harness: `AIza` is on the same refuse-list and is redacted, because #5347 added it to this function.

### The asymmetry runs the wrong way

The Sentry relay is opt-in and posts to a private project. The `gjc crash report` body is what a user files as a **public GitHub issue** — `report.ts` is explicit that the preview is the consent boundary, but a user reading that preview is checking whether the report describes their bug, not scanning a stack frame for an embedded `hf_` token.

So the surface with the weaker guard is the one with the broader audience.

### Why `sk-` did not already cover Stripe

`redactCrashSecrets` has `/\bsk-[A-Za-z0-9_-]{8,}\b/`. Stripe separates with `_`, not `-`, so `sk_live_…` was never a candidate for that rule at any length. Hugging Face has the same `_` shape.

## Testing

```
bun --cwd=packages/utils run check            # biome + tsc, exit 0
bun --cwd=packages/coding-agent run check     # biome + tsc, exit 0
bun test packages/utils/test/postmortem-crash-log.test.ts \
         packages/utils/test/crash-journal.test.ts \
         packages/utils/test/crash-fingerprint.test.ts \
         packages/coding-agent/test/crash-sanitize.test.ts \
         packages/coding-agent/test/crash-upstream-envelope.test.ts
  74 pass, 0 fail, 231 expect() calls
```

Tests added:

- `crash-sanitize.test.ts` — `drops the shapes the Sentry egress guard refuses to transmit` (outbound path) and `keeps prefix lookalikes that are too short to be tokens`.
- `postmortem-crash-log.test.ts` — `redacts the vendor tokens the Sentry egress guard already refuses` (persisted path), asserting the new markers appear and the surrounding text survives.

Both were verified to fail on unmodified `dev`, with the tokens visible verbatim in the crash record.

False-positive check: `npm install express`, `npm_short`, `hf_ prefix` as prose, `glpat-short`, `rk_prod_…`, and a 19-character npm body are all preserved unchanged.

`packages/coding-agent/src/internal-urls/docs-index.generated.ts` must be regenerated locally first (`bun run generate-docs-index`); it is not committed.

Fixtures are assembled at runtime (`["npm", "a".repeat(36)].join("_")`) rather than written as literals — a literal of this shape trips GitHub push protection even when synthetic, and allow-listing one to land a secret-scrubber test is the wrong trade.

## Risk classification

- [ ] `low-risk`
- [x] `regression-risk` — widens a fail-closed scrubber on the crash-egress path. The rules are anchored, length-bounded copies of patterns this repo already ships in `envelope.ts`, and the lookalike cases are pinned, but over-redaction degrades crash diagnosability.
- [ ] `high-risk`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:434d49ad1e0283add241d3b5cf8f1e5ef54b948eded702b9b302377d8f1c28f1 reviewer:architect reviewer-id:Yeachan-Heo evidence:bun --cwd=packages/utils run check; bun --cwd=packages/coding-agent run check; bun test packages/utils/test/postmortem-crash-log.test.ts packages/utils/test/crash-journal.test.ts packages/utils/test/crash-fingerprint.test.ts packages/coding-agent/test/crash-sanitize.test.ts packages/coding-agent/test/crash-upstream-envelope.test.ts; git diff --check
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes (both touched packages' `check` green; the full multi-workspace gate exceeds my local time budget)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken