### PR TITLE
docs(ooo-bridge): record that session startup quarantines filesystem extensions

### DIFF
--- a/docs/ooo-bridge-extension-contract.md
+++ b/docs/ooo-bridge-extension-contract.md
@@ -58,7 +58,7 @@ Before command dispatch, the exact-prefix helper increments the Ouroboros bridge
 
 ### Runtime status
 
-Session startup quarantines filesystem extension modules. `createAgentSession` seeds its extension set from `options.preloadedExtensions` and falls back to an empty set, so discovered `extensions/**` paths are ignored even when `options.additionalExtensionPaths` is supplied (`packages/coding-agent/src/sdk/session.ts`). `discoverAndLoadExtensions` remains reachable from `gjc --list-models`; no session entrypoint calls it.
+Session startup quarantines filesystem extension modules. `createAgentSession` seeds its extension set from `options.preloadedExtensions` and falls back to an empty set, so discovered `extensions/**` paths are ignored even when `options.additionalExtensionPaths` is supplied (`packages/coding-agent/src/sdk/session.ts`). `discoverAndLoadExtensions` has no production caller: its only remaining call site is `packages/coding-agent/src/cli/list-models.ts`, and `gjc --list-models` calls that entry point with `disableExtensionDiscovery: true`, bypassing discovery. No session entrypoint calls it.
 
 A bridge installed under the locations below is therefore present and inspectable, and its `input` handler never runs. `gjc customize doctor` reports the state directly:
 

--- a/docs/ooo-bridge-extension-contract.md
+++ b/docs/ooo-bridge-extension-contract.md
@@ -56,6 +56,21 @@ Before command dispatch, the exact-prefix helper increments the Ouroboros bridge
 
 ## Installation and discovery
 
+### Runtime status
+
+Session startup quarantines filesystem extension modules. `createAgentSession` seeds its extension set from `options.preloadedExtensions` and falls back to an empty set, so discovered `extensions/**` paths are ignored even when `options.additionalExtensionPaths` is supplied (`packages/coding-agent/src/sdk/session.ts`). `discoverAndLoadExtensions` remains reachable from `gjc --list-models`; no session entrypoint calls it.
+
+A bridge installed under the locations below is therefore present and inspectable, and its `input` handler never runs. `gjc customize doctor` reports the state directly:
+
+```text
+ouroboros-ooo-bridge  [stored-only]  gjc/user  (canonical)
+  reason: managed — Discovered and shown in the extension dashboard, but session startup
+          does not load filesystem extension modules. Runtime extensions come from
+          validated GJC plugin bundles.
+```
+
+GJC plugin bundles carry `subskills`, `tools`, `hooks`, `mcps`, `system_appendix`, and `agent-appendix` (`docs/gjc-plugins.md`). An `input`-event surface is outside that set, so the bridge has no bundle equivalent today. Treat the steps below as the contract for the interception surface and the install layout, and expect `ooo ...` to reach the model as ordinary chat until session startup loads extension modules again.
+
 ### Pinned Ouroboros baseline
 
 This path is verified against [Q00/ouroboros `v0.50.7`](https://github.com/Q00/ouroboros/releases/tag/v0.50.7). Install its MCP profile at the exact version, then configure GJC:


### PR DESCRIPTION
## What

Adds a `Runtime status` subsection to `docs/ooo-bridge-extension-contract.md` recording that session startup does not load filesystem extension modules, so a bridge installed at the documented locations is inert.

Documentation only. No source, test, or behavior change.

## Why

The contract doc presents `~/.gjc/agent/extensions/<name>/index.ts` as the canonical install location and ends with `Start a new GJC session after installation, then run: ooo interview "…"`. On `gjc/0.16.6` that input reaches the model as ordinary chat.

`packages/coding-agent/src/sdk/session.ts` seeds its extension set from `options.preloadedExtensions` and falls back to an empty set:

```ts
// Extension/module discovery is quarantined; retain only the private
// runtime needed for bundled product extensions, explicitly supplied SDK
// extension factories, and custom tools. Filesystem extension paths remain
// ignored here even when options.additionalExtensionPaths is supplied.
```

`preloadedExtensions` has no producer in the repository, and the only non-test caller of `discoverAndLoadExtensions` is `packages/coding-agent/src/cli/list-models.ts`. `gjc customize doctor` reports the bridge as `[stored-only]` with the same reason.

The doctor's remediation points at plugin bundles, whose surfaces are `subskills`, `tools`, `hooks`, `mcps`, `system_appendix`, and `agent-appendix` (`docs/gjc-plugins.md`). An `input`-event handler is outside that set, so the note says so rather than sending readers down a path that does not exist.

Context: #5497.

## Testing

- `ouroboros setup --runtime gjc` with `ouroboros-ai 0.54.3`, then the verified example bridge from pinned commit `4311fefd49e9c6781c4d1111b8dd3f758e7d8974` (SHA-256 `2b0e1e25ac145331f112da629076875542db6f6e63c3c17adcd6770a4dcaf7bd`) installed at the documented user-level path
- Interactive `gjc` session, `ooo status` — answered by the model as chat, with both the Ouroboros-managed bridge and the verified example bridge
- Marker extension at `~/.gjc/agent/extensions/zz-probe/index.ts` writing a file from its factory — never written, both by discovery and with the path listed in `config.yml`'s `extensions` array
- `gjc customize doctor` — both extensions reported `[stored-only]`; the quoted block in the diff is that output verbatim
- Grep of `dev` for `discoverAndLoadExtensions` and `preloadedExtensions` callers

`bun check` not run: the change is a markdown block inside `docs/`, with no code, schema, or fixture surface.

## Maintainer follow-up (2026-09-11)

The independent review lanes found one false clause in the added note: `discoverAndLoadExtensions` is not reachable from `gjc --list-models`, because `main.ts:1541` calls that entry point with `disableExtensionDiscovery: true`, so the `loadExtensions` branch runs and discovery never does. The branch was rebased onto `dev` and a correction commit was pushed on top of the author's commit; the verdict above is bound to the new head.

Head after the rebase and correction: `19226d72d15013e334b30c04ceef15bc95e15529` (rebased onto `dev` `54e8cc3f8c517b0afe71eb0cccbabcb2872197d9`). Approving evidence: `docs-index-lazy.test.ts` 5 pass / 0 fail; `bun scripts/verify-gjc-state-writers.ts --fail` clean; `bun run check:ts` exit 0.

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:ad9b3ea27a6f264b4ad08130190b339dd8707b4ae4a8aaf2a710dde4f7e79e7c reviewer:human reviewer-id:Yeachan-Heo evidence:exact-head-owner-approval;docs-only-1-file;independent-architect+redteam-lanes-caught-false-list-models-reachability-clause-and-correction-pushed;docs-index-lazy-5-pass;state-writer-gate-0-outside-writers
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken


