### PR TITLE
fix(dev): fail worktree readiness on foreign workspace links

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
   },
   "overrides": {},
   "scripts": {
-		"install:dev": "bun install && bun run build:native && bun --cwd=packages/coding-agent link && bun --cwd=packages/ai link && bun run dev:link && bun run dev:hooks && bun packages/coding-agent/src/cli.ts setup defaults",
+    "install:dev": "bun install && bun run build:native && bun --cwd=packages/coding-agent link && bun --cwd=packages/ai link && bun run dev:link && bun run dev:hooks && bun packages/coding-agent/src/cli.ts setup defaults",
     "setup:worktree": "bun install && bun run build:native",
     "dev:hooks": "git config core.hooksPath .githooks",
     "install:dev:bin": "bun install && bun run --cwd=packages/coding-agent build && bun run dev:link:bin && packages/coding-agent/dist/gjc setup defaults",

--- a/scripts/dev-link.ts
+++ b/scripts/dev-link.ts
@@ -24,7 +24,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { formatWorktreeReport, inspectWorktree } from "./worktree-deps";
+import { findForeignWorkspaceLinks, formatWorktreeReport, inspectWorktree } from "./worktree-deps";
 
 const repoRoot = path.join(import.meta.dir, "..");
 const cliSource = path.join(repoRoot, "packages", "coding-agent", "src", "cli.ts");
@@ -319,30 +319,14 @@ function assertResolvedGjcMatchesTarget(winner: GjcHit | undefined, expectedReal
 }
 
 function assertWorkspaceLinksLocal(): void {
-	const repoRootReal = realpath(repoRoot) ?? repoRoot;
-	const scopeDir = path.join(repoRoot, "node_modules", "@gajae-code");
-	let entries: string[];
-	try {
-		entries = fs.readdirSync(scopeDir);
-	} catch {
-		return;
-	}
-	const stale: Array<{ link: string; real: string }> = [];
-	for (const entry of entries) {
-		const link = path.join(scopeDir, entry);
-		try {
-			if (!fs.lstatSync(link).isSymbolicLink()) continue;
-		} catch {
-			continue;
-		}
-		const real = realpath(link);
-		if (real && !real.startsWith(repoRootReal + path.sep)) stale.push({ link, real });
-	}
+	// Shared with the test preload's dependency probe so the doctor and an actual
+	// `bun test` run agree on what counts as a usable install.
+	const stale = findForeignWorkspaceLinks(repoRoot);
 	if (stale.length === 0) return;
 	console.error("✗ Workspace symlinks point outside this checkout (stale cross-worktree install):");
-	for (const { link, real } of stale) {
+	for (const { link, target } of stale) {
 		console.error(`    ${link}`);
-		console.error(`      -> ${real}`);
+		console.error(`      -> ${target}`);
 	}
 	console.error("  Fix: rm -rf node_modules/@gajae-code && bun install");
 	process.exit(1);

--- a/scripts/worktree-deps.test.ts
+++ b/scripts/worktree-deps.test.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import {
 	WORKTREE_SETUP_COMMAND,
 	WORKTREE_SETUP_STEPS,
+	findForeignWorkspaceLinks,
 	formatWorkspaceDependencyFailure,
 	formatWorktreeReport,
 	inspectWorkspaceDependencies,
@@ -28,6 +29,14 @@ async function tempRoot(prefix: string): Promise<string> {
 async function writeWorkspacePackage(root: string, dir: string, manifest: Record<string, unknown>): Promise<void> {
 	await fs.mkdir(path.join(root, "packages", dir), { recursive: true });
 	await Bun.write(path.join(root, "packages", dir, "package.json"), JSON.stringify(manifest));
+}
+
+/** A real, resolvable workspace package: manifest plus the entry file it exports. */
+async function writeResolvableWorkspacePackage(root: string, dir: string, manifest: Record<string, unknown>): Promise<string> {
+	await writeWorkspacePackage(root, dir, manifest);
+	const entry = path.join(root, "packages", dir, "src", "index.ts");
+	await Bun.write(entry, "export {};\n");
+	return entry;
 }
 
 describe("workspace dependency inspection", () => {
@@ -90,6 +99,25 @@ describe("workspace dependency inspection", () => {
 		expect(snapshot.unresolvedPackages).toEqual(["@gajae-code/utils"]);
 	});
 
+	test("flags workspace links that resolve into another checkout", () => {
+		const snapshot = inspectWorkspaceDependencies({
+			repoRoot: "/nonexistent/worktree",
+			nodeModulesExists: () => true,
+			listWorkspacePackages: () => ["@gajae-code/utils"],
+			resolvePackage: () => "/elsewhere/packages/utils/src/index.ts",
+			packageTargetExists: () => true,
+			findForeignWorkspaceLinks: () => [
+				{ link: "/nonexistent/worktree/node_modules/@gajae-code/utils", target: "/elsewhere/packages/utils" },
+			],
+		});
+		expect(snapshot.status).toBe("foreign-workspace-links");
+		expect(snapshot.unresolvedPackages).toEqual([]);
+		const message = formatWorkspaceDependencyFailure(snapshot);
+		expect(message).toContain("/nonexistent/worktree/node_modules/@gajae-code/utils -> /elsewhere/packages/utils");
+		expect(message).toContain("another checkout's sources");
+		expect(message).toContain(WORKTREE_SETUP_COMMAND);
+	});
+
 	test("failure message names the worktree-safe command and warns off install:dev", () => {
 		const message = formatWorkspaceDependencyFailure(
 			inspectWorkspaceDependencies({
@@ -121,8 +149,56 @@ describe("workspace dependency inspection", () => {
 	});
 });
 
-describe("workspace package discovery", () => {
-	test("includes workspace packages with a root entry point and skips manifest-only artifacts", async () => {
+describe("real-filesystem defaults", () => {
+	test("pins the default target-exists check with a dangling workspace symlink on disk", async () => {
+		const root = await tempRoot("gjc-worktree-dangling-");
+		await writeWorkspacePackage(root, "utils", { name: "@gajae-code/utils", exports: { ".": "./src/index.ts" } });
+		const scopeDir = path.join(root, "node_modules", "@gajae-code");
+		await fs.mkdir(scopeDir, { recursive: true });
+		await fs.symlink(path.join(root, "packages", "utils-missing"), path.join(scopeDir, "utils"));
+
+		const snapshot = inspectWorkspaceDependencies({ repoRoot: root });
+		expect(snapshot.status).toBe("unresolved-workspace-packages");
+		expect(snapshot.unresolvedPackages).toEqual(["@gajae-code/utils"]);
+	});
+
+	test("detects a real workspace link that resolves into another checkout", async () => {
+		const root = await tempRoot("gjc-worktree-foreign-");
+		const other = await tempRoot("gjc-worktree-other-");
+		await writeResolvableWorkspacePackage(other, "utils", {
+			name: "@gajae-code/utils",
+			exports: { ".": "./src/index.ts" },
+		});
+		await writeResolvableWorkspacePackage(root, "utils", {
+			name: "@gajae-code/utils",
+			exports: { ".": "./src/index.ts" },
+		});
+		const scopeDir = path.join(root, "node_modules", "@gajae-code");
+		await fs.mkdir(scopeDir, { recursive: true });
+		await fs.symlink(path.join(other, "packages", "utils"), path.join(scopeDir, "utils"));
+
+		const links = findForeignWorkspaceLinks(root);
+		expect(links).toHaveLength(1);
+		expect(links[0]?.target).toBe(await fs.realpath(path.join(other, "packages", "utils")));
+		expect(inspectWorkspaceDependencies({ repoRoot: root }).status).toBe("foreign-workspace-links");
+	});
+
+	test("does not flag workspace links that stay inside the checkout", async () => {
+		const root = await tempRoot("gjc-worktree-local-");
+		await writeResolvableWorkspacePackage(root, "utils", {
+			name: "@gajae-code/utils",
+			exports: { ".": "./src/index.ts" },
+		});
+		const scopeDir = path.join(root, "node_modules", "@gajae-code");
+		await fs.mkdir(scopeDir, { recursive: true });
+		await fs.symlink(path.join(root, "packages", "utils"), path.join(scopeDir, "utils"));
+
+		expect(findForeignWorkspaceLinks(root)).toEqual([]);
+		expect(inspectWorkspaceDependencies({ repoRoot: root }).status).toBe("ready");
+	});
+});
+
+describe("workspace package discovery", () => {	test("includes workspace packages with a root entry point and skips manifest-only artifacts", async () => {
 		const root = await tempRoot("gjc-worktree-packages-");
 		await writeWorkspacePackage(root, "utils", {
 			name: "@gajae-code/utils",
@@ -183,6 +259,7 @@ describe("worktree readiness report", () => {
 				nodeModulesPresent: true,
 				workspacePackages: ["@gajae-code/utils"],
 				unresolvedPackages: [],
+				foreignWorkspaceLinks: [],
 				status: "ready",
 			},
 			native: { ok: true, entryPath: "/nonexistent/worktree/packages/natives/native/index.js", output: "" },
@@ -239,7 +316,7 @@ describe("test preload worktree guard", () => {
 		const output = `${result.stdout.toString()}${result.stderr.toString()}`;
 
 		expect(result.exitCode).not.toBe(0);
-		expect(output).toContain("Workspace dependencies are not installed in this checkout");
+		expect(output).toContain("Workspace dependencies are not usable in this checkout");
 		expect(output).toContain(WORKTREE_SETUP_COMMAND);
 		expect(output).toContain(WORKTREE_SETUP_STEPS);
 		expect(output).toContain("node_modules/ is absent");

--- a/scripts/worktree-deps.ts
+++ b/scripts/worktree-deps.ts
@@ -21,7 +21,17 @@ export const WORKTREE_SETUP_STEPS = "bun install && bun run build:native";
 /** Entry point whose import exercises the real native-addon loader. */
 export const NATIVE_ENTRY_PATH = path.join("packages", "natives", "native", "index.js");
 
-export type WorkspaceDependencyStatus = "ready" | "missing-node-modules" | "unresolved-workspace-packages";
+export type WorkspaceDependencyStatus =
+	| "ready"
+	| "missing-node-modules"
+	| "unresolved-workspace-packages"
+	| "foreign-workspace-links";
+
+/** A `node_modules/@gajae-code/*` symlink whose real target is outside this checkout. */
+export interface ForeignWorkspaceLink {
+	link: string;
+	target: string;
+}
 
 export interface WorkspaceDependencySnapshot {
 	repoRoot: string;
@@ -30,6 +40,8 @@ export interface WorkspaceDependencySnapshot {
 	/** Workspace packages that declare a root entry point and must resolve for tests. */
 	workspacePackages: string[];
 	unresolvedPackages: string[];
+	/** Resolvable package links that point into another checkout (stale cross-worktree install). */
+	foreignWorkspaceLinks: ForeignWorkspaceLink[];
 	status: WorkspaceDependencyStatus;
 }
 
@@ -40,6 +52,7 @@ export interface WorkspaceDependencyProbe {
 	/** Whether a resolved package entry point is a real, importable path. */
 	packageTargetExists?: (resolvedPath: string) => boolean;
 	listWorkspacePackages?: (repoRoot: string) => string[];
+	findForeignWorkspaceLinks?: (repoRoot: string) => ForeignWorkspaceLink[];
 }
 
 export interface NativeAddonProbeResult {
@@ -83,6 +96,49 @@ function defaultResolvePackage(specifier: string, fromDir: string): string {
  */
 function defaultPackageTargetExists(resolvedPath: string): boolean {
 	return fs.existsSync(resolvedPath);
+}
+
+/**
+ * Workspace links that resolve into another checkout. They import fine, but
+ * the tests then exercise the other worktree's sources, so the checkout must
+ * not be reported ready. Broken symlinks are left to the resolution probe.
+ */
+export function findForeignWorkspaceLinks(repoRoot: string): ForeignWorkspaceLink[] {
+	const scopeDir = path.join(repoRoot, "node_modules", "@gajae-code");
+	let entries: string[];
+	try {
+		entries = fs.readdirSync(scopeDir);
+	} catch {
+		return [];
+	}
+	let repoRootReal: string;
+	try {
+		repoRootReal = fs.realpathSync(repoRoot);
+	} catch {
+		repoRootReal = repoRoot;
+	}
+	const foreign: ForeignWorkspaceLink[] = [];
+	for (const entry of entries.sort()) {
+		const link = path.join(scopeDir, entry);
+		let isSymlink: boolean;
+		try {
+			isSymlink = fs.lstatSync(link).isSymbolicLink();
+		} catch {
+			continue;
+		}
+		if (!isSymlink) continue;
+		let target: string;
+		try {
+			target = fs.realpathSync(link);
+		} catch {
+			// Dangling links are the resolution probe's job, not the locality check's.
+			continue;
+		}
+		if (target !== repoRootReal && !target.startsWith(repoRootReal + path.sep)) {
+			foreign.push({ link, target });
+		}
+	}
+	return foreign;
 }
 
 /**
@@ -142,33 +198,56 @@ export function inspectWorkspaceDependencies(probe: WorkspaceDependencyProbe): W
 			}
 		}
 	}
+	const foreignWorkspaceLinks = nodeModulesPresent
+		? (probe.findForeignWorkspaceLinks ?? findForeignWorkspaceLinks)(repoRoot)
+		: [];
 	const status: WorkspaceDependencyStatus = !nodeModulesPresent
 		? "missing-node-modules"
 		: unresolvedPackages.length > 0
 			? "unresolved-workspace-packages"
-			: "ready";
-	return { repoRoot, nodeModulesDir, nodeModulesPresent, workspacePackages, unresolvedPackages, status };
+			: foreignWorkspaceLinks.length > 0
+				? "foreign-workspace-links"
+				: "ready";
+	return {
+		repoRoot,
+		nodeModulesDir,
+		nodeModulesPresent,
+		workspacePackages,
+		unresolvedPackages,
+		foreignWorkspaceLinks,
+		status,
+	};
 }
 
 /** The fail-fast message the test preload throws when the checkout cannot run tests. */
 export function formatWorkspaceDependencyFailure(snapshot: WorkspaceDependencySnapshot): string {
-	const reason =
-		snapshot.status === "missing-node-modules"
-			? `node_modules/ is absent at ${snapshot.nodeModulesDir}.`
-			: `node_modules/ exists but these workspace packages do not resolve: ${snapshot.unresolvedPackages.join(", ")}.`;
-	return [
-		"",
-		"✗ Workspace dependencies are not installed in this checkout.",
-		"",
-		`  ${reason}`,
-		"",
-		"  Tests cannot resolve @gajae-code/* workspace packages, so every run fails with a",
-		'  bare "Cannot find module" error before the suite starts. This is expected in a',
-		"  fresh `git worktree add` checkout.",
-		"",
-		...WORKTREE_SETUP_HELP,
-		"",
-	].join("\n");
+	const lines: string[] = ["", "✗ Workspace dependencies are not usable in this checkout.", ""];
+	if (snapshot.status === "missing-node-modules") {
+		lines.push(
+			`  node_modules/ is absent at ${snapshot.nodeModulesDir}.`,
+			"",
+			"  Tests cannot resolve @gajae-code/* workspace packages, so every run fails with a",
+			'  bare "Cannot find module" error before the suite starts. This is expected in a',
+			"  fresh `git worktree add` checkout.",
+		);
+	} else if (snapshot.status === "foreign-workspace-links") {
+		lines.push(
+			"  node_modules/@gajae-code/* links point outside this checkout:",
+			...snapshot.foreignWorkspaceLinks.map(({ link, target }) => `    ${link} -> ${target}`),
+			"",
+			"  Those packages resolve, but against another checkout's sources, so a green suite",
+			"  would not be evidence for this checkout. Treat it as a stale cross-worktree install.",
+		);
+	} else {
+		lines.push(
+			`  node_modules/ exists but these workspace packages do not resolve: ${snapshot.unresolvedPackages.join(", ")}.`,
+			"",
+			"  Tests cannot import them, so every run fails with a bare module-resolution error",
+			"  before the suite starts.",
+		);
+	}
+	lines.push("", ...WORKTREE_SETUP_HELP, "");
+	return lines.join("\n");
 }
 
 /**
@@ -205,14 +284,18 @@ function indentBlock(text: string, maxLines: number): string {
 /** Human-readable `dev:doctor --worktree` report. */
 export function formatWorktreeReport(report: WorktreeReport): string {
 	const { snapshot, native } = report;
-	const lines = [
-		`Worktree readiness: ${snapshot.repoRoot}`,
-		`  node_modules:       ${snapshot.nodeModulesPresent ? "present" : "ABSENT"} (${snapshot.nodeModulesDir})`,
+	const workspaceLine =
 		snapshot.status === "ready"
 			? `  workspace packages: ${snapshot.workspacePackages.length}/${snapshot.workspacePackages.length} resolve`
 			: snapshot.status === "missing-node-modules"
 				? "  workspace packages: unknown (node_modules absent)"
-				: `  workspace packages: unresolved: ${snapshot.unresolvedPackages.join(", ")}`,
+				: snapshot.status === "foreign-workspace-links"
+					? `  workspace packages: ${snapshot.foreignWorkspaceLinks.length} link(s) point outside this checkout`
+					: `  workspace packages: unresolved: ${snapshot.unresolvedPackages.join(", ")}`;
+	const lines = [
+		`Worktree readiness: ${snapshot.repoRoot}`,
+		`  node_modules:       ${snapshot.nodeModulesPresent ? "present" : "ABSENT"} (${snapshot.nodeModulesDir})`,
+		workspaceLine,
 		`  native addon:       ${native.ok ? "loads" : "UNAVAILABLE"} (${native.entryPath})`,
 	];
 	if (!native.ok && native.output) lines.push(indentBlock(native.output, 20));


### PR DESCRIPTION
## What

Third and final piece of the #5484 worktree diagnostics. The generation-2 red-team found the doctor and the shared test preload disagreed about a stale cross-worktree install:

- `dev:doctor -- --worktree` now refuses it (exit 1, "Workspace symlinks point outside this checkout"), but
- `bun test` still ran green while importing **another checkout's sources**, because the dependency probe only checks that packages resolve, and a foreign-but-existing link does resolve.

This moves the foreign-link detection into `scripts/worktree-deps.ts` so `inspectWorkspaceDependencies`, the test preload, and `dev:doctor` share one implementation, adds a dedicated `foreign-workspace-links` status whose message lists the offending links, and pins the `fs.existsSync` target check with real on-disk fixtures (dangling link reported unresolved; foreign link reported as foreign; an in-checkout link that must not be flagged). Also restores the 4-space indentation of the pre-existing `install:dev` manifest line.

## Why

#5484 is about worktrees that cannot be trusted to run tests. A worktree whose workspace links point into another checkout produces a green suite that is not evidence for this checkout — exactly the silent-false-evidence failure class the issue is about. Fixes #5484.

## Testing

- `bun test scripts/worktree-deps.test.ts scripts/dev-link.test.ts scripts/install-dev.test.ts packages/natives/test/loader-help-worktree.test.ts` — 35 pass / 0 fail.
- Foreign-link fixture: `bun test` in a checkout whose `node_modules/@gajae-code/utils` symlinks to another checkout now exits 1 with the named fix (previously 1 pass while importing the foreign source).
- Dangling-symlink fixture: reported `unresolved-workspace-packages` (default `fs.existsSync` pinned by a real on-disk fixture).
- Healthy checkout: `bun run dev:doctor -- --worktree` exits 0 (9/9 resolve, native addon loads); `bun --cwd=packages/coding-agent test test/agent-roster-label.test.ts` 2 pass.
- `bun run check:tools` clean; `bun --cwd=packages/natives test` 170 pass / 0 fail.
- Full `bun check` was not run; the touched surfaces were checked as listed above.

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:591bc6e13de250eb26153fcc54afff00aeca383ad0444cde65c56214c171e37b reviewer:human reviewer-id:Yeachan-Heo evidence:gen-2 red-team B1/B2 fixed; focused suites 35 pass; check:tools; natives tests; foreign-link and dangling-symlink fixtures
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes (touched-surface checks passed: `check:tools`, focused suites, natives tests)
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing) — dev tooling only, no user-facing change
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken
