### PR TITLE
fix(dev): make fresh worktrees self-describing and worktree-safe

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,11 +42,22 @@ bun run stats               # gjc stats from source
 One-time / environment setup:
 
 ```sh
-bun run install:dev         # bun install + native build + workspace links + dev:link + setup defaults
+bun run install:dev         # PRIMARY CHECKOUT ONLY: bun install + native build + workspace links + dev:link + setup defaults
+bun run setup:worktree      # git worktree only: bun install + native build, no global-state changes
 bun run dev:link            # symlink `gjc` on PATH to the source CLI (scripts/dev-link.ts)
 bun run dev:doctor          # verify PATH resolution of `gjc` points at this workspace
+bun run dev:doctor -- --worktree   # verify this checkout can resolve workspace deps and load the native addon
 bun run install:defaults    # (re)install bundled default definitions
 ```
+
+A second checkout created with `git worktree add` starts with no `node_modules/` and no
+built native addon, so every `bun test` fails with a bare module-resolution error until
+dependencies are installed. Run `bun run setup:worktree` there (equivalent to
+`bun install && bun run build:native`). Do **not** run `bun run install:dev` in a
+worktree: it repoints the global `gjc` on `PATH`, rewrites `core.hooksPath`, and
+overwrites user-level defaults for your primary checkout. `bun run dev:doctor -- --worktree`
+reports whether the current checkout can resolve workspace packages and load the native
+addon, and names the fix when it cannot.
 
 Removing build output (never touches sources, `node_modules/`, `.gjc/` state, or `artifacts/` test working space):
 

--- a/docs/natives-addon-loader-runtime.md
+++ b/docs/natives-addon-loader-runtime.md
@@ -188,4 +188,5 @@ Normal package/runtime diagnostics include:
 
 - reinstall hint (`bun install @gajae-code/natives`),
 - local rebuild command (`bun --cwd=packages/natives run build`),
+- worktree-safe setup hint when the loader runs from a workspace checkout (`bun run setup:worktree`),
 - optional x64 variant build hint (`TARGET_VARIANT=baseline|modern bun --cwd=packages/natives run build`).

--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
   },
   "overrides": {},
   "scripts": {
-    "install:dev": "bun install && bun run build:native && bun --cwd=packages/coding-agent link && bun --cwd=packages/ai link && bun run dev:link && bun run dev:hooks && bun packages/coding-agent/src/cli.ts setup defaults",
+		"install:dev": "bun install && bun run build:native && bun --cwd=packages/coding-agent link && bun --cwd=packages/ai link && bun run dev:link && bun run dev:hooks && bun packages/coding-agent/src/cli.ts setup defaults",
+		"setup:worktree": "bun install && bun run build:native",
     "dev:hooks": "git config core.hooksPath .githooks",
     "install:dev:bin": "bun install && bun run --cwd=packages/coding-agent build && bun run dev:link:bin && packages/coding-agent/dist/gjc setup defaults",
     "install:defaults": "bun packages/coding-agent/src/cli.ts setup defaults",

--- a/packages/natives/native/loader-state.d.ts
+++ b/packages/natives/native/loader-state.d.ts
@@ -107,6 +107,7 @@ export function validateLoadedBindings(
 
 export interface LoaderContext {
 	isCompiledBinary: boolean;
+	isWorkspaceLoad?: boolean;
 	platformTag: string;
 	packageVersion?: string;
 	addonLabel?: string;

--- a/packages/natives/native/loader-state.js
+++ b/packages/natives/native/loader-state.js
@@ -777,6 +777,9 @@ function buildHelpMessage(ctx) {
 	return (
 		"If installed via npm/bun, try reinstalling: bun install @gajae-code/natives\n" +
 		"If developing locally, build with: bun --cwd=packages/natives run build\n" +
+		(ctx.isWorkspaceLoad
+			? "In a fresh `git worktree add` checkout, run the worktree-safe setup: bun run setup:worktree\n"
+			: "") +
 		"Optional x64 variants: TARGET_VARIANT=baseline|modern bun --cwd=packages/natives run build"
 	);
 }

--- a/packages/natives/test/loader-help-worktree.test.ts
+++ b/packages/natives/test/loader-help-worktree.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Regression for https://github.com/Yeachan-Heo/gajae-code/issues/5484.
+ *
+ * A fresh `git worktree add` checkout has no built native addon, and the
+ * loader's non-compiled failure message must name the worktree-safe setup
+ * (`bun run setup:worktree`) rather than only the package-local build. Compiled
+ * binaries are unaffected: their diagnostics stay download/extract oriented.
+ *
+ * The context is injected so the assertion does not depend on whether a real
+ * addon happens to be loadable on the host.
+ */
+import { describe, expect, it } from "bun:test";
+import { loadNative } from "../native/loader-state.js";
+
+function loadFailureMessage(options: Parameters<typeof loadNative>[0]): string {
+	try {
+		loadNative(options);
+	} catch (error) {
+		return error instanceof Error ? error.message : String(error);
+	}
+	throw new Error("expected loadNative to throw");
+}
+
+describe("issue 5484: native loader failure guidance", () => {
+	it("names the worktree-safe setup command when a workspace checkout has no addon", () => {
+		const message = loadFailureMessage({
+			context: {
+				isCompiledBinary: false,
+				isWorkspaceLoad: true,
+				platformTag: "linux-x64",
+				addonLabel: "linux-x64",
+				addonFilenames: ["pi_natives.linux-x64.node"],
+				versionedDir: "/cache/gjc/9.9.9",
+				candidates: ["/repo/packages/natives/native/pi_natives.linux-x64.node"],
+			},
+			extractEmbeddedAddons: () => [],
+			stageNodeModulesAddon: () => [],
+			requireCandidate: () => {
+				throw new Error("simulated missing native addon");
+			},
+		});
+
+		expect(message).toContain("Failed to load pi_natives native addon for linux-x64");
+		expect(message).toContain("bun run setup:worktree");
+	});
+
+	it("keeps the worktree hint out of compiled-binary diagnostics", () => {
+		const message = loadFailureMessage({
+			context: {
+				isCompiledBinary: true,
+				platformTag: "linux-x64",
+				addonLabel: "linux-x64",
+				addonFilenames: ["pi_natives.linux-x64.node"],
+				versionedDir: "/cache/gjc/9.9.9",
+				candidates: [],
+			},
+			extractEmbeddedAddons: () => [],
+			stageNodeModulesAddon: () => [],
+			requireCandidate: () => {
+				throw new Error("simulated missing native addon");
+			},
+		});
+
+		expect(message).toContain("The compiled binary should extract one of");
+		expect(message).not.toContain("bun run setup:worktree");
+	});
+});

--- a/scripts/dev-link.test.ts
+++ b/scripts/dev-link.test.ts
@@ -11,6 +11,7 @@ import {
 	pathDirs,
 	smokeTest,
 } from "./dev-link";
+import { WORKTREE_SETUP_COMMAND } from "./worktree-deps";
 
 const tempRoots: string[] = [];
 const shimFlags = (5478 << 3) | 0b101;
@@ -265,6 +266,33 @@ describe.skipIf(process.platform === "win32")("dev:link Windows Bun workspace sh
 });
 
 describe("dev:link", () => {
+	test("fails --worktree in a checkout with no installed dependencies and names the fix", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-dev-link-worktree-"));
+		tempRoots.push(root);
+		const scriptsDir = path.join(root, "scripts");
+		await fs.mkdir(scriptsDir, { recursive: true });
+		await Bun.write(path.join(scriptsDir, "dev-link.ts"), Bun.file(path.join(import.meta.dir, "dev-link.ts")));
+		await Bun.write(path.join(scriptsDir, "worktree-deps.ts"), Bun.file(path.join(import.meta.dir, "worktree-deps.ts")));
+		await fs.mkdir(path.join(root, "packages", "utils"), { recursive: true });
+		await Bun.write(
+			path.join(root, "packages", "utils", "package.json"),
+			JSON.stringify({ name: "@gajae-code/utils", exports: { ".": "./src/index.ts" } }),
+		);
+
+		const result = Bun.spawnSync([process.execPath, path.join(scriptsDir, "dev-link.ts"), "--worktree"], {
+			cwd: root,
+			stderr: "pipe",
+			stdout: "pipe",
+		});
+
+		expect(result.exitCode).not.toBe(0);
+		const combined = `${result.stdout.toString()}${result.stderr.toString()}`;
+		expect(combined).toContain("node_modules:       ABSENT");
+		expect(combined).toContain("✗ This checkout cannot run the test suite.");
+		expect(combined).toContain(WORKTREE_SETUP_COMMAND);
+		expect(combined).toContain("install:dev");
+	});
+
 	test.skipIf(process.platform === "win32")("fails when --binary is shadowed by this checkout's source", async () => {
 		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-dev-link-mode-shadow-"));
 		tempRoots.push(root);
@@ -277,6 +305,10 @@ describe("dev:link", () => {
 
 		await fs.mkdir(path.dirname(fixtureScript), { recursive: true });
 		await Bun.write(fixtureScript, Bun.file(path.join(import.meta.dir, "dev-link.ts")));
+		await Bun.write(
+			path.join(root, "scripts", "worktree-deps.ts"),
+			Bun.file(path.join(import.meta.dir, "worktree-deps.ts")),
+		);
 		await makeExecutable(source, smokeFixture);
 		await makeExecutable(binary, smokeFixture);
 		await fs.mkdir(shadowDir, { recursive: true });

--- a/scripts/dev-link.ts
+++ b/scripts/dev-link.ts
@@ -15,6 +15,7 @@
  *   bun scripts/dev-link.ts            # link `gjc` -> src/cli.ts on PATH
  *   bun scripts/dev-link.ts --binary   # link `gjc` -> dist/gjc compiled binary
  *   bun scripts/dev-link.ts --check    # doctor: fail if `gjc` has drifted
+ *   bun scripts/dev-link.ts --worktree # doctor: node_modules / native addon readiness
  *
  * Env:
  *   GJC_DEV_LINK_DIR   override the target bin dir (default ~/.local/bin)
@@ -23,6 +24,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { formatWorktreeReport, inspectWorktree } from "./worktree-deps";
 
 const repoRoot = path.join(import.meta.dir, "..");
 const cliSource = path.join(repoRoot, "packages", "coding-agent", "src", "cli.ts");
@@ -353,6 +355,13 @@ function assertSourceExists(): void {
 	process.exit(1);
 }
 
+function worktreeCheck(): never {
+	const report = inspectWorktree(repoRoot);
+	const write = report.ok ? console.log : console.error;
+	write(formatWorktreeReport(report));
+	process.exit(report.ok ? 0 : 1);
+}
+
 function check(): never {
 	assertSourceExists();
 	assertWorkspaceLinksLocal();
@@ -443,6 +452,7 @@ function link(binary: boolean): never {
 }
 
 if (import.meta.main) {
-	if (process.argv.includes("--check")) check();
+	if (process.argv.includes("--worktree")) worktreeCheck();
+	else if (process.argv.includes("--check")) check();
 	else link(process.argv.includes("--binary"));
 }

--- a/scripts/install-dev.test.ts
+++ b/scripts/install-dev.test.ts
@@ -60,3 +60,15 @@ test("pre-push forwards the actual destination, remote branch and pushed object"
 		await fs.rm(temp, { recursive: true, force: true });
 	}
 });
+
+test("setup:worktree installs dependencies and builds natives without touching primary-checkout global state", async () => {
+	const repoRoot = path.resolve(import.meta.dir, "..");
+	const manifest = (await Bun.file(path.join(repoRoot, "package.json")).json()) as RootManifest;
+	const script = manifest.scripts["setup:worktree"] ?? "";
+
+	expect(script.split(" && ")).toEqual(["bun install", "bun run build:native"]);
+	// install:dev's global-state steps would hijack the primary checkout from a worktree.
+	for (const forbidden of ["link", "dev:hooks", "setup defaults"]) {
+		expect(script).not.toContain(forbidden);
+	}
+});

--- a/scripts/test-preload.ts
+++ b/scripts/test-preload.ts
@@ -1,8 +1,19 @@
 import { installRuntimeDeletionGuard } from "./safe-cleanup";
 import { decideAgentDirIsolation, readProjectEnvFile, stripAmbientProviderEnvironment } from "./test-agent-dir-isolation";
+import { formatWorkspaceDependencyFailure, inspectWorkspaceDependencies } from "./worktree-deps";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+
+// Fail fast in a fresh `git worktree add` checkout (issue #5484). Without
+// installed workspace dependencies every test file dies on a bare
+// `Cannot find module '@gajae-code/...'` error that names neither the cause nor
+// the fix. This runs before any test import and before the isolation guards
+// below, because there is nothing to isolate when the suite cannot even start.
+const workspaceDependencies = inspectWorkspaceDependencies({ repoRoot: path.join(import.meta.dir, "..") });
+if (workspaceDependencies.status !== "ready") {
+	throw new Error(formatWorkspaceDependencyFailure(workspaceDependencies));
+}
 
 // macOS `os.tmpdir()` resolves through the `/var -> /private/var` symlink, and the
 // native owner-only primitive plus the session-storage reparse guard intentionally

--- a/scripts/worktree-deps.test.ts
+++ b/scripts/worktree-deps.test.ts
@@ -1,0 +1,234 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	WORKTREE_SETUP_COMMAND,
+	WORKTREE_SETUP_STEPS,
+	formatWorkspaceDependencyFailure,
+	formatWorktreeReport,
+	inspectWorkspaceDependencies,
+	listWorkspacePackageNames,
+	probeNativeAddon,
+	type WorktreeReport,
+} from "./worktree-deps";
+
+const tempRoots: string[] = [];
+
+afterEach(async () => {
+	await Promise.all(tempRoots.splice(0).map(root => fs.rm(root, { force: true, recursive: true })));
+});
+
+async function tempRoot(prefix: string): Promise<string> {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+	tempRoots.push(root);
+	return root;
+}
+
+async function writeWorkspacePackage(root: string, dir: string, manifest: Record<string, unknown>): Promise<void> {
+	await fs.mkdir(path.join(root, "packages", dir), { recursive: true });
+	await Bun.write(path.join(root, "packages", dir, "package.json"), JSON.stringify(manifest));
+}
+
+describe("workspace dependency inspection", () => {
+	test("reports missing node_modules without attempting package resolution", () => {
+		let resolved = 0;
+		const snapshot = inspectWorkspaceDependencies({
+			repoRoot: "/nonexistent/worktree",
+			nodeModulesExists: () => false,
+			listWorkspacePackages: () => ["@gajae-code/utils"],
+			resolvePackage: () => {
+				resolved += 1;
+				return "unreachable";
+			},
+		});
+		expect(snapshot.status).toBe("missing-node-modules");
+		expect(snapshot.unresolvedPackages).toEqual([]);
+		expect(snapshot.nodeModulesDir).toBe(path.join("/nonexistent/worktree", "node_modules"));
+		expect(resolved).toBe(0);
+	});
+
+	test("lists the workspace packages that fail to resolve after install", () => {
+		const snapshot = inspectWorkspaceDependencies({
+			repoRoot: "/nonexistent/worktree",
+			nodeModulesExists: () => true,
+			listWorkspacePackages: () => ["@gajae-code/utils", "@gajae-code/ai", "@gajae-code/tui"],
+			resolvePackage: specifier => {
+				if (specifier !== "@gajae-code/utils") throw new Error(`Cannot find package '${specifier}'`);
+				return "/nonexistent/worktree/node_modules/@gajae-code/utils/src/index.ts";
+			},
+		});
+		expect(snapshot.status).toBe("unresolved-workspace-packages");
+		expect(snapshot.unresolvedPackages).toEqual(["@gajae-code/ai", "@gajae-code/tui"]);
+	});
+
+	test("is ready only when every probed package resolves", () => {
+		const snapshot = inspectWorkspaceDependencies({
+			repoRoot: "/nonexistent/worktree",
+			nodeModulesExists: () => true,
+			listWorkspacePackages: () => ["@gajae-code/utils"],
+			resolvePackage: specifier => `/resolved/${specifier}`,
+		});
+		expect(snapshot.status).toBe("ready");
+		expect(snapshot.workspacePackages).toEqual(["@gajae-code/utils"]);
+		expect(snapshot.unresolvedPackages).toEqual([]);
+	});
+
+	test("failure message names the worktree-safe command and warns off install:dev", () => {
+		const message = formatWorkspaceDependencyFailure(
+			inspectWorkspaceDependencies({
+				repoRoot: "/nonexistent/worktree",
+				nodeModulesExists: () => false,
+				listWorkspacePackages: () => [],
+			}),
+		);
+		expect(message).toContain(WORKTREE_SETUP_COMMAND);
+		expect(message).toContain(WORKTREE_SETUP_STEPS);
+		expect(message).toContain("node_modules/ is absent");
+		expect(message).toContain("install:dev");
+		expect(message).toContain("git worktree add");
+	});
+
+	test("failure message distinguishes unresolved packages from a missing install", () => {
+		const message = formatWorkspaceDependencyFailure(
+			inspectWorkspaceDependencies({
+				repoRoot: "/nonexistent/worktree",
+				nodeModulesExists: () => true,
+				listWorkspacePackages: () => ["@gajae-code/utils"],
+				resolvePackage: () => {
+					throw new Error("Cannot find package '@gajae-code/utils'");
+				},
+			}),
+		);
+		expect(message).toContain("@gajae-code/utils");
+		expect(message).toContain(WORKTREE_SETUP_COMMAND);
+	});
+});
+
+describe("workspace package discovery", () => {
+	test("includes workspace packages with a root entry point and skips manifest-only artifacts", async () => {
+		const root = await tempRoot("gjc-worktree-packages-");
+		await writeWorkspacePackage(root, "utils", {
+			name: "@gajae-code/utils",
+			exports: { ".": "./src/index.ts" },
+		});
+		await writeWorkspacePackage(root, "natives", { name: "@gajae-code/natives", main: "./native/index.js" });
+		await writeWorkspacePackage(root, "bench", { name: "@gajae-code/bench", module: "./src/index.ts" });
+		// Prebuilt platform packages intentionally export only ./package.json.
+		await writeWorkspacePackage(root, "natives-linux-x64", {
+			name: "@gajae-code/natives-linux-x64",
+			exports: { "./package.json": "./package.json" },
+		});
+		await writeWorkspacePackage(root, "foreign", { name: "some-other-package", exports: { ".": "./index.js" } });
+		await writeWorkspacePackage(root, "manifestless", { name: "@gajae-code/manifestless" });
+
+		expect(listWorkspacePackageNames(root)).toEqual([
+			"@gajae-code/bench",
+			"@gajae-code/natives",
+			"@gajae-code/utils",
+		]);
+	});
+
+	test("this checkout's probe set covers the runtime packages and excludes prebuilt platform artifacts", () => {
+		const repoRoot = path.join(import.meta.dir, "..");
+		const names = listWorkspacePackageNames(repoRoot);
+		for (const expected of ["@gajae-code/agent-core", "@gajae-code/ai", "@gajae-code/coding-agent", "@gajae-code/natives", "@gajae-code/utils"]) {
+			expect(names).toContain(expected);
+		}
+		expect(names.some(name => name.includes("natives-linux") || name.includes("natives-darwin") || name.includes("natives-win32"))).toBe(false);
+	});
+});
+
+describe("native addon probe", () => {
+	test("reports a missing entry point instead of spawning", async () => {
+		const root = await tempRoot("gjc-worktree-native-");
+		const result = probeNativeAddon(root);
+		expect(result.ok).toBe(false);
+		expect(result.entryPath).toBe(path.join(root, "packages", "natives", "native", "index.js"));
+		expect(result.output).toContain("is missing from this checkout");
+	});
+
+	test("reports success when the natives entry point loads", async () => {
+		const root = await tempRoot("gjc-worktree-native-ok-");
+		await fs.mkdir(path.join(root, "packages", "natives", "native"), { recursive: true });
+		await Bun.write(path.join(root, "packages", "natives", "native", "index.js"), 'console.log("loader-ok");\n');
+		const result = probeNativeAddon(root);
+		expect(result.ok).toBe(true);
+		expect(result.output).toContain("loader-ok");
+	});
+});
+
+describe("worktree readiness report", () => {
+	function readyReport(): WorktreeReport {
+		return {
+			snapshot: {
+				repoRoot: "/nonexistent/worktree",
+				nodeModulesDir: "/nonexistent/worktree/node_modules",
+				nodeModulesPresent: true,
+				workspacePackages: ["@gajae-code/utils"],
+				unresolvedPackages: [],
+				status: "ready",
+			},
+			native: { ok: true, entryPath: "/nonexistent/worktree/packages/natives/native/index.js", output: "" },
+			ok: true,
+		};
+	}
+
+	test("celebrates a ready worktree", () => {
+		const report = formatWorktreeReport(readyReport());
+		expect(report).toContain("node_modules:       present");
+		expect(report).toContain("workspace packages: 1/1 resolve");
+		expect(report).toContain("native addon:       loads");
+		expect(report).toContain("✓ This checkout can resolve workspace dependencies");
+		expect(report).not.toContain(WORKTREE_SETUP_COMMAND);
+	});
+
+	test("names the fix and indents the loader diagnostic when unusable", () => {
+		const report = formatWorktreeReport({
+			...readyReport(),
+			native: {
+				ok: false,
+				entryPath: "/nonexistent/worktree/packages/natives/native/index.js",
+				output: "Failed to load pi_natives native addon for linux-x64.",
+			},
+			ok: false,
+		});
+		expect(report).toContain("native addon:       UNAVAILABLE");
+		expect(report).toContain("      Failed to load pi_natives native addon for linux-x64.");
+		expect(report).toContain("✗ This checkout cannot run the test suite.");
+		expect(report).toContain(WORKTREE_SETUP_COMMAND);
+		expect(report).toContain("install:dev");
+	});
+});
+
+describe("test preload worktree guard", () => {
+	test("fails a dependency-less checkout with the fix instead of a bare module-resolution error", async () => {
+		const root = await tempRoot("gjc-worktree-preload-");
+		const scriptsDir = path.join(root, "scripts");
+		await fs.mkdir(scriptsDir, { recursive: true });
+		for (const file of ["test-preload.ts", "safe-cleanup.ts", "test-agent-dir-isolation.ts", "worktree-deps.ts"]) {
+			await Bun.write(path.join(scriptsDir, file), Bun.file(path.join(import.meta.dir, file)));
+		}
+		await Bun.write(path.join(root, "bunfig.toml"), '[test]\npreload = ["./scripts/test-preload.ts"]\n');
+		await Bun.write(
+			path.join(root, "trivial.test.ts"),
+			'import { expect, test } from "bun:test";\nimport "@gajae-code/utils";\ntest("never runs", () => expect(1).toBe(1));\n',
+		);
+
+		const result = Bun.spawnSync([process.execPath, "test", "trivial.test.ts"], {
+			cwd: root,
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const output = `${result.stdout.toString()}${result.stderr.toString()}`;
+
+		expect(result.exitCode).not.toBe(0);
+		expect(output).toContain("Workspace dependencies are not installed in this checkout");
+		expect(output).toContain(WORKTREE_SETUP_COMMAND);
+		expect(output).toContain(WORKTREE_SETUP_STEPS);
+		expect(output).toContain("node_modules/ is absent");
+		// The whole point: the named preload fix replaces the bare import failure the
+		// suite would otherwise report for `@gajae-code/utils`.
+		expect(output).not.toContain("error: Cannot find module");
+	});
+});

--- a/scripts/worktree-deps.ts
+++ b/scripts/worktree-deps.ts
@@ -1,0 +1,218 @@
+/**
+ * Worktree dependency diagnostics (issue #5484).
+ *
+ * A checkout created with `git worktree add` starts with no `node_modules/` and
+ * no built native addon, so `bun test` dies on a bare
+ * `Cannot find module '@gajae-code/...'` error that names neither the cause nor
+ * the fix. This module is the single source of truth for that diagnosis:
+ * `scripts/test-preload.ts` fails fast with it, and `dev:doctor --worktree`
+ * reports it.
+ *
+ * The decision core takes injected probes so the table stays unit-testable; the
+ * defaults read the real filesystem and Bun's resolver.
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+/** Worktree-safe setup command documented in AGENTS.md / README. */
+export const WORKTREE_SETUP_COMMAND = "bun run setup:worktree";
+/** The exact steps `setup:worktree` expands to (kept in sync by scripts/install-dev.test.ts). */
+export const WORKTREE_SETUP_STEPS = "bun install && bun run build:native";
+/** Entry point whose import exercises the real native-addon loader. */
+export const NATIVE_ENTRY_PATH = path.join("packages", "natives", "native", "index.js");
+
+export type WorkspaceDependencyStatus = "ready" | "missing-node-modules" | "unresolved-workspace-packages";
+
+export interface WorkspaceDependencySnapshot {
+	repoRoot: string;
+	nodeModulesDir: string;
+	nodeModulesPresent: boolean;
+	/** Workspace packages that declare a root entry point and must resolve for tests. */
+	workspacePackages: string[];
+	unresolvedPackages: string[];
+	status: WorkspaceDependencyStatus;
+}
+
+export interface WorkspaceDependencyProbe {
+	repoRoot: string;
+	nodeModulesExists?: (nodeModulesDir: string) => boolean;
+	resolvePackage?: (specifier: string, fromDir: string) => string;
+	listWorkspacePackages?: (repoRoot: string) => string[];
+}
+
+export interface NativeAddonProbeResult {
+	ok: boolean;
+	entryPath: string;
+	output: string;
+}
+
+export interface WorktreeReport {
+	snapshot: WorkspaceDependencySnapshot;
+	native: NativeAddonProbeResult;
+	ok: boolean;
+}
+
+/** Shared remediation block every worktree diagnostic ends with. */
+const WORKTREE_SETUP_HELP = [
+	"  Fix (worktree-safe):",
+	`    ${WORKTREE_SETUP_COMMAND}    # ${WORKTREE_SETUP_STEPS}`,
+	"",
+	"  Do NOT run `bun run install:dev` in a worktree: it repoints the global `gjc`",
+	"  symlink, rewrites git hooks, and overwrites user-level defaults for your",
+	"  primary checkout.",
+];
+
+function defaultNodeModulesExists(nodeModulesDir: string): boolean {
+	try {
+		return fs.statSync(nodeModulesDir).isDirectory();
+	} catch {
+		return false;
+	}
+}
+
+function defaultResolvePackage(specifier: string, fromDir: string): string {
+	return Bun.resolveSync(specifier, fromDir);
+}
+
+/**
+ * A workspace package is probe-able only when its manifest exposes a root entry
+ * point. The platform prebuilt packages (`@gajae-code/natives-linux-x64`, …)
+ * intentionally export only `./package.json`, so they are mobile artifacts, not
+ * importable test dependencies, and must not be reported as unresolved.
+ */
+function hasRootEntryPoint(manifest: Record<string, unknown>): boolean {
+	if (typeof manifest.main === "string" || typeof manifest.module === "string") return true;
+	const exportsField = manifest.exports;
+	if (typeof exportsField === "string") return true;
+	return typeof exportsField === "object" && exportsField !== null && "." in exportsField;
+}
+
+/** Workspace package names tests must be able to `import` in this checkout. */
+export function listWorkspacePackageNames(repoRoot: string): string[] {
+	const packagesDir = path.join(repoRoot, "packages");
+	let entries: string[];
+	try {
+		entries = fs.readdirSync(packagesDir);
+	} catch {
+		return [];
+	}
+	const names: string[] = [];
+	for (const entry of entries.sort()) {
+		let manifest: Record<string, unknown>;
+		try {
+			const parsed: unknown = JSON.parse(fs.readFileSync(path.join(packagesDir, entry, "package.json"), "utf8"));
+			if (typeof parsed !== "object" || parsed === null) continue;
+			manifest = parsed as Record<string, unknown>;
+		} catch {
+			continue;
+		}
+		const name = manifest.name;
+		if (typeof name !== "string" || !name.startsWith("@gajae-code/")) continue;
+		if (!hasRootEntryPoint(manifest)) continue;
+		names.push(name);
+	}
+	return names;
+}
+
+export function inspectWorkspaceDependencies(probe: WorkspaceDependencyProbe): WorkspaceDependencySnapshot {
+	const { repoRoot } = probe;
+	const nodeModulesDir = path.join(repoRoot, "node_modules");
+	const nodeModulesPresent = (probe.nodeModulesExists ?? defaultNodeModulesExists)(nodeModulesDir);
+	const resolvePackage = probe.resolvePackage ?? defaultResolvePackage;
+	const workspacePackages = nodeModulesPresent ? (probe.listWorkspacePackages ?? listWorkspacePackageNames)(repoRoot) : [];
+	const unresolvedPackages: string[] = [];
+	if (nodeModulesPresent) {
+		for (const specifier of workspacePackages) {
+			try {
+				resolvePackage(specifier, repoRoot);
+			} catch {
+				unresolvedPackages.push(specifier);
+			}
+		}
+	}
+	const status: WorkspaceDependencyStatus = !nodeModulesPresent
+		? "missing-node-modules"
+		: unresolvedPackages.length > 0
+			? "unresolved-workspace-packages"
+			: "ready";
+	return { repoRoot, nodeModulesDir, nodeModulesPresent, workspacePackages, unresolvedPackages, status };
+}
+
+/** The fail-fast message the test preload throws when the checkout cannot run tests. */
+export function formatWorkspaceDependencyFailure(snapshot: WorkspaceDependencySnapshot): string {
+	const reason =
+		snapshot.status === "missing-node-modules"
+			? `node_modules/ is absent at ${snapshot.nodeModulesDir}.`
+			: `node_modules/ exists but these workspace packages do not resolve: ${snapshot.unresolvedPackages.join(", ")}.`;
+	return [
+		"",
+		"✗ Workspace dependencies are not installed in this checkout.",
+		"",
+		`  ${reason}`,
+		"",
+		"  Tests cannot resolve @gajae-code/* workspace packages, so every run fails with a",
+		'  bare "Cannot find module" error before the suite starts. This is expected in a',
+		"  fresh `git worktree add` checkout.",
+		"",
+		...WORKTREE_SETUP_HELP,
+		"",
+	].join("\n");
+}
+
+/**
+ * Import the natives entry point in a child process so the real loader decides
+ * whether any candidate `.node` (workspace build, optional package, versioned
+ * cache, or installed location) actually loads.
+ */
+export function probeNativeAddon(repoRoot: string): NativeAddonProbeResult {
+	const entryPath = path.join(repoRoot, NATIVE_ENTRY_PATH);
+	if (!fs.existsSync(entryPath)) {
+		return { ok: false, entryPath, output: `${NATIVE_ENTRY_PATH} is missing from this checkout.` };
+	}
+	const result = Bun.spawnSync([process.execPath, entryPath], {
+		cwd: repoRoot,
+		stdout: "pipe",
+		stderr: "pipe",
+		timeout: 60_000,
+	});
+	const output = `${result.stdout.toString()}${result.stderr.toString()}`.trim();
+	return { ok: result.exitCode === 0, entryPath, output };
+}
+
+export function inspectWorktree(repoRoot: string): WorktreeReport {
+	const snapshot = inspectWorkspaceDependencies({ repoRoot });
+	const native = probeNativeAddon(repoRoot);
+	return { snapshot, native, ok: snapshot.status === "ready" && native.ok };
+}
+
+function indentBlock(text: string, maxLines: number): string {
+	const lines = text.split("\n").slice(0, maxLines);
+	return lines.map(line => `      ${line}`).join("\n");
+}
+
+/** Human-readable `dev:doctor --worktree` report. */
+export function formatWorktreeReport(report: WorktreeReport): string {
+	const { snapshot, native } = report;
+	const lines = [
+		`Worktree readiness: ${snapshot.repoRoot}`,
+		`  node_modules:       ${snapshot.nodeModulesPresent ? "present" : "ABSENT"} (${snapshot.nodeModulesDir})`,
+		snapshot.status === "ready"
+			? `  workspace packages: ${snapshot.workspacePackages.length}/${snapshot.workspacePackages.length} resolve`
+			: snapshot.status === "missing-node-modules"
+				? "  workspace packages: unknown (node_modules absent)"
+				: `  workspace packages: unresolved: ${snapshot.unresolvedPackages.join(", ")}`,
+		`  native addon:       ${native.ok ? "loads" : "UNAVAILABLE"} (${native.entryPath})`,
+	];
+	if (!native.ok && native.output) lines.push(indentBlock(native.output, 20));
+	if (report.ok) {
+		lines.push("", "✓ This checkout can resolve workspace dependencies and load the native addon.");
+		return lines.join("\n");
+	}
+	lines.push(
+		"",
+		"✗ This checkout cannot run the test suite.",
+		"",
+		...WORKTREE_SETUP_HELP,
+	);
+	return lines.join("\n");
+}


### PR DESCRIPTION
## What

A fresh `git worktree add` checkout has no `node_modules/` and no built native addon, so every test dies on a bare `Cannot find module '@gajae-code/utils'`, and the documented one-shot `bun run install:dev` silently hijacks the primary checkout (global `gjc` link, git hooks, user-level defaults).

- Adds `bun run setup:worktree` = `bun install && bun run build:native` (no link/hook/defaults steps).
- Documents it in `AGENTS.md` next to `install:dev`, with the primary-checkout-only warning.
- Adds `scripts/worktree-deps.ts` and makes the shared test preload fail with the named fix instead of a bare module-resolution error.
- Adds `bun run dev:doctor -- --worktree` reporting node_modules / workspace-package resolution / native-addon readiness, exiting non-zero with the fix when unusable.
- Makes the non-compiled native loader guidance name `bun run setup:worktree` (compiled-binary diagnostics unchanged).

## Why

Three separate parties lost time or shipped review evidence that could not run its tests in a worktree. The bare error names neither the cause nor the fix. Fixes #5484.

## Testing

- `bun test scripts/worktree-deps.test.ts scripts/dev-link.test.ts scripts/install-dev.test.ts packages/natives/test/loader-help-worktree.test.ts` — 29 pass / 0 fail
- Reproduction: with `node_modules` renamed, `bun test packages/coding-agent/test/agent-roster-label.test.ts` exits 1 with the named worktree fix (previously `Cannot find module '@gajae-code/utils'` with no hint).
- `bun run setup:worktree` ran end to end (bun install + native build, ~52s).
- `bun run dev:doctor -- --worktree` → 9/9 workspace packages resolve, native addon loads (exit 0); with `node_modules` absent it exits 1 naming the fix.
- `bun run check:tools` (biome + tsc tools + unsafe-rmrf) clean.
- `bun --cwd=packages/natives run check:types` clean.
- `bun --cwd=packages/natives test` — 170 pass / 59 skip / 0 fail.
- Full `bun check` was not run; the touched surfaces were checked as listed above.

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:d102b73d6bdd36441fc250d2d00d0a23ad337db84171ca1e832d424ff1b2d504 reviewer:human reviewer-id:Yeachan-Heo evidence:owner low-risk solo record on the rebased exact head; focused suites 30 pass; bun run check:tools; natives check:types
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes (touched-surface checks passed: `check:tools`, natives `check:types`, focused suites)
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing) — dev tooling only, no user-facing change
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken
