### PR TITLE
fix(dev): deliver the worktree loader hint and fail dangling links

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -73,6 +73,8 @@ curl -fsSL https://raw.githubusercontent.com/Yeachan-Heo/gajae-code/main/scripts
 
 From a checkout: `bun run install:dev`, then `bun run dev` / `bun run dev:link`. The setup command installs dependencies, rebuilds the native addon, links the source CLI, and installs bundled defaults. See the repository `AGENTS.md` for the development workflow.
 
+From a `git worktree add` checkout, run `bun run setup:worktree` instead: it installs dependencies and builds the native addon without touching the global `gjc` link, git hooks, or user defaults of your primary checkout. `bun run dev:doctor -- --worktree` reports whether the checkout can resolve workspace packages and load the native addon. `install:dev` is for the primary checkout only.
+
 ## Windows notes
 
 GJC's shell tool requires a bash-compatible shell on Windows. After a binary install, the PowerShell installer records Git Bash if it finds it. Options:

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   "overrides": {},
   "scripts": {
 		"install:dev": "bun install && bun run build:native && bun --cwd=packages/coding-agent link && bun --cwd=packages/ai link && bun run dev:link && bun run dev:hooks && bun packages/coding-agent/src/cli.ts setup defaults",
-		"setup:worktree": "bun install && bun run build:native",
+    "setup:worktree": "bun install && bun run build:native",
     "dev:hooks": "git config core.hooksPath .githooks",
     "install:dev:bin": "bun install && bun run --cwd=packages/coding-agent build && bun run dev:link:bin && packages/coding-agent/dist/gjc setup defaults",
     "install:defaults": "bun packages/coding-agent/src/cli.ts setup defaults",

--- a/packages/natives/native/loader-state.js
+++ b/packages/natives/native/loader-state.js
@@ -850,6 +850,7 @@ function initLoaderContext(require_) {
 		nativeDir,
 		versionedDir,
 		isCompiledBinary,
+		isWorkspaceLoad,
 		stageFromNodeModules,
 		selectedVariant,
 		addonFilenames,

--- a/packages/natives/test/loader-help-worktree.test.ts
+++ b/packages/natives/test/loader-help-worktree.test.ts
@@ -6,8 +6,10 @@
  * (`bun run setup:worktree`) rather than only the package-local build. Compiled
  * binaries are unaffected: their diagnostics stay download/extract oriented.
  *
- * The context is injected so the assertion does not depend on whether a real
- * addon happens to be loadable on the host.
+ * The workspace case deliberately runs the REAL loader context (no injected
+ * `context`) so a regression that drops `isWorkspaceLoad` between
+ * `initLoaderContext` and `buildHelpMessage` fails here instead of hiding
+ * behind an injected flag.
  */
 import { describe, expect, it } from "bun:test";
 import { loadNative } from "../native/loader-state.js";
@@ -22,17 +24,8 @@ function loadFailureMessage(options: Parameters<typeof loadNative>[0]): string {
 }
 
 describe("issue 5484: native loader failure guidance", () => {
-	it("names the worktree-safe setup command when a workspace checkout has no addon", () => {
+	it("names the worktree-safe setup command through the real workspace loader context", () => {
 		const message = loadFailureMessage({
-			context: {
-				isCompiledBinary: false,
-				isWorkspaceLoad: true,
-				platformTag: "linux-x64",
-				addonLabel: "linux-x64",
-				addonFilenames: ["pi_natives.linux-x64.node"],
-				versionedDir: "/cache/gjc/9.9.9",
-				candidates: ["/repo/packages/natives/native/pi_natives.linux-x64.node"],
-			},
 			extractEmbeddedAddons: () => [],
 			stageNodeModulesAddon: () => [],
 			requireCandidate: () => {
@@ -40,7 +33,7 @@ describe("issue 5484: native loader failure guidance", () => {
 			},
 		});
 
-		expect(message).toContain("Failed to load pi_natives native addon for linux-x64");
+		expect(message).toContain("Failed to load pi_natives native addon for");
 		expect(message).toContain("bun run setup:worktree");
 	});
 

--- a/scripts/dev-link.ts
+++ b/scripts/dev-link.ts
@@ -356,6 +356,9 @@ function assertSourceExists(): void {
 }
 
 function worktreeCheck(): never {
+	// A checkout whose workspace links point into another worktree resolves, but
+	// against the wrong sources; report it like `--check` instead of a false green.
+	assertWorkspaceLinksLocal();
 	const report = inspectWorktree(repoRoot);
 	const write = report.ok ? console.log : console.error;
 	write(formatWorktreeReport(report));

--- a/scripts/install-dev.test.ts
+++ b/scripts/install-dev.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "bun:test";
 import * as path from "node:path";
 import * as fs from "node:fs/promises";
+import { WORKTREE_SETUP_STEPS } from "./worktree-deps";
 
 interface RootManifest {
 	scripts: Record<string, string>;
@@ -67,6 +68,8 @@ test("setup:worktree installs dependencies and builds natives without touching p
 	const script = manifest.scripts["setup:worktree"] ?? "";
 
 	expect(script.split(" && ")).toEqual(["bun install", "bun run build:native"]);
+	// The canonical step string lives in scripts/worktree-deps.ts; pin the manifest to it.
+	expect(script).toBe(WORKTREE_SETUP_STEPS);
 	// install:dev's global-state steps would hijack the primary checkout from a worktree.
 	for (const forbidden of ["link", "dev:hooks", "setup defaults"]) {
 		expect(script).not.toContain(forbidden);

--- a/scripts/worktree-deps.test.ts
+++ b/scripts/worktree-deps.test.ts
@@ -57,6 +57,7 @@ describe("workspace dependency inspection", () => {
 				if (specifier !== "@gajae-code/utils") throw new Error(`Cannot find package '${specifier}'`);
 				return "/nonexistent/worktree/node_modules/@gajae-code/utils/src/index.ts";
 			},
+			packageTargetExists: () => true,
 		});
 		expect(snapshot.status).toBe("unresolved-workspace-packages");
 		expect(snapshot.unresolvedPackages).toEqual(["@gajae-code/ai", "@gajae-code/tui"]);
@@ -68,10 +69,25 @@ describe("workspace dependency inspection", () => {
 			nodeModulesExists: () => true,
 			listWorkspacePackages: () => ["@gajae-code/utils"],
 			resolvePackage: specifier => `/resolved/${specifier}`,
+			packageTargetExists: () => true,
 		});
 		expect(snapshot.status).toBe("ready");
 		expect(snapshot.workspacePackages).toEqual(["@gajae-code/utils"]);
 		expect(snapshot.unresolvedPackages).toEqual([]);
+	});
+
+	test("treats a resolved-but-missing target as unresolved (dangling workspace symlink)", () => {
+		const snapshot = inspectWorkspaceDependencies({
+			repoRoot: "/nonexistent/worktree",
+			nodeModulesExists: () => true,
+			listWorkspacePackages: () => ["@gajae-code/utils", "@gajae-code/ai"],
+			// Bun's resolver returns a dangling symlink path without throwing, so the
+			// resolver alone cannot distinguish it from a healthy install.
+			resolvePackage: specifier => `/nonexistent/worktree/node_modules/${specifier}/src/index.ts`,
+			packageTargetExists: resolvedPath => resolvedPath.includes("@gajae-code/ai"),
+		});
+		expect(snapshot.status).toBe("unresolved-workspace-packages");
+		expect(snapshot.unresolvedPackages).toEqual(["@gajae-code/utils"]);
 	});
 
 	test("failure message names the worktree-safe command and warns off install:dev", () => {

--- a/scripts/worktree-deps.ts
+++ b/scripts/worktree-deps.ts
@@ -16,7 +16,7 @@ import * as path from "node:path";
 
 /** Worktree-safe setup command documented in AGENTS.md / README. */
 export const WORKTREE_SETUP_COMMAND = "bun run setup:worktree";
-/** The exact steps `setup:worktree` expands to (kept in sync by scripts/install-dev.test.ts). */
+/** The exact steps `setup:worktree` expands to; `scripts/install-dev.test.ts` pins package.json to this value. */
 export const WORKTREE_SETUP_STEPS = "bun install && bun run build:native";
 /** Entry point whose import exercises the real native-addon loader. */
 export const NATIVE_ENTRY_PATH = path.join("packages", "natives", "native", "index.js");
@@ -37,6 +37,8 @@ export interface WorkspaceDependencyProbe {
 	repoRoot: string;
 	nodeModulesExists?: (nodeModulesDir: string) => boolean;
 	resolvePackage?: (specifier: string, fromDir: string) => string;
+	/** Whether a resolved package entry point is a real, importable path. */
+	packageTargetExists?: (resolvedPath: string) => boolean;
 	listWorkspacePackages?: (repoRoot: string) => string[];
 }
 
@@ -72,6 +74,15 @@ function defaultNodeModulesExists(nodeModulesDir: string): boolean {
 
 function defaultResolvePackage(specifier: string, fromDir: string): string {
 	return Bun.resolveSync(specifier, fromDir);
+}
+
+/**
+ * Bun's resolver returns a path for a package root that is a dangling symlink
+ * without throwing, even though a real `import` then fails with ENOENT. A
+ * partial/stale install must land in `unresolvedPackages`, not report ready.
+ */
+function defaultPackageTargetExists(resolvedPath: string): boolean {
+	return fs.existsSync(resolvedPath);
 }
 
 /**
@@ -119,12 +130,13 @@ export function inspectWorkspaceDependencies(probe: WorkspaceDependencyProbe): W
 	const nodeModulesDir = path.join(repoRoot, "node_modules");
 	const nodeModulesPresent = (probe.nodeModulesExists ?? defaultNodeModulesExists)(nodeModulesDir);
 	const resolvePackage = probe.resolvePackage ?? defaultResolvePackage;
+	const packageTargetExists = probe.packageTargetExists ?? defaultPackageTargetExists;
 	const workspacePackages = nodeModulesPresent ? (probe.listWorkspacePackages ?? listWorkspacePackageNames)(repoRoot) : [];
 	const unresolvedPackages: string[] = [];
 	if (nodeModulesPresent) {
 		for (const specifier of workspacePackages) {
 			try {
-				resolvePackage(specifier, repoRoot);
+				if (!packageTargetExists(resolvePackage(specifier, repoRoot))) unresolvedPackages.push(specifier);
 			} catch {
 				unresolvedPackages.push(specifier);
 			}


### PR DESCRIPTION
## What

Follow-up to #5490 (which closed #5484). The boundary red-team found two defects in the shipped worktree diagnostics:

1. **The `bun run setup:worktree` loader hint never appeared.** `initLoaderContext` computed `isWorkspaceLoad` and passed it to `resolveLoaderCandidates`, but dropped it from the context object it returns, so `buildHelpMessage` always read `undefined` and the ternary emitted an empty string. The committed test only passed because it injected an explicit `context: { isWorkspaceLoad: true }`.
2. **A dangling workspace link was reported ready.** For `node_modules/@gajae-code/<pkg>` that is a dangling symlink, Bun's resolver returns the path without throwing, so the probe, the shared preload, and `dev:doctor -- --worktree` all reported ready while a real `import` failed with a bare `ENOENT`.

Fixes: return `isWorkspaceLoad` from `initLoaderContext` and assert it through the real loader context (no injection); require a resolved package target to exist before counting it resolved; make `dev:doctor -- --worktree` reuse the existing workspace-link locality check. Also: pin the manifest step string to the shared constant, document the worktree command in `docs/install.md`, and fix the `package.json` indentation.

## Why

#5484 asked for a worktree setup script, docs, and self-describing failures. The first PR landed the script and docs, but its loader hint was a no-op in production and its probe had a false-green path for partial installs — both reproduced with real outputs, not code reading. Fixes #5484.

## Testing

- `bun test scripts/worktree-deps.test.ts scripts/dev-link.test.ts scripts/install-dev.test.ts packages/natives/test/loader-help-worktree.test.ts` — 31 pass / 0 fail.
- Reverting the one-line `isWorkspaceLoad` return makes the new real-context loader test fail (proves the test catches the defect).
- Dangling-symlink fixture: `bun scripts/dev-link.ts --worktree` now reports `unresolved: @gajae-code/utils` and exits 1, where it previously exited 0.
- Healthy checkout: `bun run dev:doctor -- --worktree` still exits 0 (9/9 resolve, native addon loads).
- `bun run check:tools` clean; `bun --cwd=packages/natives run check:types` clean; `bun --cwd=packages/natives test` 170 pass / 0 fail.
- Full `bun check` was not run; the touched surfaces were checked as listed above.

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:d12d9e59439fadbe592dcb7819ae7252a9555be53c5809b1f905578465384297 reviewer:human reviewer-id:Yeachan-Heo evidence:red-team defects D1/D2 from #5490 fixed; focused suites 31 pass; real-context loader regression; check:tools; natives check:types
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes (touched-surface checks passed: `check:tools`, natives `check:types`, focused suites)
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing) — dev tooling only, no user-facing change
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken
