### PR TITLE
[models] Add gpt-image-2.5-sunburst / gpt-image-2.5-flare image presets

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -99,41 +99,47 @@ export function injectCodexAstraModel(models: Model[]): void {
 
 /**
  * Inject dedicated image generation models into providers that support them.
- * gpt-image-2 is registered under openai and openai-codex so the image
- * generation tool can route through a dedicated model instead of the active
- * chat model. These entries are image-only and should be excluded from the
- * chat model browser UI.
+ * gpt-image-2 and the gpt-image-2.5 variants (sunburst for editing precision,
+ * flare for fast everyday generation) are registered under openai and
+ * openai-codex so the image generation tool can route through a dedicated
+ * model instead of the active chat model. These entries are image-only and
+ * should be excluded from the chat model browser UI.
  */
 export function injectImageGenerationModels(models: Model[]): void {
+	const imageModelVariants = [
+		{ id: "gpt-image-2", name: "GPT Image 2" },
+		{ id: "gpt-image-2.5-sunburst", name: "GPT Image 2.5 Sunburst" },
+		{ id: "gpt-image-2.5-flare", name: "GPT Image 2.5 Flare" },
+	];
 	const imageModelBase = {
-		id: "gpt-image-2",
-		name: "GPT Image 2",
 		reasoning: false,
 		input: ["text"],
 		output: ["text", "image"],
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		contextWindow: 128_000,
 		maxTokens: 16_384,
-	} satisfies Omit<Model, "api" | "provider" | "baseUrl">;
-	const hasOpenAI = models.some(m => m.provider === "openai" && m.id === "gpt-image-2");
-	if (!hasOpenAI) {
-		const openAIImageModel: Model<"openai-responses"> = {
-			...imageModelBase,
-			api: "openai-responses",
-			provider: "openai",
-			baseUrl: "",
-		};
-		models.push(openAIImageModel);
-	}
-	const hasCodex = models.some(m => m.provider === "openai-codex" && m.id === "gpt-image-2");
-	if (!hasCodex) {
-		const codexImageModel: Model<"openai-codex-responses"> = {
-			...imageModelBase,
-			api: "openai-codex-responses",
-			provider: "openai-codex",
-			baseUrl: "",
-		};
-		models.push(codexImageModel);
+	} satisfies Omit<Model, "api" | "provider" | "baseUrl" | "id" | "name">;
+	for (const variant of imageModelVariants) {
+		if (!models.some(m => m.provider === "openai" && m.id === variant.id)) {
+			const openAIImageModel: Model<"openai-responses"> = {
+				...imageModelBase,
+				...variant,
+				api: "openai-responses",
+				provider: "openai",
+				baseUrl: "",
+			};
+			models.push(openAIImageModel);
+		}
+		if (!models.some(m => m.provider === "openai-codex" && m.id === variant.id)) {
+			const codexImageModel: Model<"openai-codex-responses"> = {
+				...imageModelBase,
+				...variant,
+				api: "openai-codex-responses",
+				provider: "openai-codex",
+				baseUrl: "",
+			};
+			models.push(codexImageModel);
+		}
 	}
 }
 

--- a/packages/ai/test/generate-models.test.ts
+++ b/packages/ai/test/generate-models.test.ts
@@ -73,6 +73,34 @@ describe("injectImageGenerationModels", () => {
 				input: ["text"],
 				output: ["text", "image"],
 			}),
+			expect.objectContaining({
+				id: "gpt-image-2.5-sunburst",
+				api: "openai-responses",
+				provider: "openai",
+				input: ["text"],
+				output: ["text", "image"],
+			}),
+			expect.objectContaining({
+				id: "gpt-image-2.5-sunburst",
+				api: "openai-codex-responses",
+				provider: "openai-codex",
+				input: ["text"],
+				output: ["text", "image"],
+			}),
+			expect.objectContaining({
+				id: "gpt-image-2.5-flare",
+				api: "openai-responses",
+				provider: "openai",
+				input: ["text"],
+				output: ["text", "image"],
+			}),
+			expect.objectContaining({
+				id: "gpt-image-2.5-flare",
+				api: "openai-codex-responses",
+				provider: "openai-codex",
+				input: ["text"],
+				output: ["text", "image"],
+			}),
 		]);
 	});
 });


### PR DESCRIPTION
Closes #5478

## What
Extends `injectImageGenerationModels` in `packages/ai/scripts/generate-models.ts` to register `gpt-image-2.5-sunburst` (editing precision) and `gpt-image-2.5-flare` (fast everyday generation) under both `openai` (`openai-responses`) and `openai-codex` (`openai-codex-responses`), mirroring the existing `gpt-image-2` entries (image-only output, zero cost, 128k context / 16k max tokens).

## Why
`modelRoles.image` only resolves models present in the signed preset registry, and provider-qualified selectors are exact-only. The registry (rev 3) only ships `gpt-image-2`, so there is no local way to use the current 2.5 models from the OpenAI image generation guide (https://developers.openai.com/api/docs/guides/image-generation). Setting an unlisted id fails closed with "No image model configured".

## Verification
- `bun test test/generate-models.test.ts` in `packages/ai`: 7 pass
- `bunx tsc --noEmit` in `packages/ai`: clean
- After merge + registry publish, `gjc models presets refresh` should surface the 2.5 variants in `gjc --list-models image`.