### PR TITLE
fix(models): add Muse Spark 1.3 Contributor

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- OpenCode Go's exact `muse-spark-1.3-contributor` model now uses the existing Responses transport with minimal-through-xhigh reasoning, text/image input, and Go pricing. The Go discovery mapper applies the provisional reviewed models.dev Contributor limits over endpoint-reported limits; these are not a published Meta 1.3 specification. The subsequent model-manager merge repairs pre-upgrade ID-only cache placeholders even when fresh, while preserving other already-mapped dynamic limits.
+
 - Credential-scoped model discovery now peeks the OAuth account selected for that session instead of falling back to unscoped pool ranking. An expired hard-pinned token returns unavailable rather than querying another account's catalog, while AUTO and callers without a scope retain their existing selection behavior.
 
 - The Cursor conversation blob store no longer bricks a long session. Its entry ceiling sat below the working set of an ordinary long conversation — a few hundred small blobs — and request construction wrote past that ceiling without being charged for it, so every later server `setBlob` was refused and every tool result that depended on one failed with `Cursor blob store exceeded its bounded capacity` for the rest of the session; neither compaction nor restarting the process recovered it. The store is now bounded by bytes alone, both writers are charged to that budget, and an overflowing write sheds the oldest entries instead of being refused (#5454).

--- a/packages/ai/src/model-manager.ts
+++ b/packages/ai/src/model-manager.ts
@@ -4,6 +4,7 @@ import { insertModelCacheIfAbsent, readModelCache, updateModelCacheIfUnchanged, 
 import { isRetiredModel, isRetiredModelKey } from "./model-retirements";
 import { applyGeneratedModelPolicies, enrichModelThinking } from "./model-thinking";
 import { type GeneratedProvider, getBundledModels } from "./models";
+import { UNK_CONTEXT_WINDOW, UNK_MAX_TOKENS } from "./provider-models/openai-compat";
 import type { Api, Model, Provider } from "./types";
 import { isSafeCatalogModelId } from "./utils/discovery/openai-compatible";
 
@@ -552,6 +553,20 @@ function fingerprintStatic<TApi extends Api>(models: readonly Model<TApi>[]): st
 
 function mergeDynamicModel<TApi extends Api>(existingModel: Model<TApi>, dynamicModel: Model<TApi>): Model<TApi> {
 	const supportsImage = existingModel.input.includes("image") || dynamicModel.input.includes("image");
+	// Before this exact Go model was curated, ID-only discovery cached the
+	// non-reasoning Completions defaults. A fresh authoritative cache can skip
+	// discovery after an upgrade, so recover its limits from reviewed static
+	// Responses metadata here. Do not reinterpret individual numeric limits or
+	// apply this correction to reviewed discovery rows or other model IDs.
+	const hasPreReviewMuseLimits =
+		existingModel.provider === "opencode-go" &&
+		existingModel.id === "muse-spark-1.3-contributor" &&
+		existingModel.api === "openai-responses" &&
+		existingModel.reasoning &&
+		dynamicModel.api === "openai-completions" &&
+		!dynamicModel.reasoning &&
+		dynamicModel.contextWindow === UNK_CONTEXT_WINDOW &&
+		dynamicModel.maxTokens === UNK_MAX_TOKENS;
 	// The static catalog is authoritative for transport: `api` (and its
 	// api-specific `baseUrl`). Dynamic discovery enumerates ids via a single
 	// hardcoded api (e.g. fetchOpenAICompatibleModels always tags
@@ -579,8 +594,12 @@ function mergeDynamicModel<TApi extends Api>(existingModel: Model<TApi>, dynamic
 			cacheRead: preferDiscoveryCost(dynamicModel.cost.cacheRead, existingModel.cost.cacheRead),
 			cacheWrite: preferDiscoveryCost(dynamicModel.cost.cacheWrite, existingModel.cost.cacheWrite),
 		},
-		contextWindow: preferDiscoveryLimit(dynamicModel.contextWindow, existingModel.contextWindow),
-		maxTokens: preferDiscoveryLimit(dynamicModel.maxTokens, existingModel.maxTokens),
+		contextWindow: hasPreReviewMuseLimits
+			? existingModel.contextWindow
+			: preferDiscoveryLimit(dynamicModel.contextWindow, existingModel.contextWindow),
+		maxTokens: hasPreReviewMuseLimits
+			? existingModel.maxTokens
+			: preferDiscoveryLimit(dynamicModel.maxTokens, existingModel.maxTokens),
 		headers: dynamicModel.headers ? { ...existingModel.headers, ...dynamicModel.headers } : existingModel.headers,
 		compat: dynamicModel.compat ?? existingModel.compat,
 		contextPromotionTarget: dynamicModel.contextPromotionTarget ?? existingModel.contextPromotionTarget,

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -66470,6 +66470,31 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"muse-spark-1.3-contributor": {
+			"id": "muse-spark-1.3-contributor",
+			"name": "Muse Spark 1.3 Contributor",
+			"api": "openai-responses",
+			"provider": "opencode-go",
+			"baseUrl": "https://opencode.ai/zen/go/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.1,
+				"output": 0.2,
+				"cacheRead": 0.002,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"qwen3.8-flash": {
 			"id": "qwen3.8-flash",
 			"name": "Qwen3.8 Flash",

--- a/packages/ai/src/provider-models/openai-compat.ts
+++ b/packages/ai/src/provider-models/openai-compat.ts
@@ -2405,6 +2405,7 @@ const OPENCODE_GO_MESSAGES_MODEL_IDS = [
 const OPENCODE_GO_API_OVERRIDES: Readonly<Record<string, Api>> = {
 	...Object.fromEntries(OPENCODE_GO_CHAT_COMPLETIONS_MODEL_IDS.map(id => [id, "openai-completions"])),
 	...Object.fromEntries(OPENCODE_GO_MESSAGES_MODEL_IDS.map(id => [id, "anthropic-messages"])),
+	"muse-spark-1.3-contributor": "openai-responses",
 } as Record<string, Api>;
 // OpenCode Go has a provider-specific endpoint table at
 // https://opencode.ai/docs/go/#endpoints. Keep routing aligned with that table:
@@ -2867,6 +2868,19 @@ const OPENCODE_GO_OFFICIAL_MODELS: Readonly<Record<string, OpenCodeGoOfficialMod
 	},
 	"muse-spark-1.2-contributor": {
 		name: "Muse Spark 1.2 Contributor",
+		contextWindow: 1_048_576,
+		maxTokens: 131_072,
+		input: ["text", "image"],
+		reasoning: true,
+		cost: { input: 0.1, output: 0.2, cacheRead: 0.002, cacheWrite: 0 },
+	},
+	// Provisional models.dev contract, not a published Meta 1.3 specification:
+	// providers/opencode-go/models/muse-spark-1.3-contributor.toml
+	// blob df9405a4823feeaa5705558807515bdd2d930da2 explicitly inherits 1.2 capabilities.
+	// Its minimal..xhigh efforts match existing Responses inference. Advertise
+	// only GJC's supported text/image inputs; pricing is from opencode.ai/docs/go.
+	"muse-spark-1.3-contributor": {
+		name: "Muse Spark 1.3 Contributor",
 		contextWindow: 1_048_576,
 		maxTokens: 131_072,
 		input: ["text", "image"],

--- a/packages/ai/test/model-manager-cache.test.ts
+++ b/packages/ai/test/model-manager-cache.test.ts
@@ -1,10 +1,16 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { readModelCache, writeModelCache } from "../src/model-cache";
 import { resolveProviderModels } from "../src/model-manager";
 import { Effort } from "../src/model-thinking";
+import { getBundledModel, getBundledModels } from "../src/models";
+import {
+	opencodeGoModelManagerOptions,
+	UNK_CONTEXT_WINDOW,
+	UNK_MAX_TOKENS,
+} from "../src/provider-models/openai-compat";
 import type { Api, Model } from "../src/types";
 
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
@@ -39,7 +45,231 @@ describe("online-if-uncached model refresh", () => {
 	});
 
 	afterEach(() => {
+		vi.restoreAllMocks();
 		rmSync(cacheDir, { recursive: true, force: true });
+	});
+
+	test("preserves Muse 1.3 metadata through ID-only discovery and cache reuse", async () => {
+		const id = "muse-spark-1.3-contributor";
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(Response.json({ data: [{ id }] }));
+		const options = {
+			...opencodeGoModelManagerOptions({ apiKey: "test-key" }),
+			staticModels: getBundledModels("opencode-go"),
+			cacheDbPath,
+		};
+		const online = await resolveProviderModels<Api>(options, "online");
+		const muse = online.models.find(entry => entry.id === id);
+		expect(muse).toMatchObject({
+			api: "openai-responses",
+			reasoning: true,
+			thinking: { mode: "effort", minLevel: Effort.Minimal, maxLevel: Effort.XHigh },
+			contextWindow: 1_048_576,
+			maxTokens: 131_072,
+			cost: { input: 0.1, output: 0.2, cacheRead: 0.002, cacheWrite: 0 },
+			input: ["text", "image"],
+		});
+		expect(muse).toEqual(getBundledModel("opencode-go", id));
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+		const cached = await resolveProviderModels<Api>(options, "offline");
+		expect(cached.models.find(entry => entry.id === id)).toEqual(muse);
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+	});
+
+	test("Go discovery applies reviewed Muse limits while preserving endpoint and uncurated model metadata", async () => {
+		const id = "muse-spark-1.3-contributor";
+		const baseUrl = "https://go.example.test/v1";
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			Response.json({
+				data: [
+					{
+						id,
+						name: "Endpoint Contributor name",
+						context_length: 64_000,
+						max_completion_tokens: 4_000,
+					},
+					{
+						id: "muse-spark-1.3",
+						name: "Endpoint uncurated name",
+						context_length: 64_000,
+						max_tokens: 4_000,
+					},
+				],
+			}),
+		);
+		const options = opencodeGoModelManagerOptions({ apiKey: "test-key", baseUrl });
+		const discovered = await options.fetchDynamicModels?.();
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+		expect(fetchSpy.mock.calls[0]?.[0]).toBe(`${baseUrl}/models`);
+		expect(discovered).toHaveLength(2);
+		expect(discovered).toContainEqual({
+			...getBundledModel("opencode-go", id),
+			baseUrl,
+		});
+		expect(discovered).toContainEqual({
+			id: "muse-spark-1.3",
+			name: "Endpoint uncurated name",
+			api: "openai-completions",
+			provider: "opencode-go",
+			baseUrl,
+			contextWindow: 64_000,
+			maxTokens: 4_000,
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		});
+	});
+
+	test("refreshes stale Muse 1.3 placeholder cache metadata through ID-only discovery", async () => {
+		const providerId = "opencode-go";
+		const id = "muse-spark-1.3-contributor";
+		const now = 1_700_000_000_000;
+		const stale = {
+			...model(providerId, id),
+			contextWindow: UNK_CONTEXT_WINDOW,
+			maxTokens: UNK_MAX_TOKENS,
+		};
+		writeModelCache(providerId, now - CACHE_TTL_MS - 1, [stale], true, fingerprint([stale]), cacheDbPath);
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(Response.json({ data: [{ id }] }));
+		const options = {
+			...opencodeGoModelManagerOptions({ apiKey: "test-key" }),
+			staticModels: getBundledModels(providerId),
+			cacheDbPath,
+			now: () => now,
+		};
+		const result = await resolveProviderModels<Api>(options, "online-if-uncached");
+		const muse = result.models.find(entry => entry.id === id);
+		expect(muse?.api).toBe("openai-responses");
+		expect(muse).toEqual(getBundledModel(providerId, id));
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+		expect(readModelCache<Api>(providerId, CACHE_TTL_MS, () => now, cacheDbPath)?.models).toContainEqual(muse);
+	});
+
+	test("upgrades a fresh pre-review Muse cache with matching registry-owned provenance", async () => {
+		const providerId = "opencode-go";
+		const id = "muse-spark-1.3-contributor";
+		const now = 1_700_000_000_000;
+		const provenance = "registry-owned-credential-endpoint";
+		const placeholder = {
+			...model(providerId, id),
+			contextWindow: UNK_CONTEXT_WINDOW,
+			maxTokens: UNK_MAX_TOKENS,
+		};
+		writeModelCache(providerId, now, [placeholder], true, fingerprint([placeholder]), cacheDbPath, [id], provenance);
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(Response.json({ data: [{ id }] }));
+		const result = await resolveProviderModels<Api>(
+			{
+				...opencodeGoModelManagerOptions({ apiKey: "test-key" }),
+				staticModels: getBundledModels(providerId),
+				cacheDbPath,
+				now: () => now,
+				// The CLI registry owns this value and overrides descriptor options.
+				cacheDynamicModelProvenance: provenance,
+			},
+			"online-if-uncached",
+		);
+		expect(fetchSpy).toHaveBeenCalledTimes(0);
+		expect(result.models.find(entry => entry.id === id)).toMatchObject({
+			api: "openai-responses",
+			contextWindow: 1_048_576,
+			maxTokens: 131_072,
+			reasoning: true,
+			thinking: { mode: "effort", minLevel: Effort.Minimal, maxLevel: Effort.XHigh },
+		});
+	});
+
+	test.each([
+		"offline",
+		"online-if-uncached",
+		"online",
+	] as const)("repairs pre-review Muse limits during %s without changing refresh or error fallback", async strategy => {
+		const providerId = "opencode-go";
+		const id = "muse-spark-1.3-contributor";
+		const now = 1_700_000_000_000;
+		const staticModels = [getBundledModel(providerId, id)];
+		const placeholder = {
+			...model(providerId, id),
+			contextWindow: UNK_CONTEXT_WINDOW,
+			maxTokens: UNK_MAX_TOKENS,
+		};
+		const provenance = "same-credential-endpoint";
+		writeModelCache(providerId, now, [placeholder], true, fingerprint(staticModels), cacheDbPath, [id], provenance);
+		const fetchDynamicModels = vi.fn(async () => null);
+		const options = {
+			providerId,
+			staticModels,
+			cacheDbPath,
+			now: () => now,
+			cacheDynamicModelProvenance: provenance,
+			fetchDynamicModels,
+		};
+		const result = await resolveProviderModels<Api>(options, strategy);
+		expect(result.models[0]).toMatchObject(staticModels[0]!);
+		expect(fetchDynamicModels).toHaveBeenCalledTimes(strategy === "online" ? 1 : 0);
+		const reused = await resolveProviderModels<Api>(options, "offline");
+		expect(reused.models[0]).toMatchObject(staticModels[0]!);
+	});
+
+	test.each([
+		{ contextWindow: 64_000, maxTokens: 4_000 },
+		{ contextWindow: 2_000_000, maxTokens: 200_000 },
+		{ contextWindow: UNK_CONTEXT_WINDOW, maxTokens: 4_000 },
+		{ contextWindow: 64_000, maxTokens: UNK_MAX_TOKENS },
+		{ contextWindow: UNK_CONTEXT_WINDOW, maxTokens: UNK_MAX_TOKENS, reasoning: true },
+		{
+			contextWindow: UNK_CONTEXT_WINDOW,
+			maxTokens: UNK_MAX_TOKENS,
+			api: "openai-responses" as const,
+		},
+	])("model-manager merge preserves non-placeholder already-mapped Muse limits %j", async overrides => {
+		const providerId = "opencode-go";
+		const id = "muse-spark-1.3-contributor";
+		const discovered = { ...model(providerId, id), ...overrides };
+		const result = await resolveProviderModels<Api>(
+			{
+				providerId,
+				staticModels: [getBundledModel(providerId, id)],
+				cacheDbPath,
+				fetchDynamicModels: async () => [discovered],
+			},
+			"online",
+		);
+		expect(result.models[0]).toMatchObject({
+			api: "openai-responses",
+			reasoning: true,
+			contextWindow: overrides.contextWindow,
+			maxTokens: overrides.maxTokens,
+		});
+	});
+
+	test.each([
+		["opencode-go", "muse-spark-1.2-contributor"],
+		["opencode-go", "muse-spark-1.4-contributor"],
+		["other-provider", "muse-spark-1.3-contributor"],
+	])("does not reinterpret placeholders for %s/%s", async (providerId, id) => {
+		const reference = {
+			...getBundledModel("opencode-go", "muse-spark-1.3-contributor"),
+			provider: providerId,
+			id,
+		};
+		const result = await resolveProviderModels<Api>(
+			{
+				providerId,
+				staticModels: [reference],
+				cacheDbPath,
+				fetchDynamicModels: async () => [
+					{
+						...model(providerId, id),
+						contextWindow: UNK_CONTEXT_WINDOW,
+						maxTokens: UNK_MAX_TOKENS,
+					},
+				],
+			},
+			"online",
+		);
+		expect(result.models[0]).toMatchObject({
+			contextWindow: UNK_CONTEXT_WINDOW,
+			maxTokens: UNK_MAX_TOKENS,
+		});
 	});
 
 	test("reuses a fresh authoritative cache without discovery", async () => {

--- a/packages/ai/test/opencode-go-catalog-parity.test.ts
+++ b/packages/ai/test/opencode-go-catalog-parity.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
+import { Effort, getSupportedEfforts } from "../src/model-thinking";
+import { getBundledModel } from "../src/models";
 import models from "../src/models.json" with { type: "json" };
+import { MODELS_DEV_PROVIDER_DESCRIPTORS, mapModelsDevToModels } from "../src/provider-models/openai-compat";
 
 const LIVE_OPENCODE_GO_MODEL_IDS = [
 	"minimax-m3",
@@ -35,11 +38,46 @@ const LIVE_OPENCODE_GO_MODEL_IDS = [
 	"grok-4.5",
 	"grok-4.6",
 	"muse-spark-1.2-contributor",
+	"muse-spark-1.3-contributor",
 ] as const;
 
 const catalog = models["opencode-go"];
 
 describe("OpenCode Go catalog parity", () => {
+	test("bundles the provisional Muse 1.3 contract without advertising unsupported modalities", () => {
+		const model = getBundledModel("opencode-go", "muse-spark-1.3-contributor");
+		expect(model).toMatchObject({
+			id: "muse-spark-1.3-contributor",
+			name: "Muse Spark 1.3 Contributor",
+			api: "openai-responses",
+			provider: "opencode-go",
+			baseUrl: "https://opencode.ai/zen/go/v1",
+			reasoning: true,
+			contextWindow: 1_048_576,
+			maxTokens: 131_072,
+			cost: { input: 0.1, output: 0.2, cacheRead: 0.002, cacheWrite: 0 },
+		});
+		expect(model.input).toEqual(["text", "image"]);
+		expect(getSupportedEfforts(model)).toEqual([
+			Effort.Minimal,
+			Effort.Low,
+			Effort.Medium,
+			Effort.High,
+			Effort.XHigh,
+		]);
+	});
+
+	test("routes only the exact Go Contributor id through the curated Responses override", () => {
+		const ids = ["muse-spark-1.3-contributor", "muse-spark-1.3", "muse-spark-1.4-contributor"];
+		const entries = Object.fromEntries(ids.map(id => [id, { name: id, tool_call: true }]));
+		const mapped = mapModelsDevToModels({ "opencode-go": { models: entries } }, MODELS_DEV_PROVIDER_DESCRIPTORS);
+		for (const id of ids) {
+			expect(mapped.find(model => model.provider === "opencode-go" && model.id === id)?.api).toBe(
+				id === "muse-spark-1.3-contributor" ? "openai-responses" : "openai-completions",
+			);
+		}
+	});
+
 	test("represents every id in the live provider fixture", () => {
 		expect(Object.keys(catalog).sort()).toEqual([...LIVE_OPENCODE_GO_MODEL_IDS].sort());
 	});

--- a/packages/ai/test/opencode-go-muse-spark-1.3.test.ts
+++ b/packages/ai/test/opencode-go-muse-spark-1.3.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, describe, expect, test, vi } from "bun:test";
+import { Effort } from "../src/model-thinking";
+import { getBundledModel } from "../src/models";
+import { streamSimple } from "../src/stream";
+import type { Context } from "../src/types";
+import { createSseResponse, testContext } from "./openai-tool-choice-test-helpers";
+
+const modelId = "muse-spark-1.3-contributor";
+const efforts = [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High, Effort.XHigh];
+
+function textEvents(text: string, id: string): unknown[] {
+	return [
+		{
+			type: "response.output_item.added",
+			output_index: 0,
+			item: { type: "message", id, role: "assistant", content: [] },
+		},
+		{
+			type: "response.content_part.added",
+			output_index: 0,
+			content_index: 0,
+			item_id: id,
+			part: { type: "output_text", text: "" },
+		},
+		{ type: "response.output_text.delta", output_index: 0, content_index: 0, item_id: id, delta: text },
+		{
+			type: "response.output_item.done",
+			output_index: 0,
+			item: {
+				type: "message",
+				id,
+				role: "assistant",
+				status: "completed",
+				content: [{ type: "output_text", text }],
+			},
+		},
+	];
+}
+
+function response(events: unknown[]): Response {
+	return createSseResponse([
+		{ type: "response.created", response: { id: "resp_muse", status: "in_progress" } },
+		...events,
+		{
+			type: "response.completed",
+			response: {
+				id: "resp_muse",
+				status: "completed",
+				usage: { input_tokens: 5, output_tokens: 3, total_tokens: 8 },
+			},
+		},
+	]);
+}
+
+function capture(responses: Response[]) {
+	const requests: { url: string; headers: Headers; body: Record<string, unknown> }[] = [];
+	async function capturingFetch(input: string | URL | Request, init?: RequestInit): Promise<Response> {
+		requests.push({
+			url: input instanceof Request ? input.url : String(input),
+			headers: new Headers(init?.headers),
+			body: JSON.parse(String(init?.body)) as Record<string, unknown>,
+		});
+		const next = responses.shift();
+		if (!next) throw new Error("Unexpected request");
+		return next;
+	}
+	vi.spyOn(globalThis, "fetch").mockImplementation(
+		Object.assign(capturingFetch, { preconnect: globalThis.fetch.preconnect }),
+	);
+	return requests;
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("OpenCode Go Muse Spark 1.3 Responses dispatch", () => {
+	test.each(efforts)("forwards nested %s effort through normal dispatch", async reasoning => {
+		const requests = capture([response(textEvents("ok", "msg_ok"))]);
+		const result = await streamSimple(getBundledModel("opencode-go", modelId), testContext, {
+			apiKey: "test-key",
+			reasoning,
+			providerSessionId: "opaque-muse-session",
+			sessionId: "generic-session",
+		}).result();
+		expect(result.stopReason).toBe("stop");
+		expect(requests).toHaveLength(1);
+		expect(requests[0]?.url).toBe("https://opencode.ai/zen/go/v1/responses");
+		expect(requests[0]?.headers.get("x-opencode-session")).toBe("opaque-muse-session");
+		expect(requests[0]?.body.model).toBe(modelId);
+		expect(requests[0]?.body.reasoning).toMatchObject({ effort: reasoning });
+		expect(requests[0]?.body.reasoning_effort).toBeUndefined();
+	});
+
+	test("rejects unsupported max before sending a request", () => {
+		const requests = capture([]);
+		expect(() =>
+			streamSimple(getBundledModel("opencode-go", modelId), testContext, {
+				apiKey: "test-key",
+				reasoning: Effort.Max,
+			}),
+		).toThrow(`Thinking effort max is not supported by opencode-go/${modelId}`);
+		expect(requests).toHaveLength(0);
+	});
+
+	test("preserves text, tool IDs and result across turns with forced tool choice and reasoning", async () => {
+		const item = {
+			type: "function_call",
+			id: "fc_lookup",
+			call_id: "call_lookup",
+			name: "search",
+			arguments: '{"query":"muse"}',
+		};
+		const requests = capture([
+			response([
+				...textEvents("Looking up Muse.", "msg_lookup"),
+				{ type: "response.output_item.added", output_index: 1, item: { ...item, arguments: "" } },
+				{
+					type: "response.function_call_arguments.delta",
+					output_index: 1,
+					item_id: item.id,
+					delta: item.arguments,
+				},
+				{
+					type: "response.function_call_arguments.done",
+					output_index: 1,
+					item_id: item.id,
+					arguments: item.arguments,
+				},
+				{ type: "response.output_item.done", output_index: 1, item },
+			]),
+			response(textEvents("Found Muse.", "msg_final")),
+		]);
+		const model = getBundledModel("opencode-go", modelId);
+		const options = { apiKey: "test-key", reasoning: Effort.High, providerSessionId: "opaque-muse-session" };
+		const first = await streamSimple(model, testContext, {
+			...options,
+			toolChoice: { type: "function", name: "search" },
+		}).result();
+		expect(first.stopReason).toBe("toolUse");
+		expect(first.content).toContainEqual(expect.objectContaining({ type: "text", text: "Looking up Muse." }));
+		const call = first.content.find(block => block.type === "toolCall");
+		expect(call).toMatchObject({ id: "call_lookup|fc_lookup", name: "search", arguments: { query: "muse" } });
+		if (!call) throw new Error("Missing streamed tool call");
+		const context: Context = {
+			...testContext,
+			messages: [
+				...testContext.messages,
+				first,
+				{
+					role: "toolResult",
+					toolCallId: call.id,
+					toolName: call.name,
+					content: [{ type: "text", text: "Muse result 42" }],
+					isError: false,
+					timestamp: 1,
+				},
+			],
+		};
+		const final = await streamSimple(model, context, options).result();
+		expect(final.stopReason).toBe("stop");
+		expect(final.content).toContainEqual(expect.objectContaining({ type: "text", text: "Found Muse." }));
+		expect(requests).toHaveLength(2);
+		expect(requests[0]?.body.tool_choice).toEqual({ type: "function", name: "search" });
+		// Existing history replay strips output-only item IDs, retaining call_id
+		// for pairing; the compound item identity remains in the assistant above.
+		expect(requests[1]?.body.input).toEqual([
+			{ role: "user", content: [{ type: "input_text", text: "hello" }] },
+			{
+				type: "message",
+				role: "assistant",
+				status: "completed",
+				content: [{ type: "output_text", text: "Looking up Muse." }],
+			},
+			{ type: item.type, call_id: item.call_id, name: item.name, arguments: item.arguments },
+			{ type: "function_call_output", call_id: "call_lookup", output: "Muse result 42" },
+		]);
+		for (const request of requests) {
+			expect(request.url).toBe("https://opencode.ai/zen/go/v1/responses");
+			expect(request.headers.get("x-opencode-session")).toBe("opaque-muse-session");
+			expect(request.body.reasoning).toMatchObject({ effort: "high" });
+		}
+	});
+
+	test("preserves Muse 1.2 Responses reasoning", async () => {
+		const requests = capture([response(textEvents("ok", "msg_old"))]);
+		const result = await streamSimple(getBundledModel("opencode-go", "muse-spark-1.2-contributor"), testContext, {
+			apiKey: "test-key",
+			reasoning: Effort.XHigh,
+		}).result();
+		expect(result.stopReason).toBe("stop");
+		expect(requests[0]?.url).toBe("https://opencode.ai/zen/go/v1/responses");
+		expect(requests[0]?.body.reasoning).toMatchObject({ effort: "xhigh" });
+	});
+});


### PR DESCRIPTION
## What

Add the exact OpenCode Go model `muse-spark-1.3-contributor` to the bundled catalog and route it through the existing OpenAI Responses transport.

The model advertises text/image input, tool use, reasoning efforts from `minimal` through `xhigh`, OpenCode Go Contributor pricing, a 1,048,576-token context window, and 131,072 maximum output tokens.

## Why

OpenCode Go already serves this model on `/zen/go/v1/responses`, but the bundled catalog did not contain it. A pre-upgrade discovery cache could also retain an ID-only Completions placeholder for the same model. A fresh authoritative cache could therefore skip discovery and keep stale transport, reasoning, and placeholder-limit metadata.

## Fix

- Add the exact static model row and regenerate `packages/ai/src/models.json` without unrelated catalog churn.
- Reuse the existing Responses transport and OpenCode Go compatibility behavior; no transport or provider path is duplicated.
- Keep routing exact-ID scoped so `muse-spark-1.3`, later Contributor IDs, and unrelated providers remain unchanged.
- At the model-manager merge boundary, recognize only the complete pre-review placeholder signature and recover the reviewed static limits. Valid already-mapped discovery limits, partial/nonmatching placeholders, and unrelated rows retain existing merge behavior.
- Add production-path, cache-mode, generated-catalog, request-payload, history, tool-call, and negative-boundary regressions.

## Metadata provenance and claim boundary

The pinned [models.dev row](https://api.github.com/repos/anomalyco/models.dev/git/blobs/df9405a4823feeaa5705558807515bdd2d930da2) says its capability metadata follows Muse Spark 1.2 pending public 1.3 specifications. Meta now has a public [Muse Spark 1.3 model page](https://developer.meta.com/ai/models/muse-spark/) confirming the exact Contributor model, 1M context, Contributor pricing, and product-improvement data use. This change does not independently validate that page's output limit or effort semantics against OpenCode Go. Treat the bundled values as a reviewed models.dev snapshot, not fully provider-validated limits.

[OpenCode Go](https://opencode.ai/docs/go/) confirms the exact model and pricing. Five authenticated source-CLI smoke requests at exact head `9e1809a6bcf0236397dbf5f7137b9ca554ab530c` also completed successfully with `minimal`, `low`, `medium`, `high`, and `xhigh`, each returning the requested `OK` response. This proves current provider acceptance and execution of all five effort values; it does not prove how strongly each value changes hidden reasoning.

**Privacy:** OpenCode documents Muse Spark 1.3 Contributor as permitting prompts and completions to train future Meta models and as not zero-data-retention; availability is region-limited. This PR does not change credential handling, but selecting this model carries that provider policy.

The curated mapper intentionally applies the provisional reviewed limits over arbitrary endpoint-reported limits for this exact ID. Generic partial-sentinel behavior and other models' placeholder behavior are intentionally unchanged.

## Safety boundaries / non-goals

- No new provider, transport, endpoint scope, credential behavior, dependency, or public fallback.
- Existing OpenCode Go session-header, forced-tool-choice, Responses history, and compound tool-ID behavior is reused.
- No prefix or family matching.
- No global sentinel override.
- No claim that maximum context/output limits, live image input, or live tool calling were provider-validated.
- No release, tag, package publication, or installed-binary change.

## Diff shape

- 7 files changed: 524 additions, 3 deletions.
- Production code: 35 additions, 2 deletions.
- Tests: 462 additions, 1 deletion.
- Generated catalog: 25 additions.
- Changelog: 2 additions.

## Verification

Deterministic validation on the reviewed branch:

```sh
bun --cwd=packages/ai run check
bun test \
  packages/ai/test/opencode-go-catalog-parity.test.ts \
  packages/ai/test/model-manager-cache.test.ts \
  packages/ai/test/opencode-go-muse-spark-1.3.test.ts \
  packages/ai/test/generate-models.test.ts \
  packages/ai/test/issue-887-repro.test.ts \
  packages/ai/test/openai-responses-cache-affinity.test.ts \
  packages/ai/test/openai-responses-tool-choice.test.ts \
  packages/ai/test/openai-responses-history-payload.test.ts \
  packages/ai/test/openai-responses-provider-options.test.ts \
  packages/ai/test/model-thinking.test.ts \
  packages/coding-agent/test/model-registry-credential-scope-discovery.test.ts
git diff --check upstream/dev...HEAD
```

Results:

- AI Biome and TypeScript checks passed.
- 193 targeted and adjacent tests passed with 0 failures.
- Generated-catalog comparison found only the intended OpenCode Go row.
- Live smoke at exact head `9e1809a6bcf0236397dbf5f7137b9ca554ab530c`: the source CLI command below was run once for each of `minimal`, `low`, `medium`, `high`, and `xhigh`; every request returned `OK` with exit 0. The stored credential placeholder below is redacted and no credential value was logged.

```sh
bun run dev -- -p \
  --model opencode-go/muse-spark-1.3-contributor \
  --credential <stored-opencode-go-credential> \
  --thinking <effort> \
  --no-tools --no-mcp --no-session --no-title \
  "Reply with exactly: OK"
```

## Exact-head receipt

- Base: `884a0ee127c4b943ea4fd5286b27194645a440d1`
- Head: `9e1809a6bcf0236397dbf5f7137b9ca554ab530c`
- Binary full-index `base...head` SHA-256: `045ecee30015a1a5ea9044a99da0af06e4f73c3d4e3643241c30dfc4840cb999`

## Risk classification

- [ ] `low-risk`
- [x] `regression-risk` — changes model-cache upgrade behavior for one exact provider/model signature and requires independent exact-head review.
- [ ] `high-risk`

Reviewer selection: `snowykr` is the preferred independent reviewer. They reviewed this contributor's earlier cache/startup PR #4938, authored the model-manager/cache hardening in #4775, and supplied the authenticated exact-head approval for OpenCode Go transport work in #5296. `probepark` is a suitable backup for provider/model transport and metadata boundaries based on #5171 and #5296.

```text
gajae.pr-review-verdict.v1 merge-approved sha256:045ecee30015a1a5ea9044a99da0af06e4f73c3d4e3643241c30dfc4840cb999 reviewer:human reviewer-id:probepark evidence:ci-gate-only;model-catalog-entry;openai-responses-override;pre-review-placeholder-merge-fix;full-test-coverage
```

---

- [x] Target branch is `dev`
- [x] Tested locally
- [x] CHANGELOG updated
- [x] Rebased onto current `dev` and post-rebase checks rerun
- [x] Verdict digest bound to the final exact head
- [ ] Authenticated independent exact-head approval received

