### PR TITLE
fix(autorouting): declare the Muse Spark 1.3 Contributor catalog key

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Successful macOS installs and updates can offer the optional experimental, third-party community Gajae Code App (#5140), defaulting to No. The shared installer requires canonical release checksums and a verified bundle/signature, skips installed apps and automation, and supports `GJC_NO_COMMUNITY_APP=1`; app failures leave GJC installed.
 ### Fixed
+- The `opencode-go/muse-spark-1.3-contributor` catalog row added in #5485 is now declared in the autorouting tier-map skip list, so `check:autorouting-map` and its CI gate pass again instead of failing on the unlabeled new key.
 - Image generation now sends the selected image-role model instead of silently substituting a provider default for Antigravity, Gemini, OpenRouter, and Alibaba.
 - The Ultragoal Ask guard now binds state lookup and nudge consumption to an explicit nonblank caller session, regardless of active skill or stale skill/environment session metadata, preventing another session's durable goal from blocking that caller or consuming its nudge budget (#5465).
 - Completed coordinator runtime markers with the legacy `ready_for_input: true` shape now resume and self-heal on the next lifecycle write, while other contradictory readiness and liveness markers remain hard errors (#5471).

--- a/packages/coding-agent/src/config/autorouting-tier-map.ts
+++ b/packages/coding-agent/src/config/autorouting-tier-map.ts
@@ -373,6 +373,9 @@ export const TIER_MAP_SKIP_LIST = {
 	"opencode-go/muse-spark-1.2-contributor": {
 		rationale: "post-rebase catalog addition from dev; not yet curated",
 	},
+	"opencode-go/muse-spark-1.3-contributor": {
+		rationale: "catalog addition from PR #5485; not yet curated",
+	},
 	"opencode-go/qwen3.8-flash": { rationale: "post-rebase catalog addition from dev; not yet curated" },
 	"opencode-go/qwen3.8-max": { rationale: "post-rebase catalog addition from dev; not yet curated" },
 	"opencode-zen/grok-4.6": { rationale: "post-rebase catalog addition from dev; not yet curated" },


### PR DESCRIPTION
## What

Declare `opencode-go/muse-spark-1.3-contributor` in the autorouting `TIER_MAP_SKIP_LIST`, mirroring its `opencode-go/muse-spark-1.2-contributor` sibling. One catalog key plus one CHANGELOG bullet; no product behavior changes.

## Why

PR #5485 merged the new OpenCode Go catalog row without the companion autorouting tier-map entry. The gate that guards this registry now rejects the new unlabeled in-scope key, so `dev` is red:

```
$ bun --cwd=packages/coding-agent run check:autorouting-map
Autorouting tier-map gate failed.
Offending provider/model-id keys:
- opencode-go/muse-spark-1.3-contributor
```

`packages/coding-agent/test/autorouting-tier-map-gate.test.ts` fails 2 of 8 for the same reason. `check:autorouting-map` is part of root `check:ts` and `ci:check:full`, so the merge left the aggregate TS and full-CI gates failing.

The sibling `muse-spark-1.2-contributor` is registered the same way in this file, so this follow-up follows the existing convention rather than inventing routing tier/rank data.

## Testing

```sh
bun --cwd=packages/coding-agent run check:autorouting-map   # gate passed: 4315 in-scope keys; 3929 baseline skips
bun test packages/coding-agent/test/autorouting-tier-map-gate.test.ts   # 8 pass, 0 fail
bun --cwd=packages/coding-agent run check   # biome + tsc --noEmit clean
```

## Risk classification

- [x] `low-risk` — one registry entry plus a changelog line; no behavior change outside the tier-map gate that currently fails.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:ed6d8c939f8048c01b88a3fbf49186a8060dd904a0d788c7705e7b8e2bc0307b reviewer:human reviewer-id:probepark evidence:ci-gate-waiting-only;changelog-present;skip-list-entry-mirrors-1.2-sibling;4-line-fix
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes (not run in full; the package-scoped check and the affected gate both pass, see Testing)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken

