### PR TITLE
feat(ai): add Devin CLI provider over ACP (#5480)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -34,6 +34,7 @@
         "pi-ai": "./src/cli.ts",
       },
       "dependencies": {
+        "@agentclientprotocol/sdk": "catalog:",
         "@anthropic-ai/sdk": "catalog:",
         "@bufbuild/protobuf": "catalog:",
         "@gajae-code/natives": "catalog:",

--- a/docs/devin-provider.md
+++ b/docs/devin-provider.md
@@ -142,8 +142,11 @@ convert Devin usage into GJC token accounting; use Devin's `/usage` or
 
 - Provider id `devin`, API `devin-acp`, implemented in
   `packages/ai/src/providers/devin-acp.ts`.
-- One `devin acp` child process per GJC session, reused across turns and killed
-  at session teardown (`providerSessionState`).
+- One `devin acp` child process per GJC session and working directory, reused
+  across turns and killed at session teardown (`providerSessionState`). The
+  working directory is part of that cache identity, so `/move` starts a fresh
+  ACP session in the new directory (Devin's own conversation history restarts,
+  as it would for a new session) and closes the child it replaced.
 - Authentication, model catalog, tool execution, and usage stay inside Devin;
   GJC never reads or stores Devin credentials.
 

--- a/docs/devin-provider.md
+++ b/docs/devin-provider.md
@@ -107,7 +107,7 @@ permission policy gates. GJC answers from an explicit policy:
 
 | `GJC_DEVIN_PERMISSION_MODE` | Behavior |
 | --- | --- |
-| unset / `allow` (default) | Grant the least-privileged option Devin offered — `allow_once` before `allow_always`. One action per prompt: GJC never escalates to a persistent grant on its own. |
+| unset / `allow` (default) | Grants `allow_once`. A request that offers no `allow_once` is **cancelled**: GJC never grants a persistent approval on its own. |
 | `deny` | Reject with `reject_once` (or `reject_always` when that is the only refusal offered). |
 | any other value | Fails closed to `deny`. |
 

--- a/docs/devin-provider.md
+++ b/docs/devin-provider.md
@@ -1,0 +1,151 @@
+# Devin CLI provider (ACP)
+
+GJC can drive [Devin CLI](https://docs.devin.ai/cli) as a selectable provider.
+Devin is integrated through its Agent Client Protocol server
+(`devin acp`), because that is the only programmatic interface Devin CLI
+exposes: Devin publishes no model-inference endpoint, and its CLI credentials
+cannot be reused for arbitrary inference requests.
+
+That makes `devin` an **agent-level provider**, not a model backend. This page
+states exactly what that means for tools, permissions, workflows, and billing.
+
+## Setup
+
+```sh
+# 1. Install Devin CLI and authenticate (credentials stay with Devin).
+#    https://docs.devin.ai/cli
+devin auth login
+
+# 2. Confirm the CLI is reachable. GJC spawns `devin acp` over stdio.
+devin models list
+
+# 3. Start GJC and pick a Devin model.
+gjc
+#   /model          -> provider model picker
+#   gjc models      -> non-interactive model list
+```
+
+If `devin` is not on `PATH`, point GJC at the executable:
+
+```sh
+GJC_DEVIN_CLI_PATH=/opt/devin/bin/devin gjc
+```
+
+## Models
+
+GJC discovers the models **your account** can use from the ACP session's own
+`model` config option and applies the model you select with the session's
+`session/set_config_option` request. The catalog therefore follows your Devin
+account and enterprise allowlists instead of a hardcoded list. `adaptive` is the
+default selector when no model has been chosen yet
+([Devin's recommended default](https://docs.devin.ai/cli/adaptive)); enterprise
+organizations can disable it.
+
+Selecting a model the account does not offer fails loudly with the account's
+actual options rather than silently running a different (possibly more
+expensive) model. If you switch models mid-session, GJC applies the change to
+the live ACP session.
+
+## What applies to a Devin turn
+
+| Surface | Applies? |
+| --- | --- |
+| GJC TUI, transcript rendering, session persistence, resume | Yes |
+| Provider/model selection (`/model`, `gjc models`, role profiles) | Yes |
+| Cancelling a turn (Esc/Ctrl+C) | Yes — GJC sends ACP `session/cancel` |
+| Devin's own tool calls shown in the transcript | Yes, read-only (see below) |
+| GJC tools (bash, read, edit, grep, task, web search, LSP, …) | **No** — Devin runs its own tools |
+| GJC skills, workflows (`deep-interview`, `ralplan`, `ultragoal`, `autoresearch`), role agents, hooks | **No** — they are not sent to Devin |
+| GJC permission prompts for GJC tools | **No** — see "Permissions" |
+| GJC context compaction, handoff, branch summaries | **No** — refused up front, never sent to Devin |
+| GJC token accounting, cost display, context-window pressure | **No** — Devin reports its own usage |
+
+### Why GJC tools do not participate
+
+A GJC model provider returns an assistant message whose tool calls GJC then
+executes. ACP works the other way around: the agent executes its tools and
+reports them to the client. GJC therefore renders Devin's `tool_call` /
+`tool_call_update` notifications as read-only transcript entries and always
+finishes the turn with a normal stop, so GJC never re-executes a Devin tool
+call. Each entry carries its ACP identity under an `_acp` key
+(`toolCallId`, `kind`, `status`) in its arguments.
+
+Devin owns the conversation history. GJC forwards only your newest message, and
+Devin applies its own rules (`AGENTS.md`, `.devin/` rules and skills, MCP
+servers you configured with `devin mcp`). GJC's own `AGENTS.md`-driven harness
+guidance is not injected into Devin turns.
+
+### Maintenance and utility calls are refused
+
+GJC also routes non-turn work through a provider: context compaction, handoff
+generation, branch summaries, and utility generations such as session titles,
+commit messages, and prompt suggestions. Devin is an agent, not a text model, so
+GJC refuses those requests instead of spending your Devin quota on them, with an
+error naming what happened (`maintenanceCall` on the provider request).
+
+A Devin turn therefore requires an interactive GJC session turn: a session
+identity plus a user message. Utility one-shots that carry no session identity
+are rejected the same way.
+
+This rarely matters in practice: because GJC forwards only your newest message,
+Devin manages the conversation context itself, so GJC-side compaction is not
+needed to keep a Devin session going. GJC's own transcript can still reach its
+auto-compaction threshold on a long session, in which case compaction reports the
+error above — switch to a non-Devin model (`/model`) for that operation, or keep
+a non-Devin model as your main model when you rely on GJC-side compaction.
+
+### Images
+
+Image attachments are forwarded only when the ACP agent advertises image prompt
+support (an ACP `promptCapabilities` negotiation). Otherwise the attachment is
+replaced with a visible note in the prompt, so nothing is dropped silently.
+
+## Permissions
+
+Devin asks the ACP client — GJC — before running the operations its own
+permission policy gates. GJC answers from an explicit policy:
+
+| `GJC_DEVIN_PERMISSION_MODE` | Behavior |
+| --- | --- |
+| unset / `allow` (default) | Grant the least-privileged option Devin offered — `allow_once` before `allow_always`. One action per prompt: GJC never escalates to a persistent grant on its own. |
+| `deny` | Reject with `reject_once` (or `reject_always` when that is the only refusal offered). |
+| any other value | Fails closed to `deny`. |
+
+If Devin offers no option matching the policy, GJC answers `cancelled` rather
+than approving something it was not offered.
+
+This policy mirrors GJC's own stance for its own tools: GJC is an autonomous
+coding agent and does not prompt for every tool call. Set
+`GJC_DEVIN_PERMISSION_MODE=deny` for untrusted repositories, or configure
+Devin's own permission mode (`devin --permission-mode`, `DEVIN_PERMISSION_MODE`)
+so it does not ask in the first place.
+
+## Billing
+
+Devin usage is billed to **your Devin account** (quota/credits or ACUs,
+depending on your plan). GJC records zero cost for Devin turns and does not
+convert Devin usage into GJC token accounting; use Devin's `/usage` or
+`/session-stats` inside a session for that.
+
+## Troubleshooting
+
+| Symptom | Cause and fix |
+| --- | --- |
+| Provider shows no models | Devin CLI missing, unauthenticated, or off `PATH`. Run `devin auth login`; set `GJC_DEVIN_CLI_PATH` if needed. |
+| `Devin CLI is not authenticated` | GJC reached the CLI but it has no credentials. Run `devin auth login` (or set `WINDSURF_API_KEY` for enterprise builds). |
+| `Devin account does not offer model "<id>"` | The model is not in your account's allowlist. Pick a discovered model. |
+| `Devin ACP process exited with code …` | The CLI crashed; the stderr tail is included in the message. |
+| Turn stalls then errors | The agent stopped sending updates within the stream idle timeout. Check `devin doctor`/`devin --version`. |
+| Error naming maintenance calls | GJC refused a compaction/handoff/branch-summary request on a Devin model. Switch to a non-Devin model for that operation. |
+
+## Implementation notes
+
+- Provider id `devin`, API `devin-acp`, implemented in
+  `packages/ai/src/providers/devin-acp.ts`.
+- One `devin acp` child process per GJC session, reused across turns and killed
+  at session teardown (`providerSessionState`).
+- Authentication, model catalog, tool execution, and usage stay inside Devin;
+  GJC never reads or stores Devin credentials.
+
+See also: [Models and providers](./models.md),
+[Environment variables](./environment-variables.md).

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -627,7 +627,18 @@ See [External control readiness](./external-control-readiness.md#jetbrains-air-c
 
 ---
 
-## 12) Removed ingress modes
+## 12) Devin CLI provider (ACP)
+
+| Variable | Values | Default | Behavior |
+| --- | --- | --- | --- |
+| `GJC_DEVIN_CLI_PATH` | executable path | `devin` on `PATH` | Executable GJC spawns as `<path> acp`. Use it when the Devin CLI is installed outside `PATH`. |
+| `GJC_DEVIN_PERMISSION_MODE` | `allow`, `deny` | `allow` | How GJC answers Devin's ACP permission requests for Devin's own tool calls. `allow` grants the least-privileged option Devin offered (`allow_once` before `allow_always`); `deny` selects `reject_once`/`reject_always`. Invalid values fail closed to `deny`. |
+
+Devin authentication lives entirely in the Devin CLI (`devin auth login`, or `WINDSURF_API_KEY` for enterprise builds); GJC stores no Devin credential. See [Devin CLI provider (ACP)](./devin-provider.md) for the integration boundary, model discovery, and billing.
+
+---
+
+## 13) Removed ingress modes
 
 `--mode rpc`, `--mode rpc-ui`, and `--mode bridge` have been removed. The retired bridge-prefixed variables and `GJC_RPC_EMIT_TITLE` are not runtime configuration variables. Use the [SDK machine interface](./sdk.md) for external machine control.
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -632,7 +632,7 @@ See [External control readiness](./external-control-readiness.md#jetbrains-air-c
 | Variable | Values | Default | Behavior |
 | --- | --- | --- | --- |
 | `GJC_DEVIN_CLI_PATH` | executable path | `devin` on `PATH` | Executable GJC spawns as `<path> acp`. Use it when the Devin CLI is installed outside `PATH`. |
-| `GJC_DEVIN_PERMISSION_MODE` | `allow`, `deny` | `allow` | How GJC answers Devin's ACP permission requests for Devin's own tool calls. `allow` grants the least-privileged option Devin offered (`allow_once` before `allow_always`); `deny` selects `reject_once`/`reject_always`. Invalid values fail closed to `deny`. |
+| `GJC_DEVIN_PERMISSION_MODE` | `allow`, `deny` | `allow` | How GJC answers Devin's ACP permission requests for Devin's own tool calls. `allow` grants `allow_once`; a request that offers none is answered `cancelled`, because GJC never grants a persistent approval on its own. `deny` selects `reject_once`/`reject_always`. Invalid values fail closed to `deny`. |
 
 Devin authentication lives entirely in the Devin CLI (`devin auth login`, or `WINDSURF_API_KEY` for enterprise builds); GJC stores no Devin credential. See [Devin CLI provider (ACP)](./devin-provider.md) for the integration boundary, model discovery, and billing.
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -759,6 +759,23 @@ Extensions can register providers at runtime (`pi.registerProvider(...)`), inclu
 - custom stream handler registration for new API IDs
 - custom OAuth provider registration
 
+### Agent-level providers (ACP)
+
+Some upstreams publish a complete agent instead of a model endpoint. Those are
+integrated as **agent-level providers**: the provider id is selectable like any
+other, but the upstream agent owns model choice, tool execution, conversation
+history, and usage accounting.
+
+`devin` (Devin CLI) is the first one. GJC spawns `devin acp` and speaks the
+Agent Client Protocol over stdio; `devin` models appear through the ordinary
+provider/model selection path once the CLI is installed and authenticated, and
+the provider is credentialless (`getApiKey*` returns `kNoAuth`) because
+authentication belongs to the CLI (`devin auth login`).
+
+See [Devin CLI provider (ACP)](./devin-provider.md) for the full boundary: which
+GJC surfaces apply to a Devin turn, the tool-call permission policy
+(`GJC_DEVIN_PERMISSION_MODE`), and billing.
+
 ## Auth and API key resolution order
 
 When requesting a key for a provider, effective order is:

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 
-- Lossless and managed assistant-message snapshots now carry the in-process provider-resolved tool-call marker across the boundary. The marker is a symbol, so a deep snapshot silently dropped it and the agent loop would then dispatch a provider-executed tool call to a local tool of the same display name. This affected Cursor's exec-owned calls and the new Devin ACP provider alike.
+- Lossless, managed, abort-path, and safety-stop assistant-message rebuilds now carry the in-process provider-resolved tool-call marker across the boundary. The marker is a symbol, so a deep snapshot silently dropped it, and the loop would then dispatch a provider-executed tool call to a local tool of the same display name — or, on an aborted turn, fabricate a failed tool result for it. This affected Cursor's exec-owned calls and the new Devin ACP provider alike. The marker is registered with `Symbol.for` and restoration is fail-closed on ambiguous identity.
 
 - Publish reasoning summaries, thinking, and tool-call updates during ordinary unmanaged streaming instead of holding them until text, response completion, or interruption. Tool execution still waits for terminal validation; already-published legacy guarded calls receive explicit rejection instead of silent resampling. Managed fallback attempts remain atomic.
 

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Maintenance LLM calls (compaction, handoff, branch summaries) forward a `maintenanceCall: true` marker to the provider. Agent-level providers such as Devin over ACP use it to refuse work they cannot serve instead of forwarding a summarization prompt to a billed upstream agent.
+
 ### Fixed
 
 - Publish reasoning summaries, thinking, and tool-call updates during ordinary unmanaged streaming instead of holding them until text, response completion, or interruption. Tool execution still waits for terminal validation; already-published legacy guarded calls receive explicit rejection instead of silent resampling. Managed fallback attempts remain atomic.

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- Lossless and managed assistant-message snapshots now carry the in-process provider-resolved tool-call marker across the boundary. The marker is a symbol, so a deep snapshot silently dropped it and the agent loop would then dispatch a provider-executed tool call to a local tool of the same display name. This affected Cursor's exec-owned calls and the new Devin ACP provider alike.
+
 - Publish reasoning summaries, thinking, and tool-call updates during ordinary unmanaged streaming instead of holding them until text, response completion, or interruption. Tool execution still waits for terminal validation; already-published legacy guarded calls receive explicit rejection instead of silent resampling. Managed fallback attempts remain atomic.
 
 ## [0.16.6] - 2026-09-07

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -34,7 +34,7 @@ import {
 	neutralizeReservedControlTokens,
 	stripUnusableReasoningItems,
 } from "@gajae-code/ai/utils";
-import { isCursorExecResolved } from "@gajae-code/ai/utils/block-symbols";
+import { copyProviderResolvedToolCall, isProviderResolvedToolCall } from "@gajae-code/ai/utils/block-symbols";
 import {
 	attachUnicodeEscapeEvidence,
 	type UnicodeEscapeEvidence,
@@ -2107,6 +2107,7 @@ function managedAssistantShell(
 	}
 	const content = rawArray === undefined ? [] : rawArray.flatMap(managedContentBlock);
 	restoreTransientUnicodeEscapeEvidence(content, value);
+	restoreProviderResolvedMarkers(content, value);
 	const usage = managedAssistantUsage(managedAttemptSnapshot(managedProperty(source, "usage")));
 	const api = managedProperty(source, "api");
 	const provider = managedProperty(source, "provider");
@@ -2179,6 +2180,32 @@ function managedAssistantShell(
 function managedContentBlock(block: unknown): AssistantMessage["content"] {
 	const normalized = managedAssistantContent(block);
 	return normalized ? [normalized] : [];
+}
+
+/**
+ * Carry the in-process provider-resolved marker across a managed snapshot.
+ *
+ * A managed shell deep-snapshots content, and symbol keys do not survive that.
+ * Losing the marker would let the loop dispatch a tool call the provider already
+ * executed, so it is re-attached by tool-call identity (`id` plus `name`), the
+ * same way transient unicode-escape evidence is restored.
+ */
+function restoreProviderResolvedMarkers(destination: AssistantMessage["content"], source: unknown): void {
+	const sourceContent = managedProperty(source, "content");
+	if (!Array.isArray(sourceContent)) return;
+	const marked = sourceContent.filter(
+		(block): block is object => typeof block === "object" && block !== null && isProviderResolvedToolCall(block),
+	);
+	if (marked.length === 0) return;
+	for (const destinationBlock of destination) {
+		if (destinationBlock.type !== "toolCall") continue;
+		const matches = marked.filter(
+			candidate =>
+				managedProperty(candidate, "id") === destinationBlock.id &&
+				managedProperty(candidate, "name") === destinationBlock.name,
+		);
+		if (matches.length === 1) copyProviderResolvedToolCall(destinationBlock, matches[0] as object);
+	}
 }
 
 function managedUnicodeEscapeEvidence(value: unknown): UnicodeEscapeEvidence | undefined {
@@ -2835,6 +2862,10 @@ class ManagedAttemptTransaction {
 				snapshotBlock = normalized;
 				snapshot.content[index] = snapshotBlock;
 			}
+			// A lossless snapshot must stay lossless for the in-process marker that
+			// tells the loop a provider already executed this call. Dropping it here
+			// would make the loop dispatch the provider's own tool call locally.
+			copyProviderResolvedToolCall(snapshotBlock, sourceBlock);
 			if (metadata) {
 				const detachedMetadata = escapedToolCallMetadata(snapshotBlock);
 				const evidencePresenceChanged = Boolean(metadata.evidence) !== Boolean(detachedMetadata.evidence);
@@ -4205,7 +4236,7 @@ async function runLoopBody(
 				// This maintains the tool_use/tool_result pairing that the API requires
 				type ToolCallContent = Extract<AssistantMessage["content"][number], { type: "toolCall" }>;
 				const toolCalls = message.content.filter(
-					(c): c is ToolCallContent => c.type === "toolCall" && !isCursorExecResolved(c),
+					(c): c is ToolCallContent => c.type === "toolCall" && !isProviderResolvedToolCall(c),
 				);
 				const toolResults: ToolResultMessage[] = [];
 				for (const toolCall of toolCalls) {
@@ -4238,7 +4269,7 @@ async function runLoopBody(
 			// Check for tool calls
 			type ToolCallContent = Extract<AssistantMessage["content"][number], { type: "toolCall" }>;
 			const toolCalls = message.content.filter(
-				(c): c is ToolCallContent => c.type === "toolCall" && !isCursorExecResolved(c),
+				(c): c is ToolCallContent => c.type === "toolCall" && !isProviderResolvedToolCall(c),
 			);
 			hasMoreToolCalls = toolCalls.length > 0;
 
@@ -5035,7 +5066,7 @@ async function executeToolCalls(
 	} = config;
 	type ToolCallContent = Extract<AssistantMessage["content"][number], { type: "toolCall" }>;
 	const toolCalls = assistantMessage.content.filter(
-		(c): c is ToolCallContent => c.type === "toolCall" && !isCursorExecResolved(c),
+		(c): c is ToolCallContent => c.type === "toolCall" && !isProviderResolvedToolCall(c),
 	);
 	const emittedToolResults: ToolResultMessage[] = [];
 	const toolCallInfos = toolCalls.map(call => ({ id: call.id, name: call.name }));

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -879,6 +879,7 @@ function sanitizeProviderSafetyStopProvenance(
 			return repaired;
 		}
 		restoreTransientUnicodeEscapeEvidence(rebuilt.content, message);
+		restoreProviderResolvedMarkers(rebuilt.content, message);
 		return rebuilt;
 	}
 	const rebuilt = managedAssistantShell(message, model);
@@ -2204,8 +2205,28 @@ function restoreProviderResolvedMarkers(destination: AssistantMessage["content"]
 				managedProperty(candidate, "id") === destinationBlock.id &&
 				managedProperty(candidate, "name") === destinationBlock.name,
 		);
-		if (matches.length === 1) copyProviderResolvedToolCall(destinationBlock, matches[0] as object);
+		// Ambiguity suppresses every candidate rather than dispatching a call the
+		// provider may already have executed: this predicate is a safety gate.
+		for (const match of matches) copyProviderResolvedToolCall(destinationBlock, match as object);
 	}
+}
+
+/**
+ * Detach content the way `structuredClone` does, but keep the in-process
+ * provider-resolved marker. The abort path clamps partial content and then
+ * filters provider-resolved calls out of the synthesized aborted results, so a
+ * plain structured clone would fabricate a failed tool result for a call the
+ * provider already ran.
+ */
+function cloneContentPreservingProviderResolved(content: AssistantMessage["content"]): AssistantMessage["content"] {
+	const cloned = structuredClone(content) as AssistantMessage["content"];
+	for (let index = 0; index < content.length; index += 1) {
+		const source = content[index];
+		const target = cloned[index];
+		if (source?.type !== "toolCall" || target?.type !== "toolCall") continue;
+		copyProviderResolvedToolCall(target, source);
+	}
+	return cloned;
 }
 
 function managedUnicodeEscapeEvidence(value: unknown): UnicodeEscapeEvidence | undefined {
@@ -2862,10 +2883,6 @@ class ManagedAttemptTransaction {
 				snapshotBlock = normalized;
 				snapshot.content[index] = snapshotBlock;
 			}
-			// A lossless snapshot must stay lossless for the in-process marker that
-			// tells the loop a provider already executed this call. Dropping it here
-			// would make the loop dispatch the provider's own tool call locally.
-			copyProviderResolvedToolCall(snapshotBlock, sourceBlock);
 			if (metadata) {
 				const detachedMetadata = escapedToolCallMetadata(snapshotBlock);
 				const evidencePresenceChanged = Boolean(metadata.evidence) !== Boolean(detachedMetadata.evidence);
@@ -3204,6 +3221,7 @@ class ManagedAttemptTransaction {
 				managedProperty(snapshot, "content") as AssistantMessage["content"],
 				value,
 			);
+			restoreProviderResolvedMarkers(managedProperty(snapshot, "content") as AssistantMessage["content"], value);
 		}
 		return snapshot;
 	}
@@ -4970,7 +4988,7 @@ function emitAbortedAssistantMessage(
 	const now = Date.now();
 	const abortedMessage: AssistantMessage = {
 		role: "assistant",
-		content: partialMessage ? structuredClone(partialMessage.content) : [],
+		content: partialMessage ? cloneContentPreservingProviderResolved(partialMessage.content) : [],
 		api: config.model.api,
 		provider: config.model.provider,
 		model: config.model.id,

--- a/packages/agent/src/compaction/branch-summarization.ts
+++ b/packages/agent/src/compaction/branch-summarization.ts
@@ -93,6 +93,12 @@ export interface GenerateBranchSummaryOptions {
 	sessionId?: string;
 	/** Opaque provider conversation identity; never derived from branch-summary content. */
 	providerSessionId?: string;
+	/**
+	 * Marks this as GJC maintenance work rather than an interactive user turn.
+	 * Agent-level providers (e.g. `devin-acp`) refuse maintenance calls they
+	 * cannot serve instead of forwarding them to a billed upstream agent.
+	 */
+	maintenanceCall?: boolean;
 	/** Shared provider state map so the branch summary call reuses session-scoped transport/session caches. */
 	providerSessionState?: Map<string, ProviderSessionState>;
 	/** Hint that websocket transport should be preferred when supported by the provider implementation. */
@@ -337,6 +343,7 @@ export async function generateBranchSummary(
 			sessionId,
 			providerSessionId,
 			providerSessionState,
+			maintenanceCall: options.maintenanceCall,
 			preferWebsockets,
 		},
 		{ telemetry: options.telemetry, oneshotKind: "branch_summary" },

--- a/packages/agent/src/compaction/compaction.ts
+++ b/packages/agent/src/compaction/compaction.ts
@@ -868,6 +868,12 @@ export interface SummaryOptions {
 	remoteEndpoint?: string;
 	remoteInstructions?: string;
 	initiatorOverride?: MessageAttribution;
+	/**
+	 * Marks this as GJC maintenance work rather than an interactive user turn.
+	 * Agent-level providers (e.g. `devin-acp`) refuse maintenance calls they
+	 * cannot serve instead of forwarding them to a billed upstream agent.
+	 */
+	maintenanceCall?: boolean;
 	metadata?: Record<string, unknown>;
 	convertToLlm?: ConvertToLlm;
 	/**
@@ -1026,6 +1032,7 @@ export async function generateSummary(
 			apiKey,
 			reasoning: maintenanceReasoning(model),
 			initiatorOverride: options?.initiatorOverride,
+			maintenanceCall: options?.maintenanceCall,
 			metadata: options?.metadata,
 			sessionId: options?.sessionId,
 			providerSessionId: options?.providerSessionId,
@@ -1065,6 +1072,12 @@ export interface HandoffOptions {
 	promptExtension?: string;
 	convertToLlm?: ConvertToLlm;
 	initiatorOverride?: MessageAttribution;
+	/**
+	 * Marks this as GJC maintenance work rather than an interactive user turn.
+	 * Agent-level providers (e.g. `devin-acp`) refuse maintenance calls they
+	 * cannot serve instead of forwarding them to a billed upstream agent.
+	 */
+	maintenanceCall?: boolean;
 	metadata?: Record<string, unknown>;
 	/**
 	 * Optional telemetry handle. When provided, the handoff LLM call is
@@ -1124,6 +1137,7 @@ export async function generateHandoff(
 			reasoning: maintenanceReasoning(model),
 			toolChoice: "none",
 			initiatorOverride: options.initiatorOverride,
+			maintenanceCall: options.maintenanceCall,
 			metadata: options.metadata,
 			sessionId: options.sessionId,
 			providerSessionId: options.providerSessionId,
@@ -1397,6 +1411,7 @@ export async function compact(
 		remoteEndpoint: settings.remoteEnabled === false ? undefined : settings.remoteEndpoint,
 		remoteInstructions: options?.remoteInstructions,
 		initiatorOverride: options?.initiatorOverride,
+		maintenanceCall: options?.maintenanceCall,
 		metadata: options?.metadata,
 		convertToLlm: options?.convertToLlm,
 		telemetry: options?.telemetry,
@@ -1574,6 +1589,7 @@ async function generateTurnPrefixSummary(
 			apiKey,
 			reasoning: maintenanceReasoning(model),
 			initiatorOverride: options?.initiatorOverride,
+			maintenanceCall: options?.maintenanceCall,
 			metadata: options?.metadata,
 			sessionId: options?.sessionId,
 			providerSessionId: options?.providerSessionId,

--- a/packages/agent/test/compaction-transport.test.ts
+++ b/packages/agent/test/compaction-transport.test.ts
@@ -112,6 +112,7 @@ describe("maintenance call transport forwarding (#736)", () => {
 			providerSessionId: "provider-session-1",
 			providerSessionState,
 			preferWebsockets: true,
+			maintenanceCall: true,
 		});
 
 		expect(captured).toHaveLength(1);
@@ -119,6 +120,7 @@ describe("maintenance call transport forwarding (#736)", () => {
 		expect(captured[0]?.providerSessionId).toBe("provider-session-1");
 		expect(captured[0]?.providerSessionState).toBe(providerSessionState);
 		expect(captured[0]?.preferWebsockets).toBe(true);
+		expect(captured[0]?.maintenanceCall).toBe(true);
 	});
 
 	it("generateHandoff forwards sessionId, providerSessionState, and preferWebsockets", async () => {
@@ -132,6 +134,7 @@ describe("maintenance call transport forwarding (#736)", () => {
 			providerSessionId: "provider-session-2",
 			providerSessionState,
 			preferWebsockets: true,
+			maintenanceCall: true,
 		});
 
 		expect(captured).toHaveLength(1);
@@ -139,6 +142,7 @@ describe("maintenance call transport forwarding (#736)", () => {
 		expect(captured[0]?.providerSessionId).toBe("provider-session-2");
 		expect(captured[0]?.providerSessionState).toBe(providerSessionState);
 		expect(captured[0]?.preferWebsockets).toBe(true);
+		expect(captured[0]?.maintenanceCall).toBe(true);
 	});
 
 	it("generateBranchSummary forwards sessionId, providerSessionState, and preferWebsockets", async () => {
@@ -169,6 +173,7 @@ describe("maintenance call transport forwarding (#736)", () => {
 			providerSessionId: "provider-session-3",
 			providerSessionState,
 			preferWebsockets: true,
+			maintenanceCall: true,
 		});
 
 		expect(captured).toHaveLength(1);
@@ -176,6 +181,7 @@ describe("maintenance call transport forwarding (#736)", () => {
 		expect(captured[0]?.providerSessionId).toBe("provider-session-3");
 		expect(captured[0]?.providerSessionState).toBe(providerSessionState);
 		expect(captured[0]?.preferWebsockets).toBe(true);
+		expect(captured[0]?.maintenanceCall).toBe(true);
 	});
 
 	it("compact() forwards transport fields to the history summary (short summary is derived locally, #2335)", async () => {
@@ -187,6 +193,7 @@ describe("maintenance call transport forwarding (#736)", () => {
 			providerSessionId: "provider-session-4",
 			providerSessionState,
 			preferWebsockets: true,
+			maintenanceCall: true,
 		});
 
 		// history summary only: shortSummary is derived from the main summary
@@ -197,6 +204,7 @@ describe("maintenance call transport forwarding (#736)", () => {
 			expect(options.providerSessionId).toBe("provider-session-4");
 			expect(options.providerSessionState).toBe(providerSessionState);
 			expect(options.preferWebsockets).toBe(true);
+			expect(options.maintenanceCall).toBe(true);
 		}
 	});
 });

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Devin CLI is now a first-class provider (`devin`, api `devin-acp`). Devin publishes no model-inference endpoint, so GJC speaks its documented programmatic surface instead: it spawns `devin acp` and drives the Agent Client Protocol over stdio. Devin owns model selection (discovered from the account's ACP session `model` config option), tool execution, conversation history, and usage; GJC renders Devin's tool calls read-only and always ends the turn with a normal stop so they are never re-executed, forwards cancellation as ACP `session/cancel`, and answers Devin's permission requests from `GJC_DEVIN_PERMISSION_MODE` (`allow` grants `allow_once`, never `allow_always`; `deny` rejects; invalid values fail closed). Maintenance and utility calls that need a text model — compaction, handoff, branch summaries, session titles — are refused instead of being spent on a Devin agent turn; `StreamOptions.maintenanceCall` marks them. See `docs/devin-provider.md`.
+
 ### Fixed
 
 - The image generation role can select OpenAI's current GPT Image models. `gpt-image-2.5-sunburst` (editing precision) and `gpt-image-2.5-flare` (fast everyday generation) now ship in the bundled catalog under both `openai` and `openai-codex` with the same image-only, zero-cost, 128k-context/16k-max-token shape as `gpt-image-2`, so a provider-qualified `modelRoles.image: openai-codex/gpt-image-2.5-sunburst` selector resolves instead of failing with `No image model configured` (#5478).

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 ### Added
 
-- Devin CLI is now a first-class provider (`devin`, api `devin-acp`). Devin publishes no model-inference endpoint, so GJC speaks its documented programmatic surface instead: it spawns `devin acp` and drives the Agent Client Protocol over stdio. Devin owns model selection (discovered from the account's ACP session `model` config option), tool execution, conversation history, and usage; GJC renders Devin's tool calls read-only and always ends the turn with a normal stop so they are never re-executed, forwards cancellation as ACP `session/cancel`, and answers Devin's permission requests from `GJC_DEVIN_PERMISSION_MODE` (`allow` grants `allow_once`, never `allow_always`; `deny` rejects; invalid values fail closed). Maintenance and utility calls that need a text model — compaction, handoff, branch summaries, session titles — are refused instead of being spent on a Devin agent turn; `StreamOptions.maintenanceCall` marks them. See `docs/devin-provider.md`.
+- Devin CLI is now a first-class provider (`devin`, api `devin-acp`). Devin publishes no model-inference endpoint, so GJC speaks its documented programmatic surface instead: it spawns `devin acp` and drives the Agent Client Protocol over stdio. Devin owns model selection (discovered from the account's ACP session `model` config option), tool execution, conversation history, and usage; GJC renders Devin's tool calls read-only and always ends the turn with a normal stop so they are never re-executed, forwards cancellation as ACP `session/cancel`, and answers Devin's permission requests from `GJC_DEVIN_PERMISSION_MODE` (`allow` grants `allow_once` and cancels when none is offered, never granting a persistent approval; `deny` rejects; invalid values fail closed). Maintenance and utility calls that need a text model — compaction, handoff, branch summaries, session titles — are refused instead of being spent on a Devin agent turn; `StreamOptions.maintenanceCall` marks them. See `docs/devin-provider.md`.
+
+### Changed
+
+- `@gajae-code/ai/utils/block-symbols` now exports the provider-neutral provider-resolved tool-call marker: `kProviderResolvedToolCall`, `ProviderResolvedCarrier`, `isProviderResolvedToolCall`, and `copyProviderResolvedToolCall` replace `kCursorExecResolved`, `CursorExecResolvedCarrier`, `isCursorExecResolved`, and `copyCursorExecResolved`. Cursor exec-owned calls and Devin's ACP tool calls both use it, and it is registered with `Symbol.for` so duplicate module instances cannot disagree about it.
 
 ### Fixed
 

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -38,6 +38,7 @@
 		"generate-models": "bun scripts/generate-models.ts"
 	},
 	"dependencies": {
+		"@agentclientprotocol/sdk": "catalog:",
 		"@anthropic-ai/sdk": "catalog:",
 		"@bufbuild/protobuf": "catalog:",
 		"@gajae-code/natives": "catalog:",

--- a/packages/ai/src/api-registry.ts
+++ b/packages/ai/src/api-registry.ts
@@ -26,6 +26,7 @@ const BUILTIN_APIS = new Set<KnownApi>([
 	"google-vertex",
 	"ollama-chat",
 	"cursor-agent",
+	"devin-acp",
 ]);
 
 export type CustomStreamFn = (

--- a/packages/ai/src/provider-models/descriptors.ts
+++ b/packages/ai/src/provider-models/descriptors.ts
@@ -53,6 +53,7 @@ import {
 } from "./openai-compat";
 import {
 	cursorModelManagerOptions,
+	devinModelManagerOptions,
 	glmZcodeModelManagerOptions,
 	jetbrainsJunieModelManagerOptions,
 	kiroModelManagerOptions,
@@ -364,6 +365,12 @@ export const PROVIDER_DESCRIPTORS: readonly ProviderDescriptor[] = [
 		catalog("GLM ZCode (unofficial)", ["GLM_ZCODE_API_KEY"], { oauthProvider: "glm-zcode" }),
 	),
 	descriptor("jetbrains-junie", "claude-sonnet-4-6", config => jetbrainsJunieModelManagerOptions(config)),
+	// `adaptive` is Devin's documented recommended default (docs.devin.ai/cli/adaptive).
+	// Enterprise organizations may disable it; the account's real model list comes from
+	// the ACP session's model config option.
+	descriptor("devin", "adaptive", () => devinModelManagerOptions(), {
+		allowUnauthenticated: true,
+	}),
 	descriptor("github-copilot", "gpt-4o", config => githubCopilotModelManagerOptions(config)),
 	descriptor("google", "gemini-2.5-pro", config => googleModelManagerOptions(config)),
 	catalogDescriptor(

--- a/packages/ai/src/provider-models/special.ts
+++ b/packages/ai/src/provider-models/special.ts
@@ -5,6 +5,7 @@ import type { ModelManagerOptions } from "../model-manager";
 import { buildZCodeSourceHeaders, resolveGlmZcodeAnthropicBaseUrl } from "../providers/anthropic";
 import { fetchKiroApiModels, isKiroApiKey, kiroApiStaticModels } from "../providers/kiro-api-key";
 import { fetchOpenCodexModels, OPENCODEX_MODEL_CACHE_TTL_MS } from "../providers/openai-opencodex-responses";
+import type { Model } from "../types";
 import { fetchCodexModels } from "../utils/discovery/codex";
 import { fetchOpenAICompatibleModels } from "../utils/discovery/openai-compatible";
 import { createBundledReferenceMap } from "./bundled-references";
@@ -13,6 +14,44 @@ export function openCodexModelManagerOptions(): ModelManagerOptions<"openai-resp
 		providerId: "opencodex",
 		cacheTtlMs: OPENCODEX_MODEL_CACHE_TTL_MS,
 		fetchDynamicModels: fetchOpenCodexModels,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Devin CLI (ACP)
+// ---------------------------------------------------------------------------
+
+/**
+ * Lazy handle to the ACP provider module. The ACP SDK must stay out of the
+ * catalog/startup import graph, so it is only required when Devin model
+ * discovery actually runs.
+ */
+interface DevinAcpDiscoveryModule {
+	fetchDevinAcpModels: (config?: {
+		cliPath?: string;
+		cliArgs?: readonly string[];
+		cwd?: string;
+	}) => Promise<Model<"devin-acp">[] | null>;
+}
+
+const devinAcpDiscovery = once(() => require("../providers/devin-acp") as DevinAcpDiscoveryModule);
+
+export interface DevinModelManagerConfig {
+	cliPath?: string;
+	cliArgs?: readonly string[];
+	cwd?: string;
+}
+
+/**
+ * Devin models come from the ACP session's own `model` config option: the
+ * account and enterprise allowlists are authoritative there, and ACP is the
+ * documented programmatic surface (`devin acp`). Discovery fails closed to "no
+ * models" when the CLI is missing or unauthenticated.
+ */
+export function devinModelManagerOptions(config: DevinModelManagerConfig = {}): ModelManagerOptions<"devin-acp"> {
+	return {
+		providerId: "devin",
+		fetchDynamicModels: () => devinAcpDiscovery().fetchDevinAcpModels(config),
 	};
 }
 

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -28,7 +28,7 @@ import type {
 	Usage,
 } from "../types";
 import { normalizeSystemPrompts } from "../utils";
-import { kCursorExecResolved } from "../utils/block-symbols";
+import { kProviderResolvedToolCall } from "../utils/block-symbols";
 import { AssistantMessageEventStream } from "../utils/event-stream";
 import { transportFailureFacts } from "../utils/fallback-transport";
 import { FirstEventTimeoutError, getStreamFirstEventTimeoutMs, getStreamIdleTimeoutMs } from "../utils/idle-iterator";
@@ -2384,7 +2384,7 @@ type ToolCallState = ToolCall & {
 	index: number;
 	partialJson?: string;
 	kind: "mcp" | "todo_write" | "native" | "cursor-exec";
-	[kCursorExecResolved]?: true;
+	[kProviderResolvedToolCall]?: true;
 };
 
 interface BlockState {
@@ -4320,7 +4320,7 @@ function synthesizeCursorExecToolCall(
 		arguments: cursorJsonSafeValue(args) as Record<string, unknown>,
 		index: output.content.length,
 		kind: "cursor-exec",
-		[kCursorExecResolved]: true,
+		[kProviderResolvedToolCall]: true,
 	};
 	output.content.push(block);
 	const contentIndex = output.content.length - 1;

--- a/packages/ai/src/providers/devin-acp.ts
+++ b/packages/ai/src/providers/devin-acp.ts
@@ -1,0 +1,983 @@
+/**
+ * Devin CLI provider — an ACP (Agent Client Protocol) client.
+ *
+ * Devin CLI exposes no raw model-inference endpoint. Its programmatic surface is
+ * `devin acp`: an Agent Client Protocol server over stdio that runs the whole
+ * agent (https://docs.devin.ai/cli/reference/commands#devin-acp). GJC therefore
+ * speaks ACP as the *client* and treats Devin as an agent-level provider:
+ *
+ * - GJC spawns `devin acp` and speaks ACP over the child's stdio.
+ * - One ACP session is reused for the lifetime of a GJC conversation, keyed by
+ *   `providerSessionId` and stored in `providerSessionState`; `close()` kills
+ *   the child process at session teardown.
+ * - Devin owns conversation history, so only the newest user turn is forwarded.
+ * - Devin executes its own tools. `session/update` tool calls are rendered as
+ *   display-only `toolCall` blocks and every turn terminates with
+ *   `stopReason: "stop"`, so GJC never re-executes a Devin tool call.
+ * - `session/request_permission` is answered from an explicit policy, never
+ *   silently: see {@link DevinAcpPermissionMode}.
+ *
+ * Boundary (documented in docs/devin-provider.md): GJC tools, skills, workflows,
+ * hooks, and permission prompts for GJC's own tools do not apply inside a Devin
+ * turn; GJC maintenance work (compaction, handoff, branch summaries) and utility
+ * one-shots are refused rather than forwarded to Devin; and Devin bills its own
+ * account/ACU usage.
+ */
+
+import {
+	type ToolCall as AcpToolCall,
+	type Agent,
+	type Client,
+	ClientSideConnection,
+	type ContentBlock,
+	type InitializeResponse,
+	ndJsonStream,
+	type PermissionOption,
+	type PromptCapabilities,
+	RequestError,
+	type RequestPermissionRequest,
+	type RequestPermissionResponse,
+	type SessionConfigOption,
+	type SessionNotification,
+	type StopReason,
+	type ToolCallUpdate,
+} from "@agentclientprotocol/sdk";
+import { VERSION } from "@gajae-code/utils";
+import type {
+	Api,
+	AssistantMessage,
+	AssistantMessageEventStream as AssistantMessageEventStreamType,
+	Context,
+	Model,
+	ProviderSessionState,
+	StreamOptions,
+	ToolCall,
+} from "../types";
+import { AssistantMessageEventStream } from "../utils/event-stream";
+import { getStreamFirstEventTimeoutMs, getStreamIdleTimeoutMs } from "../utils/idle-iterator";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Environment variable overriding the Devin executable GJC spawns. */
+export const DEVIN_ACP_CLI_ENV = "GJC_DEVIN_CLI_PATH";
+/** Environment variable selecting how GJC answers Devin permission requests. */
+export const DEVIN_ACP_PERMISSION_MODE_ENV = "GJC_DEVIN_PERMISSION_MODE";
+/** Executable that serves `devin acp` when nothing overrides it. */
+export const DEVIN_ACP_DEFAULT_CLI = "devin";
+/**
+ * Placeholder base URL. The ACP transport never issues an HTTP request, but a
+ * model record must carry a non-empty base URL through the model registry.
+ */
+export const DEVIN_ACP_BASE_URL = "acp://devin-cli";
+/**
+ * Conservative catalog defaults. ACP exposes no per-model token metadata, and
+ * GJC never sends conversation history to an ACP agent, so these values are
+ * display-only for this provider rather than a transport budget.
+ */
+export const DEVIN_ACP_CONTEXT_WINDOW = 200_000;
+export const DEVIN_ACP_MAX_TOKENS = 64_000;
+
+const DEVIN_ACP_CLIENT_NAME = "gajae-code";
+/** ACP `auth_required` JSON-RPC error code (`RequestError.authRequired()`). */
+const ACP_AUTH_REQUIRED_CODE = -32000;
+/** Cap on one tool-call `arguments` payload copied into a transcript message. */
+const ACP_TOOL_ARGUMENT_MAX_BYTES = 16 * 1024;
+const DEVIN_ACP_STDERR_TAIL_BYTES = 4 * 1024;
+
+// ---------------------------------------------------------------------------
+// Public provider surface
+// ---------------------------------------------------------------------------
+
+/**
+ * How GJC answers Devin's `session/request_permission` prompts.
+ *
+ * - `"allow"` (default) selects the least-permissive grant the agent offered
+ *   (`allow_once` before `allow_always`). Devin then runs that one action.
+ * - `"deny"` selects `reject_once` before `reject_always`.
+ *
+ * Neither mode escalates persistently on its own, and an unrecognized
+ * `GJC_DEVIN_PERMISSION_MODE` value fails closed to `"deny"`.
+ */
+export type DevinAcpPermissionMode = "allow" | "deny";
+
+/** A permission request Devin raised for one of its own tool calls. */
+export interface DevinAcpPermissionRequest {
+	sessionId: string;
+	toolCallId: string;
+	title: string;
+	kind?: string;
+	rawInput?: unknown;
+	options: ReadonlyArray<{ optionId: string; name: string; kind: string }>;
+}
+
+/** Selected option id, or `cancelled` to answer with ACP `outcome: cancelled`. */
+export type DevinAcpPermissionDecision = { optionId: string } | { cancelled: true };
+
+/** Explicit decision callback; replaces the built-in permission mode policy. */
+export type DevinAcpPermissionHandler = (
+	request: DevinAcpPermissionRequest,
+) => Promise<DevinAcpPermissionDecision> | DevinAcpPermissionDecision;
+
+/** Provider configuration threaded through `StreamOptions.devinAcp`. */
+export interface DevinAcpConfig {
+	/** Executable serving `devin acp`. Defaults to {@link DEVIN_ACP_CLI_ENV} or `devin`. */
+	cliPath?: string;
+	/** Extra argv inserted before the `acp` verb. */
+	cliArgs?: readonly string[];
+	/** Working directory for the agent process. Defaults to `process.cwd()`. */
+	cwd?: string;
+	/** Overrides the permission policy for this request. */
+	permissionMode?: DevinAcpPermissionMode;
+	/** Explicit permission decisions. When absent, the configured mode decides. */
+	permissionHandler?: DevinAcpPermissionHandler;
+}
+
+/**
+ * Devin ACP stream options. Every provider-specific field lives on
+ * `StreamOptions.devinAcp`; the alias exists so `ApiOptionsMap` can name this
+ * API's option type like every other API does.
+ */
+export type DevinAcpOptions = StreamOptions;
+
+// ---------------------------------------------------------------------------
+// Pure helpers (exported for the provider test suite)
+// ---------------------------------------------------------------------------
+
+/** Map an ACP tool kind to the display tool name GJC renders. */
+export function devinAcpDisplayToolName(kind: string | null | undefined, name?: string | null): string {
+	switch (kind) {
+		case "read":
+			return "read";
+		case "edit":
+			return "edit";
+		case "delete":
+			return "delete";
+		case "move":
+			return "move";
+		case "search":
+			return "grep";
+		case "execute":
+			return "bash";
+		case "think":
+			return "think";
+		case "fetch":
+			return "fetch";
+		case "switch_mode":
+			return "switch_mode";
+		default: {
+			const explicit = typeof name === "string" ? name.trim() : "";
+			return explicit.length > 0 ? explicit : "tool";
+		}
+	}
+}
+
+/**
+ * Copy a tool-call `rawInput` payload into a transcript-safe `arguments` record.
+ *
+ * ACP payloads arrive through JSON-RPC, so they are already JSON-shaped; this
+ * only wraps non-objects and refuses to stage an unbounded payload.
+ */
+export function devinAcpToolArguments(rawInput: unknown): Record<string, unknown> {
+	if (rawInput === undefined || rawInput === null) return {};
+	if (typeof rawInput !== "object" || Array.isArray(rawInput)) return { value: rawInput };
+	let serialized: string;
+	try {
+		serialized = JSON.stringify(rawInput);
+	} catch {
+		return {};
+	}
+	if (serialized === undefined || serialized.length > ACP_TOOL_ARGUMENT_MAX_BYTES) return { truncated: true };
+	return rawInput as Record<string, unknown>;
+}
+
+/** Map an ACP prompt stop reason onto GJC's assistant stop reason. */
+export function devinAcpStopReason(stopReason: StopReason): "stop" | "length" | "aborted" {
+	switch (stopReason) {
+		case "max_tokens":
+		case "max_turn_requests":
+			return "length";
+		case "cancelled":
+			return "aborted";
+		default:
+			return "stop";
+	}
+}
+
+/** Flatten ACP select option groups into `{ id, name }` model entries. */
+export function devinAcpSelectOptions(
+	options: Extract<SessionConfigOption, { type: "select" }>["options"],
+): Array<{ id: string; name: string }> {
+	const entries: Array<{ id: string; name: string }> = [];
+	for (const candidate of options) {
+		if ("group" in candidate) {
+			for (const grouped of candidate.options) entries.push({ id: grouped.value, name: grouped.name });
+			continue;
+		}
+		entries.push({ id: candidate.value, name: candidate.name });
+	}
+	return entries;
+}
+
+/** Select the least-permissive option matching the configured policy. */
+export function devinAcpSelectPermissionOption(
+	options: ReadonlyArray<PermissionOption>,
+	mode: DevinAcpPermissionMode,
+): { optionId: string } | null {
+	const preferred =
+		mode === "allow" ? (["allow_once", "allow_always"] as const) : (["reject_once", "reject_always"] as const);
+	for (const kind of preferred) {
+		const found = options.find(option => option.kind === kind);
+		if (found) return { optionId: found.optionId };
+	}
+	return null;
+}
+
+/** Resolve the permission policy from an explicit config value or the environment. */
+export function devinAcpResolvePermissionMode(
+	configured: DevinAcpPermissionMode | undefined,
+	env: Record<string, string | undefined> = process.env,
+): DevinAcpPermissionMode {
+	if (configured === "allow" || configured === "deny") return configured;
+	const raw = env[DEVIN_ACP_PERMISSION_MODE_ENV]?.trim().toLowerCase();
+	if (raw === undefined || raw.length === 0) return "allow";
+	return raw === "allow" ? "allow" : "deny";
+}
+
+/** Build the ACP prompt content blocks for the newest user turn. */
+export function devinAcpPromptBlocks(context: Context, supportsImages: boolean): ContentBlock[] {
+	const messages = Array.isArray(context.messages) ? context.messages : [];
+	let lastUser: (typeof messages)[number] | undefined;
+	for (let index = messages.length - 1; index >= 0; index--) {
+		if (messages[index]?.role === "user") {
+			lastUser = messages[index];
+			break;
+		}
+	}
+	if (lastUser?.role !== "user") return [];
+	const content =
+		typeof lastUser.content === "string" ? [{ type: "text" as const, text: lastUser.content }] : lastUser.content;
+	const blocks: ContentBlock[] = [];
+	for (const item of content) {
+		if (item.type === "text") {
+			if (item.text.length > 0) blocks.push({ type: "text", text: item.text });
+			continue;
+		}
+		if (item.type === "image") {
+			if (!supportsImages) {
+				blocks.push({
+					type: "text",
+					text: `[image attachment omitted: this Devin ACP agent does not advertise image prompt support (${item.mimeType})]`,
+				});
+				continue;
+			}
+			blocks.push({ type: "image", data: item.data, mimeType: item.mimeType });
+		}
+	}
+	return blocks;
+}
+
+// ---------------------------------------------------------------------------
+// Turn state
+// ---------------------------------------------------------------------------
+
+interface ActiveTurn {
+	stream: AssistantMessageEventStream;
+	output: AssistantMessage;
+	textIndex: number | null;
+	thinkingIndex: number | null;
+	toolCallIndexes: Map<string, number>;
+	settled: boolean;
+}
+
+function closeTextBlock(turn: ActiveTurn): void {
+	if (turn.textIndex === null) return;
+	const block = turn.output.content[turn.textIndex];
+	const text = block?.type === "text" ? block.text : "";
+	turn.stream.push({ type: "text_end", contentIndex: turn.textIndex, content: text, partial: turn.output });
+	turn.textIndex = null;
+}
+
+function closeThinkingBlock(turn: ActiveTurn): void {
+	if (turn.thinkingIndex === null) return;
+	const block = turn.output.content[turn.thinkingIndex];
+	const thinking = block?.type === "thinking" ? block.thinking : "";
+	turn.stream.push({
+		type: "thinking_end",
+		contentIndex: turn.thinkingIndex,
+		content: thinking,
+		partial: turn.output,
+	});
+	turn.thinkingIndex = null;
+}
+
+function appendTextDelta(turn: ActiveTurn, text: string): void {
+	if (text.length === 0) return;
+	closeThinkingBlock(turn);
+	if (turn.textIndex === null) {
+		const index = turn.output.content.length;
+		turn.output.content.push({ type: "text", text: "" });
+		turn.textIndex = index;
+		turn.stream.push({ type: "text_start", contentIndex: index, partial: turn.output });
+	}
+	const block = turn.output.content[turn.textIndex];
+	if (block?.type !== "text") return;
+	block.text += text;
+	turn.stream.push({ type: "text_delta", contentIndex: turn.textIndex, delta: text, partial: turn.output });
+}
+
+function appendThinkingDelta(turn: ActiveTurn, text: string): void {
+	if (text.length === 0) return;
+	closeTextBlock(turn);
+	if (turn.thinkingIndex === null) {
+		const index = turn.output.content.length;
+		turn.output.content.push({ type: "thinking", thinking: "" });
+		turn.thinkingIndex = index;
+		turn.stream.push({ type: "thinking_start", contentIndex: index, partial: turn.output });
+	}
+	const block = turn.output.content[turn.thinkingIndex];
+	if (block?.type !== "thinking") return;
+	block.thinking += text;
+	turn.stream.push({ type: "thinking_delta", contentIndex: turn.thinkingIndex, delta: text, partial: turn.output });
+}
+
+/** Metadata GJC attaches to a tool call that ran inside the Devin agent. */
+function acpAnnotation(toolCallId: string, kind?: string | null, status?: string | null): Record<string, unknown> {
+	return {
+		toolCallId,
+		...(kind ? { kind } : {}),
+		...(status ? { status } : {}),
+	};
+}
+
+function upsertToolCall(turn: ActiveTurn, toolCall: AcpToolCall | ToolCallUpdate, existingOnly: boolean): void {
+	closeTextBlock(turn);
+	closeThinkingBlock(turn);
+	const kind = "kind" in toolCall ? toolCall.kind : undefined;
+	const status = "status" in toolCall ? toolCall.status : undefined;
+	const title = toolCall.title ?? "";
+	const index = turn.toolCallIndexes.get(toolCall.toolCallId);
+	if (index !== undefined) {
+		const block = turn.output.content[index];
+		if (block?.type !== "toolCall") return;
+		const previous = block.arguments._acp as Record<string, unknown> | undefined;
+		// ACP tool-call updates carry only changed fields, so merge with what the
+		// opening `tool_call` already recorded instead of dropping it.
+		block.arguments = {
+			...block.arguments,
+			_acp: {
+				...previous,
+				...(kind ? { kind } : {}),
+				...(status ? { status } : {}),
+			},
+		};
+		if (title.length > 0) block.intent = title;
+		turn.stream.push({ type: "toolcall_end", contentIndex: index, toolCall: block, partial: turn.output });
+		return;
+	}
+	if (existingOnly) return;
+	const block: ToolCall = {
+		type: "toolCall",
+		id: toolCall.toolCallId,
+		name: devinAcpDisplayToolName(kind, "name" in toolCall ? toolCall.name : undefined),
+		arguments: {
+			...devinAcpToolArguments("rawInput" in toolCall ? toolCall.rawInput : undefined),
+			_acp: acpAnnotation(toolCall.toolCallId, kind, status),
+		},
+		...(title.length > 0 ? { intent: title } : {}),
+	};
+	const created = turn.output.content.length;
+	turn.output.content.push(block);
+	turn.toolCallIndexes.set(toolCall.toolCallId, created);
+	turn.stream.push({ type: "toolcall_start", contentIndex: created, partial: turn.output });
+	turn.stream.push({ type: "toolcall_end", contentIndex: created, toolCall: block, partial: turn.output });
+}
+
+function applySessionUpdate(turn: ActiveTurn, update: SessionNotification["update"]): void {
+	switch (update.sessionUpdate) {
+		case "agent_message_chunk":
+			if (update.content.type === "text") appendTextDelta(turn, update.content.text);
+			return;
+		case "agent_thought_chunk":
+			if (update.content.type === "text") appendThinkingDelta(turn, update.content.text);
+			return;
+		case "tool_call":
+			upsertToolCall(turn, update, false);
+			return;
+		case "tool_call_update":
+			upsertToolCall(turn, update, true);
+			return;
+		default:
+			// user_message_chunk echoes our own prompt; plan/plan_update/plan_removed,
+			// available_commands_update, current_mode_update, config_option_update,
+			// session_info_update and usage_update carry no GJC-visible surface. Unknown
+			// update kinds are never assumed safe to render into the transcript.
+			return;
+	}
+}
+
+function settleTurn(turn: ActiveTurn, reason: "done" | "error" | "aborted"): void {
+	if (turn.settled) return;
+	turn.settled = true;
+	if (reason === "done") {
+		turn.stream.push({
+			type: "done",
+			reason: turn.output.stopReason === "length" ? "length" : "stop",
+			message: turn.output,
+		});
+	} else {
+		turn.stream.push({ type: "error", reason, error: turn.output });
+	}
+	turn.stream.end();
+}
+
+// ---------------------------------------------------------------------------
+// ACP bridge
+// ---------------------------------------------------------------------------
+
+interface DevinAcpSessionHandle {
+	id: string;
+	configOptions: SessionConfigOption[] | null;
+}
+
+function resolveSessionId(value: string | undefined): string | undefined {
+	if (typeof value !== "string") return undefined;
+	const trimmed = value.trim();
+	return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function errorMessage(error: unknown): string {
+	if (error instanceof Error && error.message.length > 0) return error.message;
+	return String(error);
+}
+
+function isAuthRequired(error: unknown): boolean {
+	return error instanceof RequestError && error.code === ACP_AUTH_REQUIRED_CODE;
+}
+
+/**
+ * Devin turns are interactive session turns only.
+ *
+ * GJC routes several non-turn requests through a model provider — context
+ * compaction, handoff generation, session-title generation, branch summaries —
+ * and each of those would otherwise be sent to Devin as a real (billed) agent
+ * prompt that cannot answer it. They are refused up front with an actionable
+ * message instead.
+ */
+function refuseNonInteractiveTurn(options: DevinAcpOptions | undefined): void {
+	if (options?.maintenanceCall || options?.initiatorOverride === "agent") {
+		throw new Error(
+			"Devin ACP cannot serve GJC maintenance calls (context compaction, handoff, branch summaries): it is an agent, not a text model. Switch to a non-Devin model for that operation — Devin manages its own conversation context, so GJC-side compaction is not needed for a Devin turn.",
+		);
+	}
+	if (!resolveSessionId(options?.providerSessionId) && !resolveSessionId(options?.sessionId)) {
+		throw new Error(
+			"Devin ACP turns require a session identity (providerSessionId). GJC utility one-shots such as session-title generation are not supported on a Devin model.",
+		);
+	}
+}
+
+const DEVIN_ACP_INSTALL_HINT =
+	"Install Devin CLI (https://docs.devin.ai/cli) and run `devin auth login`, or point GJC_DEVIN_CLI_PATH at the executable.";
+
+/** Turn a launch failure (missing binary, permissions) into an actionable message. */
+function spawnFailureMessage(error: unknown): string {
+	const base = errorMessage(error);
+	return /ENOENT|not found|EACCES/i.test(base) ? `${base} ${DEVIN_ACP_INSTALL_HINT}` : base;
+}
+
+class DevinAcpBridge implements ProviderSessionState {
+	readonly #proc: Bun.Subprocess<"pipe", "pipe", "pipe">;
+	readonly #connection: ClientSideConnection;
+	readonly #cwd: string;
+	readonly #permissionMode: DevinAcpPermissionMode;
+	readonly #permissionHandler: DevinAcpPermissionHandler | undefined;
+	#init: Promise<InitializeResponse> | undefined;
+	#session: Promise<DevinAcpSessionHandle> | undefined;
+	#promptCapabilities: PromptCapabilities | undefined;
+	#turn: ActiveTurn | null = null;
+	#stderrTail = "";
+	#exitError: Error | null = null;
+	#disposed = false;
+
+	constructor(config: {
+		argv: readonly string[];
+		cwd: string;
+		permissionMode: DevinAcpPermissionMode;
+		permissionHandler?: DevinAcpPermissionHandler;
+	}) {
+		this.#cwd = config.cwd;
+		this.#permissionMode = config.permissionMode;
+		this.#permissionHandler = config.permissionHandler;
+		this.#proc = Bun.spawn([...config.argv], {
+			cwd: config.cwd,
+			stdin: "pipe",
+			stdout: "pipe",
+			stderr: "pipe",
+			env: process.env,
+		});
+		const sink = this.#proc.stdin;
+		const output = new WritableStream<Uint8Array>({
+			async write(chunk) {
+				sink.write(chunk);
+				await sink.flush();
+			},
+			async close() {
+				await sink.end();
+			},
+			async abort() {
+				try {
+					await sink.end();
+				} catch {
+					// The child already closed its end of the pipe.
+				}
+			},
+		});
+		this.#connection = new ClientSideConnection(
+			(_agent: Agent) => this.#client(),
+			ndJsonStream(output, this.#proc.stdout),
+		);
+		void this.#drainStderr();
+		void this.#watchExit();
+	}
+
+	get exitError(): Error | null {
+		return this.#exitFailure();
+	}
+
+	/**
+	 * Terminal child-process failure, if any. Read from the live exit code as well
+	 * as the exit watcher so a turn that races the watcher still reports the real
+	 * cause instead of a generic transport error.
+	 */
+	#exitFailure(): Error | null {
+		if (this.#exitError) return this.#exitError;
+		const code = this.#proc.exitCode;
+		if (code === null) return null;
+		const tail = this.#stderrTail.trim();
+		return new Error(`Devin ACP process exited with code ${code}${tail.length > 0 ? `: ${tail}` : "."}`);
+	}
+
+	get supportsImages(): boolean {
+		return this.#promptCapabilities?.image === true;
+	}
+
+	#client(): Client {
+		return {
+			requestPermission: params => this.#handlePermission(params),
+			sessionUpdate: notification => {
+				const turn = this.#turn;
+				if (!turn || turn.settled) return;
+				applySessionUpdate(turn, notification.update);
+			},
+		};
+	}
+
+	async #drainStderr(): Promise<void> {
+		try {
+			const decoder = new TextDecoder();
+			for await (const chunk of this.#proc.stderr as ReadableStream<Uint8Array>) {
+				this.#stderrTail = (this.#stderrTail + decoder.decode(chunk, { stream: true })).slice(
+					-DEVIN_ACP_STDERR_TAIL_BYTES,
+				);
+			}
+		} catch {
+			// Diagnostics only; the protocol path reports real failures.
+		}
+	}
+
+	async #watchExit(): Promise<void> {
+		await this.#proc.exited;
+		if (this.#disposed) return;
+		this.#disposed = true;
+		this.#exitError = this.#exitFailure();
+		const turn = this.#turn;
+		if (turn && !turn.settled) {
+			turn.output.stopReason = "error";
+			turn.output.errorMessage = this.#exitError?.message ?? "Devin ACP process exited.";
+			settleTurn(turn, "error");
+		}
+	}
+
+	async #ensureInitialized(): Promise<InitializeResponse> {
+		this.#init ??= this.#connection.initialize({
+			protocolVersion: 1,
+			clientCapabilities: { fs: {}, terminal: false },
+			clientInfo: { name: DEVIN_ACP_CLIENT_NAME, version: VERSION },
+		});
+		try {
+			const response = await this.#init;
+			this.#promptCapabilities = response.agentCapabilities?.promptCapabilities ?? undefined;
+			return response;
+		} catch (error) {
+			this.#init = undefined;
+			throw error;
+		}
+	}
+
+	async #ensureSession(): Promise<DevinAcpSessionHandle> {
+		this.#session ??= (async () => {
+			await this.#ensureInitialized();
+			try {
+				const response = await this.#connection.newSession({ cwd: this.#cwd, mcpServers: [] });
+				return { id: response.sessionId, configOptions: response.configOptions ?? null };
+			} catch (error) {
+				if (isAuthRequired(error)) {
+					throw new Error(
+						"Devin CLI is not authenticated. Run `devin auth login` (or set WINDSURF_API_KEY for enterprise builds) and retry.",
+					);
+				}
+				throw error;
+			}
+		})();
+		try {
+			return await this.#session;
+		} catch (error) {
+			this.#session = undefined;
+			throw error;
+		}
+	}
+
+	#modelConfigOption(session: DevinAcpSessionHandle): Extract<SessionConfigOption, { type: "select" }> | undefined {
+		return session.configOptions?.find(
+			(candidate): candidate is Extract<SessionConfigOption, { type: "select" }> =>
+				candidate.category === "model" && candidate.type === "select",
+		);
+	}
+
+	async listModels(): Promise<Array<{ id: string; name: string }>> {
+		const session = await this.#ensureSession();
+		const option = this.#modelConfigOption(session);
+		return option ? devinAcpSelectOptions(option.options) : [];
+	}
+
+	/**
+	 * Apply the GJC-selected model to the ACP session.
+	 *
+	 * When the session advertises a model selector, a model the account cannot
+	 * use fails loudly instead of silently running a different (possibly more
+	 * expensive) model. Agents without a model selector keep their own default.
+	 */
+	async #selectModel(modelId: string): Promise<void> {
+		if (modelId.length === 0) return;
+		const session = await this.#ensureSession();
+		const option = this.#modelConfigOption(session);
+		if (!option) return;
+		if (option.currentValue === modelId) return;
+		const available = devinAcpSelectOptions(option.options).some(entry => entry.id === modelId);
+		if (!available) {
+			throw new Error(
+				`Devin account does not offer model "${modelId}". Run \`devin models list\` or pick a discovered Devin model.`,
+			);
+		}
+		const response = await this.#connection.setSessionConfigOption({
+			sessionId: session.id,
+			configId: option.id,
+			value: modelId,
+		});
+		session.configOptions = response.configOptions;
+	}
+
+	async #handlePermission(params: RequestPermissionRequest): Promise<RequestPermissionResponse> {
+		const request: DevinAcpPermissionRequest = {
+			sessionId: params.sessionId,
+			toolCallId: params.toolCall.toolCallId,
+			title: params.toolCall.title ?? "",
+			...(params.toolCall.kind ? { kind: params.toolCall.kind } : {}),
+			...(params.toolCall.rawInput !== undefined ? { rawInput: params.toolCall.rawInput } : {}),
+			options: params.options.map(option => ({ optionId: option.optionId, name: option.name, kind: option.kind })),
+		};
+		let decision: DevinAcpPermissionDecision | null = null;
+		if (this.#permissionHandler) {
+			try {
+				decision = await this.#permissionHandler(request);
+			} catch {
+				// A broken handler must never become an implicit approval.
+				decision = null;
+			}
+		} else {
+			decision = devinAcpSelectPermissionOption(params.options, this.#permissionMode);
+		}
+		if (!decision || "cancelled" in decision) return { outcome: { outcome: "cancelled" } };
+		if (!params.options.some(option => option.optionId === decision.optionId))
+			return { outcome: { outcome: "cancelled" } };
+		return { outcome: { outcome: "selected", optionId: decision.optionId } };
+	}
+
+	/**
+	 * Start one ACP prompt turn. Returns synchronously with the caller's stream;
+	 * the returned promise settles when the turn finishes.
+	 *
+	 * One ACP session carries one turn at a time: a concurrent call would
+	 * interleave two transcripts into the same session.
+	 */
+	beginTurn(
+		turn: ActiveTurn,
+		model: Model<"devin-acp">,
+		context: Context,
+		options: DevinAcpOptions | undefined,
+	): Promise<void> {
+		const active = this.#turn;
+		if (active && !active.settled) {
+			turn.output.stopReason = "error";
+			turn.output.errorMessage = "A Devin ACP turn is already running on this session.";
+			settleTurn(turn, "error");
+			return Promise.resolve();
+		}
+		this.#turn = turn;
+		return this.#runTurn(turn, model, context, options);
+	}
+
+	async #runTurn(
+		turn: ActiveTurn,
+		model: Model<"devin-acp">,
+		context: Context,
+		options: DevinAcpOptions | undefined,
+	): Promise<void> {
+		const { output } = turn;
+		try {
+			refuseNonInteractiveTurn(options);
+		} catch (error) {
+			output.stopReason = "error";
+			output.errorMessage = errorMessage(error);
+			settleTurn(turn, "error");
+			if (this.#turn === turn) this.#turn = null;
+			return;
+		}
+		const startedAt = Date.now();
+		const idleTimeoutMs = options?.streamIdleTimeoutMs ?? getStreamIdleTimeoutMs();
+		const firstEventTimeoutMs = options?.streamFirstEventTimeoutMs ?? getStreamFirstEventTimeoutMs(idleTimeoutMs);
+		let watchdog: ReturnType<typeof setTimeout> | undefined;
+		const arm = (budgetMs: number | undefined, label: string) => {
+			if (watchdog !== undefined) clearTimeout(watchdog);
+			if (budgetMs === undefined || !Number.isFinite(budgetMs) || budgetMs <= 0) return;
+			watchdog = setTimeout(() => {
+				void this.cancelTurn(new Error(`Devin ACP ${label} timed out after ${budgetMs}ms`));
+			}, budgetMs);
+		};
+		const onAbort = () => {
+			void this.cancelTurn();
+		};
+		options?.signal?.addEventListener("abort", onAbort, { once: true });
+		try {
+			const exited = this.#exitFailure();
+			if (exited) throw exited;
+			if (options?.signal?.aborted) {
+				output.stopReason = "aborted";
+				settleTurn(turn, "aborted");
+				return;
+			}
+			arm(firstEventTimeoutMs, "first-agent-update");
+			const session = await this.#ensureSession();
+			await this.#selectModel(model.id);
+			const blocks = devinAcpPromptBlocks(context, this.supportsImages);
+			if (blocks.length === 0) {
+				throw new Error(
+					"Devin ACP turns require a user message to forward; an empty prompt is not sent to the agent.",
+				);
+			}
+			arm(idleTimeoutMs, "agent-update");
+			const response = await this.#connection.prompt({ sessionId: session.id, prompt: blocks });
+			closeTextBlock(turn);
+			closeThinkingBlock(turn);
+			if (options?.signal?.aborted) {
+				output.stopReason = "aborted";
+				settleTurn(turn, "aborted");
+				return;
+			}
+			output.stopReason = devinAcpStopReason(response.stopReason);
+			if (output.stopReason === "length") {
+				output.errorMessage = "Devin ended the turn at its own turn or token limit.";
+			}
+			output.duration = Date.now() - startedAt;
+			settleTurn(turn, "done");
+		} catch (error) {
+			closeTextBlock(turn);
+			closeThinkingBlock(turn);
+			const mapped = (await this.#settledExitFailure()) ?? error;
+			output.stopReason = options?.signal?.aborted ? "aborted" : "error";
+			output.errorMessage = errorMessage(mapped);
+			settleTurn(turn, output.stopReason === "aborted" ? "aborted" : "error");
+		} finally {
+			if (watchdog !== undefined) clearTimeout(watchdog);
+			options?.signal?.removeEventListener("abort", onAbort);
+			if (this.#turn === turn) this.#turn = null;
+		}
+	}
+
+	async #settledExitFailure(): Promise<Error | null> {
+		const immediate = this.#exitFailure();
+		if (immediate) return immediate;
+		// The ACP transport can report a closed connection before the exit watcher
+		// observes the child's status; give the process a bounded moment to settle so
+		// the turn reports the real cause (exit code and stderr tail).
+		await Promise.race([this.#proc.exited, Bun.sleep(250)]);
+		return this.#exitFailure();
+	}
+
+	/** Cancel the in-flight turn: ACP `session/cancel` first, then settle the stream. */
+	async cancelTurn(reason?: Error): Promise<void> {
+		const turn = this.#turn;
+		const session = await this.#session?.catch(() => undefined);
+		if (session) {
+			try {
+				await this.#connection.cancel({ sessionId: session.id });
+			} catch {
+				// The agent may already have finished; the turn settles below regardless.
+			}
+		}
+		if (turn && !turn.settled) {
+			turn.output.stopReason = reason ? "error" : "aborted";
+			if (reason) turn.output.errorMessage = errorMessage(reason);
+			settleTurn(turn, reason ? "error" : "aborted");
+		}
+	}
+
+	close(): void {
+		if (this.#disposed) return;
+		this.#disposed = true;
+		const turn = this.#turn;
+		if (turn && !turn.settled) {
+			turn.output.stopReason = "aborted";
+			settleTurn(turn, "aborted");
+		}
+		try {
+			this.#proc.kill();
+		} catch {
+			// Already exited.
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Provider entry points
+// ---------------------------------------------------------------------------
+
+function createTurn(model: Model<"devin-acp">): ActiveTurn {
+	const stream = new AssistantMessageEventStream();
+	const output: AssistantMessage = {
+		role: "assistant",
+		content: [],
+		api: "devin-acp" as Api,
+		provider: model.provider,
+		model: model.id,
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+	return { stream, output, textIndex: null, thinkingIndex: null, toolCallIndexes: new Map(), settled: false };
+}
+
+/**
+ * Resolve (or create) the ACP bridge for this conversation.
+ *
+ * A bridge is stored in the caller-owned `providerSessionState` map so its child
+ * process is killed by GJC's session teardown. Without that map the caller gets a
+ * disposable bridge, and `streamDevinAcp` closes it when the turn settles.
+ */
+function resolveBridge(config: { streamOptions: DevinAcpOptions | undefined; conversationId: string | undefined }): {
+	bridge: DevinAcpBridge;
+	owned: boolean;
+} {
+	const acp = config.streamOptions?.devinAcp;
+	const cliPath = acp?.cliPath ?? process.env[DEVIN_ACP_CLI_ENV]?.trim() ?? DEVIN_ACP_DEFAULT_CLI;
+	const argv = [cliPath, ...(acp?.cliArgs ?? []), "acp"];
+	const cwd = acp?.cwd ?? process.cwd();
+	const spawn = () =>
+		new DevinAcpBridge({
+			argv,
+			cwd,
+			permissionMode: devinAcpResolvePermissionMode(acp?.permissionMode),
+			permissionHandler: acp?.permissionHandler,
+		});
+	const stateMap = config.streamOptions?.providerSessionState;
+	if (!stateMap) return { bridge: spawn(), owned: true };
+	const key = `devin-acp:${config.conversationId ?? "ephemeral"}:${argv.join("\u0000")}`;
+	const existing = stateMap.get(key);
+	if (existing instanceof DevinAcpBridge && !existing.exitError) return { bridge: existing, owned: false };
+	if (existing) existing.close();
+	const created = spawn();
+	stateMap.set(key, created);
+	return { bridge: created, owned: false };
+}
+
+export const streamDevinAcp: (
+	model: Model<"devin-acp">,
+	context: Context,
+	options?: DevinAcpOptions,
+) => AssistantMessageEventStreamType = (model, context, options) => {
+	try {
+		const conversationId = resolveSessionId(options?.providerSessionId) ?? resolveSessionId(options?.sessionId);
+		const { bridge, owned } = resolveBridge({ streamOptions: options, conversationId });
+		const turn = createTurn(model);
+		const settled = bridge.beginTurn(turn, model, context, options);
+		if (owned) void settled.finally(() => bridge.close());
+		return turn.stream;
+	} catch (error) {
+		// Launch failures must surface as a stream error, never as a thrown
+		// provider call: callers (and the lazy dispatch wrapper) expect a stream.
+		const turn = createTurn(model);
+		turn.output.stopReason = "error";
+		turn.output.errorMessage = spawnFailureMessage(error);
+		settleTurn(turn, "error");
+		return turn.stream;
+	}
+};
+
+/**
+ * Discover the account's Devin models over ACP.
+ *
+ * `devin models list --format json` is deliberately not parsed: its schema is
+ * undocumented, while the session's own `model` config option is the
+ * authoritative ACP surface for the authenticated account and enterprise
+ * allowlists. Returns `null` when the CLI is missing, unauthenticated, or the
+ * agent advertises no model selector — which the model registry treats as
+ * "no dynamic models".
+ */
+export async function fetchDevinAcpModels(
+	config: { cliPath?: string; cliArgs?: readonly string[]; cwd?: string } = {},
+): Promise<Model<"devin-acp">[] | null> {
+	const cliPath = config.cliPath ?? process.env[DEVIN_ACP_CLI_ENV]?.trim() ?? DEVIN_ACP_DEFAULT_CLI;
+	const bridge = (() => {
+		try {
+			return new DevinAcpBridge({
+				argv: [cliPath, ...(config.cliArgs ?? []), "acp"],
+				cwd: config.cwd ?? process.cwd(),
+				permissionMode: "deny",
+			});
+		} catch {
+			// A missing or unlaunchable CLI is "no discovered models", not a failure.
+			return null;
+		}
+	})();
+	if (!bridge) return null;
+	try {
+		const models = await bridge.listModels();
+		if (models.length === 0) return null;
+		const input = bridge.supportsImages ? (["text", "image"] as const) : (["text"] as const);
+		return models.map(entry => ({
+			id: entry.id,
+			name: entry.name,
+			api: "devin-acp",
+			provider: "devin",
+			baseUrl: DEVIN_ACP_BASE_URL,
+			reasoning: false,
+			input: [...input],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: DEVIN_ACP_CONTEXT_WINDOW,
+			maxTokens: DEVIN_ACP_MAX_TOKENS,
+		}));
+	} catch {
+		return null;
+	} finally {
+		bridge.close();
+	}
+}

--- a/packages/ai/src/providers/devin-acp.ts
+++ b/packages/ai/src/providers/devin-acp.ts
@@ -53,6 +53,7 @@ import type {
 	StreamOptions,
 	ToolCall,
 } from "../types";
+import { kProviderResolvedToolCall, type ProviderResolvedCarrier } from "../utils/block-symbols";
 import { AssistantMessageEventStream } from "../utils/event-stream";
 import { getStreamFirstEventTimeoutMs, getStreamIdleTimeoutMs } from "../utils/idle-iterator";
 
@@ -93,8 +94,8 @@ const DEVIN_ACP_STDERR_TAIL_BYTES = 4 * 1024;
 /**
  * How GJC answers Devin's `session/request_permission` prompts.
  *
- * - `"allow"` (default) selects the least-permissive grant the agent offered
- *   (`allow_once` before `allow_always`). Devin then runs that one action.
+ * - `"allow"` (default) selects `allow_once`. A request that offers no
+ *   `allow_once` is cancelled: GJC never grants a persistent approval on its own.
  * - `"deny"` selects `reject_once` before `reject_always`.
  *
  * Neither mode escalates persistently on its own, and an unrecognized
@@ -220,13 +221,19 @@ export function devinAcpSelectOptions(
 	return entries;
 }
 
-/** Select the least-permissive option matching the configured policy. */
+/**
+ * Select the option matching the configured policy.
+ *
+ * `allow` grants a single action and never a persistent one: when the agent
+ * offers no `allow_once`, the request is cancelled rather than escalated to
+ * `allow_always`. `deny` may fall back to `reject_always`, because a persistent
+ * refusal only reduces what the agent may do.
+ */
 export function devinAcpSelectPermissionOption(
 	options: ReadonlyArray<PermissionOption>,
 	mode: DevinAcpPermissionMode,
 ): { optionId: string } | null {
-	const preferred =
-		mode === "allow" ? (["allow_once", "allow_always"] as const) : (["reject_once", "reject_always"] as const);
+	const preferred = mode === "allow" ? (["allow_once"] as const) : (["reject_once", "reject_always"] as const);
 	for (const kind of preferred) {
 		const found = options.find(option => option.kind === kind);
 		if (found) return { optionId: found.optionId };
@@ -377,7 +384,7 @@ function upsertToolCall(turn: ActiveTurn, toolCall: AcpToolCall | ToolCallUpdate
 		return;
 	}
 	if (existingOnly) return;
-	const block: ToolCall = {
+	const block: ToolCall & ProviderResolvedCarrier = {
 		type: "toolCall",
 		id: toolCall.toolCallId,
 		name: devinAcpDisplayToolName(kind, "name" in toolCall ? toolCall.name : undefined),
@@ -386,6 +393,9 @@ function upsertToolCall(turn: ActiveTurn, toolCall: AcpToolCall | ToolCallUpdate
 			_acp: acpAnnotation(toolCall.toolCallId, kind, status),
 		},
 		...(title.length > 0 ? { intent: title } : {}),
+		// The agent already ran this call. The marker is what stops the GJC agent
+		// loop from dispatching it to a local tool of the same display name.
+		[kProviderResolvedToolCall]: true,
 	};
 	const created = turn.output.content.length;
 	turn.output.content.push(block);

--- a/packages/ai/src/providers/devin-acp.ts
+++ b/packages/ai/src/providers/devin-acp.ts
@@ -86,6 +86,10 @@ const ACP_AUTH_REQUIRED_CODE = -32000;
 /** Cap on one tool-call `arguments` payload copied into a transcript message. */
 const ACP_TOOL_ARGUMENT_MAX_BYTES = 16 * 1024;
 const DEVIN_ACP_STDERR_TAIL_BYTES = 4 * 1024;
+/** Bound on waiting for a live ACP session before a cancellation settles anyway. */
+const DEVIN_ACP_CANCEL_DELIVERY_GRACE_MS = 250;
+/** Bound on waiting for a cancelled agent to acknowledge before a child is reaped. */
+const DEVIN_ACP_CANCEL_ACK_GRACE_MS = 500;
 
 // ---------------------------------------------------------------------------
 // Public provider surface
@@ -296,6 +300,18 @@ interface ActiveTurn {
 	thinkingIndex: number | null;
 	toolCallIndexes: Map<string, number>;
 	settled: boolean;
+	/**
+	 * Resolved by `cancelTurn` so a cancellation that races the ACP handshake stops
+	 * the turn instead of waiting for a session that may never be created.
+	 */
+	cancellation: Promise<void>;
+	requestCancellation: () => void;
+	/**
+	 * Re-arms this turn's idle budget; set only while this turn's ACP prompt is in
+	 * flight. It lives on the turn, not the bridge, so a stale turn can never
+	 * re-arm — or cancel — the turn that replaced it.
+	 */
+	rearmIdle: (() => void) | undefined;
 }
 
 function closeTextBlock(turn: ActiveTurn): void {
@@ -501,8 +517,9 @@ class DevinAcpBridge implements ProviderSessionState {
 	readonly #proc: Bun.Subprocess<"pipe", "pipe", "pipe">;
 	readonly #connection: ClientSideConnection;
 	readonly #cwd: string;
-	readonly #permissionMode: DevinAcpPermissionMode;
-	readonly #permissionHandler: DevinAcpPermissionHandler | undefined;
+	/** Re-applied per turn: the bridge is cached, the policy is not. */
+	#permissionMode: DevinAcpPermissionMode;
+	#permissionHandler: DevinAcpPermissionHandler | undefined;
 	#init: Promise<InitializeResponse> | undefined;
 	#session: Promise<DevinAcpSessionHandle> | undefined;
 	#promptCapabilities: PromptCapabilities | undefined;
@@ -579,6 +596,9 @@ class DevinAcpBridge implements ProviderSessionState {
 			sessionUpdate: notification => {
 				const turn = this.#turn;
 				if (!turn || turn.settled) return;
+				// The idle budget is the gap between agent updates, not a whole-turn wall
+				// clock: a long but active Devin turn must never be killed by it.
+				turn.rearmIdle?.();
 				applySessionUpdate(turn, notification.update);
 			},
 		};
@@ -755,6 +775,11 @@ class DevinAcpBridge implements ProviderSessionState {
 			if (this.#turn === turn) this.#turn = null;
 			return;
 		}
+		// The bridge is cached per conversation, so the permission policy is applied
+		// per turn: a later turn that tightens the mode, or supplies its own handler,
+		// must not inherit whichever turn happened to create the child.
+		this.#permissionMode = devinAcpResolvePermissionMode(options?.devinAcp?.permissionMode);
+		this.#permissionHandler = options?.devinAcp?.permissionHandler;
 		const startedAt = Date.now();
 		const idleTimeoutMs = options?.streamIdleTimeoutMs ?? getStreamIdleTimeoutMs();
 		const firstEventTimeoutMs = options?.streamFirstEventTimeoutMs ?? getStreamFirstEventTimeoutMs(idleTimeoutMs);
@@ -779,8 +804,15 @@ class DevinAcpBridge implements ProviderSessionState {
 				return;
 			}
 			arm(firstEventTimeoutMs, "first-agent-update");
-			const session = await this.#ensureSession();
+			// Race the handshake against cancellation: a `devin acp` child that never
+			// answers `initialize`/`session/new` must not hang the turn (or leak the
+			// child) after the caller already cancelled it.
+			const handshake = this.#ensureSession();
+			void handshake.catch(() => undefined);
+			const session = await Promise.race([handshake, turn.cancellation.then(() => null)]);
+			if (session === null || turn.settled) return;
 			await this.#selectModel(model.id);
+			if (turn.settled) return;
 			const blocks = devinAcpPromptBlocks(context, this.supportsImages);
 			if (blocks.length === 0) {
 				throw new Error(
@@ -788,7 +820,23 @@ class DevinAcpBridge implements ProviderSessionState {
 				);
 			}
 			arm(idleTimeoutMs, "agent-update");
-			const response = await this.#connection.prompt({ sessionId: session.id, prompt: blocks });
+			turn.rearmIdle = () => arm(idleTimeoutMs, "agent-update");
+			const promptCall = this.#connection.prompt({ sessionId: session.id, prompt: blocks });
+			// A child that never answers `session/prompt` must not park `#runTurn` forever,
+			// or a disposable bridge could never be reaped.
+			void promptCall.catch(() => undefined);
+			const response = await Promise.race([
+				promptCall,
+				turn.cancellation.then(async () => {
+					// Grace for the cancelled agent to answer `session/cancel` before a
+					// disposable child is reaped; a hung agent still unwinds after this bound.
+					await Bun.sleep(DEVIN_ACP_CANCEL_ACK_GRACE_MS);
+					return null;
+				}),
+			]);
+			// A cancel that raced the prompt settles the stream first; never rewrite the
+			// terminal state of a turn that has already been published.
+			if (response === null || turn.settled) return;
 			closeTextBlock(turn);
 			closeThinkingBlock(turn);
 			if (options?.signal?.aborted) {
@@ -806,11 +854,15 @@ class DevinAcpBridge implements ProviderSessionState {
 			closeTextBlock(turn);
 			closeThinkingBlock(turn);
 			const mapped = (await this.#settledExitFailure()) ?? error;
-			output.stopReason = options?.signal?.aborted ? "aborted" : "error";
-			output.errorMessage = errorMessage(mapped);
-			settleTurn(turn, output.stopReason === "aborted" ? "aborted" : "error");
+			// A turn already published by a racing cancel keeps its terminal state.
+			if (!turn.settled) {
+				output.stopReason = options?.signal?.aborted ? "aborted" : "error";
+				output.errorMessage = errorMessage(mapped);
+				settleTurn(turn, output.stopReason === "aborted" ? "aborted" : "error");
+			}
 		} finally {
 			if (watchdog !== undefined) clearTimeout(watchdog);
+			turn.rearmIdle = undefined;
 			options?.signal?.removeEventListener("abort", onAbort);
 			if (this.#turn === turn) this.#turn = null;
 		}
@@ -826,10 +878,13 @@ class DevinAcpBridge implements ProviderSessionState {
 		return this.#exitFailure();
 	}
 
-	/** Cancel the in-flight turn: ACP `session/cancel` first, then settle the stream. */
+	/** Cancel the in-flight turn: notify the agent best-effort, then settle the stream. */
 	async cancelTurn(reason?: Error): Promise<void> {
 		const turn = this.#turn;
-		const session = await this.#session?.catch(() => undefined);
+		const session = await Promise.race([
+			this.#session?.catch(() => undefined) ?? Promise.resolve(undefined),
+			Bun.sleep(DEVIN_ACP_CANCEL_DELIVERY_GRACE_MS).then(() => undefined),
+		]);
 		if (session) {
 			try {
 				await this.#connection.cancel({ sessionId: session.id });
@@ -837,6 +892,9 @@ class DevinAcpBridge implements ProviderSessionState {
 				// The agent may already have finished; the turn settles below regardless.
 			}
 		}
+		// Only now wake a parked handshake or prompt: the cancellation must be delivered
+		// before `#runTurn` unwinds and a disposable child is reaped.
+		turn?.requestCancellation();
 		if (turn && !turn.settled) {
 			turn.output.stopReason = reason ? "error" : "aborted";
 			if (reason) turn.output.errorMessage = errorMessage(reason);
@@ -883,7 +941,33 @@ function createTurn(model: Model<"devin-acp">): ActiveTurn {
 		stopReason: "stop",
 		timestamp: Date.now(),
 	};
-	return { stream, output, textIndex: null, thinkingIndex: null, toolCallIndexes: new Map(), settled: false };
+	const cancellation = Promise.withResolvers<void>();
+	return {
+		stream,
+		output,
+		textIndex: null,
+		thinkingIndex: null,
+		toolCallIndexes: new Map(),
+		settled: false,
+		cancellation: cancellation.promise,
+		requestCancellation: cancellation.resolve,
+		rearmIdle: undefined,
+	};
+}
+
+/**
+ * Stable identity for the cached ACP child.
+ *
+ * `cwd` is part of the identity on purpose: `/move` changes `process.cwd()`, and a
+ * cached child keeps the directory it was spawned in, so a cwd change must miss the
+ * cache and respawn instead of running Devin's tools in the abandoned tree.
+ */
+export function devinAcpBridgeIdentity(
+	conversationId: string | undefined,
+	cwd: string,
+	argv: readonly string[],
+): string {
+	return `devin-acp:${conversationId ?? "ephemeral"}:${cwd}\u0000${argv.join("\u0000")}`;
 }
 
 /**
@@ -910,10 +994,19 @@ function resolveBridge(config: { streamOptions: DevinAcpOptions | undefined; con
 		});
 	const stateMap = config.streamOptions?.providerSessionState;
 	if (!stateMap) return { bridge: spawn(), owned: true };
-	const key = `devin-acp:${config.conversationId ?? "ephemeral"}:${argv.join("\u0000")}`;
+	const key = devinAcpBridgeIdentity(config.conversationId, cwd, argv);
 	const existing = stateMap.get(key);
 	if (existing instanceof DevinAcpBridge && !existing.exitError) return { bridge: existing, owned: false };
 	if (existing) existing.close();
+	// One conversation maps to one live child. A cwd (or argv) change supersedes the
+	// previous bridge, and leaving it in the map would keep a child bound to the
+	// abandoned directory running until session teardown.
+	const prefix = `devin-acp:${config.conversationId ?? "ephemeral"}:`;
+	for (const [candidateKey, candidate] of stateMap) {
+		if (candidateKey === key || !candidateKey.startsWith(prefix)) continue;
+		stateMap.delete(candidateKey);
+		if (candidate instanceof DevinAcpBridge) candidate.close();
+	}
 	const created = spawn();
 	stateMap.set(key, created);
 	return { bridge: created, owned: false };
@@ -929,7 +1022,14 @@ export const streamDevinAcp: (
 		const { bridge, owned } = resolveBridge({ streamOptions: options, conversationId });
 		const turn = createTurn(model);
 		const settled = bridge.beginTurn(turn, model, context, options);
-		if (owned) void settled.finally(() => bridge.close());
+		if (owned) {
+			// A disposable child is reaped as soon as the turn unwinds, which the
+			// cancellation races above guarantee even for an agent that never answers.
+			void settled.then(
+				() => bridge.close(),
+				() => bridge.close(),
+			);
+		}
 		return turn.stream;
 	} catch (error) {
 		// Launch failures must surface as a stream error, never as a thrown

--- a/packages/ai/src/providers/devin-acp.ts
+++ b/packages/ai/src/providers/devin-acp.ts
@@ -133,7 +133,11 @@ export interface DevinAcpConfig {
 	cliArgs?: readonly string[];
 	/** Working directory for the agent process. Defaults to `process.cwd()`. */
 	cwd?: string;
-	/** Overrides the permission policy for this request. */
+	/**
+	 * Overrides the permission policy for this request. Any value other than
+	 * `"allow"` fails closed to `"deny"`, including out-of-type values from
+	 * untyped callers.
+	 */
 	permissionMode?: DevinAcpPermissionMode;
 	/** Explicit permission decisions. When absent, the configured mode decides. */
 	permissionHandler?: DevinAcpPermissionHandler;
@@ -250,7 +254,9 @@ export function devinAcpResolvePermissionMode(
 	configured: DevinAcpPermissionMode | undefined,
 	env: Record<string, string | undefined> = process.env,
 ): DevinAcpPermissionMode {
-	if (configured === "allow" || configured === "deny") return configured;
+	// An explicit value always wins and fails closed: an out-of-type value from an
+	// untyped caller must never fall through to the permissive default.
+	if (configured !== undefined) return configured === "allow" ? "allow" : "deny";
 	const raw = env[DEVIN_ACP_PERMISSION_MODE_ENV]?.trim().toLowerCase();
 	if (raw === undefined || raw.length === 0) return "allow";
 	return raw === "allow" ? "allow" : "deny";
@@ -766,6 +772,10 @@ class DevinAcpBridge implements ProviderSessionState {
 		options: DevinAcpOptions | undefined,
 	): Promise<void> {
 		const { output } = turn;
+		// Every provider opens with a start event carrying its partial assistant
+		// message: the loop uses it to publish streaming updates and to hold the
+		// partial while the turn runs.
+		turn.stream.push({ type: "start", partial: output });
 		try {
 			refuseNonInteractiveTurn(options);
 		} catch (error) {

--- a/packages/ai/src/providers/register-builtins.ts
+++ b/packages/ai/src/providers/register-builtins.ts
@@ -34,6 +34,7 @@ import type { BedrockOptions } from "./amazon-bedrock";
 import type { AnthropicOptions } from "./anthropic";
 import type { AzureOpenAIResponsesOptions } from "./azure-openai-responses";
 import type { CursorOptions } from "./cursor";
+import type { DevinAcpOptions } from "./devin-acp";
 import type { GoogleOptions } from "./google";
 import type { GoogleGeminiCliOptions } from "./google-gemini-cli";
 import type { GoogleVertexOptions } from "./google-vertex";
@@ -146,6 +147,14 @@ interface CursorProviderModule {
 	) => AssistantMessageEventStream;
 }
 
+interface DevinAcpProviderModule {
+	streamDevinAcp: (
+		model: Model<"devin-acp">,
+		context: Context,
+		options: DevinAcpOptions,
+	) => AssistantMessageEventStream;
+}
+
 interface BedrockProviderModule {
 	streamBedrock: (
 		model: Model<"bedrock-converse-stream">,
@@ -176,6 +185,7 @@ let openAICompletionsProviderModulePromise: Promise<LazyProviderModule<"openai-c
 let openAIResponsesProviderModulePromise: Promise<LazyProviderModule<"openai-responses">> | undefined;
 let ollamaProviderModulePromise: Promise<LazyProviderModule<"ollama-chat">> | undefined;
 let cursorProviderModulePromise: Promise<LazyProviderModule<"cursor-agent">> | undefined;
+let devinAcpProviderModulePromise: Promise<LazyProviderModule<"devin-acp">> | undefined;
 let bedrockProviderModuleOverride: LazyProviderModule<"bedrock-converse-stream"> | undefined;
 let kiroCodeWhispererProviderModulePromise: Promise<LazyProviderModule<"kiro-codewhisperer-stream">> | undefined;
 let bedrockProviderModulePromise: Promise<LazyProviderModule<"bedrock-converse-stream">> | undefined;
@@ -459,6 +469,14 @@ function loadCursorProviderModule(): Promise<LazyProviderModule<"cursor-agent">>
 	return cursorProviderModulePromise;
 }
 
+function loadDevinAcpProviderModule(): Promise<LazyProviderModule<"devin-acp">> {
+	devinAcpProviderModulePromise ||= Promise.resolve().then(() => {
+		const provider = require("./devin-acp") as DevinAcpProviderModule;
+		return { stream: provider.streamDevinAcp };
+	});
+	return devinAcpProviderModulePromise;
+}
+
 function loadBedrockProviderModule(): Promise<LazyProviderModule<"bedrock-converse-stream">> {
 	if (bedrockProviderModuleOverride) {
 		return Promise.resolve(bedrockProviderModuleOverride);
@@ -492,6 +510,7 @@ export const PROVIDER_RUNTIME_DESCRIPTORS: readonly ProviderRuntimeDescriptor<Ap
 	{ api: "openai-responses", load: loadOpenAIResponsesProviderModule },
 	{ api: "ollama-chat", load: loadOllamaProviderModule },
 	{ api: "cursor-agent", load: loadCursorProviderModule },
+	{ api: "devin-acp", load: loadDevinAcpProviderModule },
 	{ api: "kiro-codewhisperer-stream", load: loadKiroCodeWhispererProviderModule },
 	{ api: "bedrock-converse-stream", load: loadBedrockProviderModule },
 ] as readonly ErasedProviderRuntimeDescriptor[];
@@ -538,6 +557,7 @@ export const streamOpenAIResponses = createLazyStream(
 	PROVIDER_OWNED_STREAM_WATCHDOG,
 );
 export const streamCursor = createLazyStream(loadCursorProviderModule, PROVIDER_OWNED_STREAM_WATCHDOG);
+export const streamDevinAcp = createLazyStream(loadDevinAcpProviderModule, PROVIDER_OWNED_STREAM_WATCHDOG);
 export const streamOllama = createLazyStream(loadOllamaProviderModule);
 
 export const streamBedrock = createLazyStream(loadBedrockProviderModule);

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -39,6 +39,7 @@ import {
 	readAwsStaticEnvironmentCredentials,
 } from "./providers/aws-credential-config";
 import type { CursorOptions } from "./providers/cursor";
+import type { DevinAcpOptions } from "./providers/devin-acp";
 import type { GoogleOptions } from "./providers/google";
 import type { GoogleGeminiCliOptions } from "./providers/google-gemini-cli";
 import type { GoogleVertexOptions } from "./providers/google-vertex";
@@ -54,6 +55,7 @@ import {
 	streamAzureOpenAIResponses,
 	streamBedrock,
 	streamCursor,
+	streamDevinAcp,
 	streamGoogle,
 	streamGoogleGeminiCli,
 	streamGoogleVertex,
@@ -398,6 +400,9 @@ export function stream<TApi extends Api>(
 			(options || {}) as KiroCodeWhispererOptions,
 			onStreamCreated,
 		);
+	} else if (model.api === "devin-acp") {
+		// Devin authenticates through its own CLI, so there is no GJC API key to resolve.
+		return streamDevinAcp(model as Model<"devin-acp">, context, (options || {}) as DevinAcpOptions, onStreamCreated);
 	}
 
 	const apiKey = options?.apiKey || (model.provider === "opencodex" ? "local" : getEnvApiKey(model.provider));
@@ -952,6 +957,7 @@ function mapOptionsForApi<TApi extends Api>(
 		cacheRetention: options?.cacheRetention ?? model.cacheRetention,
 		headers: options?.headers,
 		initiatorOverride: options?.initiatorOverride,
+		maintenanceCall: options?.maintenanceCall,
 		maxRetryDelayMs: options?.maxRetryDelayMs,
 		requestMaxRetries: options?.fallbackManaged ? 0 : options?.requestMaxRetries,
 		streamMaxRetries: options?.fallbackManaged ? 0 : options?.streamMaxRetries,
@@ -959,6 +965,7 @@ function mapOptionsForApi<TApi extends Api>(
 		sessionId: options?.sessionId,
 		providerSessionId: options?.providerSessionId,
 		providerSessionState: options?.providerSessionState,
+		devinAcp: options?.devinAcp,
 		onPayload: options?.onPayload,
 		onResponse: options?.onResponse,
 		onStreamCreated: options?.onStreamCreated,
@@ -1266,6 +1273,11 @@ function mapOptionsForApi<TApi extends Api>(
 				onToolResult,
 			});
 		}
+
+		case "devin-acp":
+			return castApi<"devin-acp">({
+				...base,
+			});
 
 		case "kiro-codewhisperer-stream":
 			return castApi<"kiro-codewhisperer-stream">({

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -34,6 +34,7 @@ import type {
 	WriteArgs,
 	WriteResult,
 } from "./providers/cursor/gen/agent_pb";
+import type { DevinAcpConfig, DevinAcpOptions } from "./providers/devin-acp";
 import type { GoogleOptions } from "./providers/google";
 import type { GoogleGeminiCliOptions } from "./providers/google-gemini-cli";
 import type { GoogleVertexOptions } from "./providers/google-vertex";
@@ -60,6 +61,7 @@ export type KnownApi =
 	| "google-vertex"
 	| "ollama-chat"
 	| "cursor-agent"
+	| "devin-acp"
 	| "kiro-codewhisperer-stream";
 export type Api = KnownApi | (string & {});
 export interface ApiOptionsMap {
@@ -74,6 +76,7 @@ export interface ApiOptionsMap {
 	"google-vertex": GoogleVertexOptions;
 	"ollama-chat": OllamaChatOptions;
 	"cursor-agent": CursorOptions;
+	"devin-acp": DevinAcpOptions;
 	"kiro-codewhisperer-stream": KiroCodeWhispererOptions;
 }
 // Compile-time exhaustiveness check - this will fail if ApiOptionsMap doesn't have all KnownApi keys
@@ -153,6 +156,7 @@ export const KNOWN_PROVIDERS = [
 	"fugu",
 	"gitlab-duo",
 	"cursor",
+	"devin",
 	"jetbrains-junie",
 	"deepseek",
 	"deepinfra",
@@ -456,6 +460,13 @@ export interface StreamOptions {
 	 */
 	providerSessionState?: Map<string, ProviderSessionState>;
 	/**
+	 * Set by GJC for internal maintenance/one-shot work (context compaction,
+	 * handoff and branch summaries, utility generations) rather than an
+	 * interactive user turn. Agent-level providers use it to refuse requests they
+	 * cannot serve instead of forwarding them to a billed upstream agent.
+	 */
+	maintenanceCall?: boolean;
+	/**
 	 * Optional callback for inspecting or replacing provider payloads before sending.
 	 * Return undefined to keep the payload unchanged.
 	 * The `scope` parameter carries the per-attempt identity for execution attribution.
@@ -520,6 +531,12 @@ export interface StreamOptions {
 	authCredentialType?: "api_key" | "oauth";
 	/** Cursor exec/MCP tool handlers (cursor-agent only). */
 	execHandlers?: CursorExecHandlers;
+	/**
+	 * Devin CLI ACP provider configuration (devin-acp only). When absent, the
+	 * provider spawns `devin acp` from PATH (or `GJC_DEVIN_CLI_PATH`) in the
+	 * current working directory and applies the default permission policy.
+	 */
+	devinAcp?: DevinAcpConfig;
 	/** Per-attempt identity for execution attribution. Threaded into onPayload/onResponse calls. */
 	attemptScope?: AttemptScopeRef;
 }

--- a/packages/ai/src/utils/block-symbols.ts
+++ b/packages/ai/src/utils/block-symbols.ts
@@ -1,11 +1,21 @@
-export const kCursorExecResolved = Symbol("provider.block.cursorExecResolved");
+/**
+ * Provider-resolved tool-call markers.
+ *
+ * A provider that executes a tool call itself (Cursor exec-owned calls, or an
+ * agent-level ACP provider such as Devin, whose agent runs its own tools) marks
+ * the emitted `toolCall` block with this symbol. The agent loop then treats the
+ * call as display-only and never dispatches it to a GJC tool. Symbols are used
+ * instead of a wire field so the marker exists only in-process and can never
+ * round-trip through a transcript or a provider payload.
+ */
+export const kProviderResolvedToolCall = Symbol("provider.block.providerResolvedToolCall");
 
-export type CursorExecResolvedCarrier = object & { [kCursorExecResolved]?: true };
+export type ProviderResolvedCarrier = object & { [kProviderResolvedToolCall]?: true };
 
-export function isCursorExecResolved(block: CursorExecResolvedCarrier | null | undefined): boolean {
-	return block?.[kCursorExecResolved] === true;
+export function isProviderResolvedToolCall(block: ProviderResolvedCarrier | null | undefined): boolean {
+	return block?.[kProviderResolvedToolCall] === true;
 }
 
-export function copyCursorExecResolved(target: CursorExecResolvedCarrier, source: CursorExecResolvedCarrier): void {
-	if (source[kCursorExecResolved] === true) target[kCursorExecResolved] = true;
+export function copyProviderResolvedToolCall(target: ProviderResolvedCarrier, source: ProviderResolvedCarrier): void {
+	if (source[kProviderResolvedToolCall] === true) target[kProviderResolvedToolCall] = true;
 }

--- a/packages/ai/src/utils/block-symbols.ts
+++ b/packages/ai/src/utils/block-symbols.ts
@@ -8,7 +8,7 @@
  * instead of a wire field so the marker exists only in-process and can never
  * round-trip through a transcript or a provider payload.
  */
-export const kProviderResolvedToolCall = Symbol("provider.block.providerResolvedToolCall");
+export const kProviderResolvedToolCall: unique symbol = Symbol.for("@gajae-code/ai.provider-resolved-tool-call.v1");
 
 export type ProviderResolvedCarrier = object & { [kProviderResolvedToolCall]?: true };
 

--- a/packages/ai/test/devin-acp-provider.test.ts
+++ b/packages/ai/test/devin-acp-provider.test.ts
@@ -19,6 +19,8 @@ import {
 	DEVIN_ACP_CONTEXT_WINDOW,
 	DEVIN_ACP_MAX_TOKENS,
 	type DevinAcpConfig,
+	devinAcpBridgeIdentity,
+	devinAcpResolvePermissionMode,
 	fetchDevinAcpModels,
 	streamDevinAcp,
 } from "../src/providers/devin-acp";
@@ -107,6 +109,20 @@ async function waitForFile(file: string, timeoutMs = 5_000): Promise<string> {
 		await Bun.sleep(25);
 	}
 	throw new Error(`receipt ${file} was never written`);
+}
+
+/** Fails when the child is still alive at the deadline; a reaped child raises ESRCH. */
+async function expectProcessExit(pid: number, timeoutMs = 5_000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		try {
+			process.kill(pid, 0);
+		} catch {
+			return;
+		}
+		await Bun.sleep(25);
+	}
+	throw new Error(`child ${pid} was never reaped after its turn settled`);
 }
 
 describe("devin provider registration", () => {
@@ -316,6 +332,19 @@ describe("devin permission policy", () => {
 		);
 		expect(assistantText(message)).toBe('decision:{"outcome":"cancelled"}');
 	});
+
+	test("resolves the documented policy from the environment and fails closed", () => {
+		expect(devinAcpResolvePermissionMode(undefined, {})).toBe("allow");
+		expect(devinAcpResolvePermissionMode(undefined, { GJC_DEVIN_PERMISSION_MODE: "" })).toBe("allow");
+		expect(devinAcpResolvePermissionMode(undefined, { GJC_DEVIN_PERMISSION_MODE: "  " })).toBe("allow");
+		expect(devinAcpResolvePermissionMode(undefined, { GJC_DEVIN_PERMISSION_MODE: "agent-free" })).toBe("deny");
+		// Case and surrounding whitespace are normalized; anything unrecognized is denied.
+		expect(devinAcpResolvePermissionMode(undefined, { GJC_DEVIN_PERMISSION_MODE: " ALLOW " })).toBe("allow");
+		expect(devinAcpResolvePermissionMode(undefined, { GJC_DEVIN_PERMISSION_MODE: "allow_always" })).toBe("deny");
+		// An explicit typed mode always wins over the environment.
+		expect(devinAcpResolvePermissionMode("deny", { GJC_DEVIN_PERMISSION_MODE: "allow" })).toBe("deny");
+		expect(devinAcpResolvePermissionMode("allow", { GJC_DEVIN_PERMISSION_MODE: "deny" })).toBe("allow");
+	});
 });
 
 describe("devin session lifecycle", () => {
@@ -356,6 +385,93 @@ describe("devin session lifecycle", () => {
 		}
 	});
 
+	test("keeps an active turn alive on a gap-based idle budget", async () => {
+		// 8 updates 120ms apart (~1s of activity) with a 400ms idle budget: only a
+		// gap-based budget lets the turn finish, a whole-turn deadline would not.
+		const { message } = await drain(
+			streamDevinAcp(devinModel(), userContext("long turn"), {
+				...fixtureTurn("slow-chunks"),
+				streamIdleTimeoutMs: 400,
+			}),
+		);
+		expect(message.stopReason).toBe("stop");
+		expect(assistantText(message)).toBe("01234567");
+	});
+
+	test("still expires the idle budget when the agent goes silent after activity", async () => {
+		// Activity re-arms the budget; it must not disable it.
+		const { message } = await drain(
+			streamDevinAcp(devinModel(), userContext("go quiet"), {
+				...fixtureTurn("chunk-then-silence"),
+				streamIdleTimeoutMs: 300,
+			}),
+		);
+		expect(assistantText(message)).toBe("alive");
+		expect(message.stopReason).toBe("error");
+		expect(message.errorMessage).toContain("timed out");
+	});
+
+	test("reaps a disposable child when a parked prompt settles the turn", async () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-devin-owned-child-"));
+		tempDirs.push(dir);
+		const receipt = path.join(dir, "prompt-receipt.json");
+		// No `providerSessionState`: this bridge is disposable, so only the turn's own
+		// settlement can reap the child.
+		const { message } = await drain(
+			streamDevinAcp(devinModel(), userContext("go quiet"), {
+				...fixtureTurn("chunk-then-silence", {}, receipt),
+				streamIdleTimeoutMs: 300,
+			}),
+		);
+		expect(message.stopReason).toBe("error");
+		const receiptBody = JSON.parse(await waitForFile(receipt)) as { pid?: number };
+		expect(typeof receiptBody.pid).toBe("number");
+		await expectProcessExit(receiptBody.pid as number);
+	});
+
+	test("settles a cancel that races the ACP handshake without forwarding the prompt", async () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-devin-slow-session-"));
+		tempDirs.push(dir);
+		const receipt = path.join(dir, "prompt-receipt.json");
+		const controller = new AbortController();
+		const streamResult = streamDevinAcp(devinModel(), userContext("cancel me"), {
+			...fixtureTurn("slow-session", {}, receipt),
+			signal: controller.signal,
+		});
+		setTimeout(() => controller.abort(), 50);
+		const message = await streamResult.result();
+		expect(message.stopReason).toBe("aborted");
+		// Outlive the fixture's 600ms `session/new`: a prompt that had been forwarded
+		// would have written its receipt by now.
+		await Bun.sleep(900);
+		expect(fs.existsSync(receipt)).toBe(false);
+	});
+
+	test("applies each turn's permission policy on a cached conversation", async () => {
+		const state = new Map<string, ProviderSessionState>();
+		try {
+			const first = await drain(
+				streamDevinAcp(devinModel(), userContext("clean up"), {
+					...fixtureTurn("permission"),
+					providerSessionId: "policy-conversation",
+					providerSessionState: state,
+				}),
+			);
+			expect(assistantText(first.message)).toBe('decision:{"outcome":"selected","optionId":"allow-once"}');
+			const second = await drain(
+				streamDevinAcp(devinModel(), userContext("clean up"), {
+					...fixtureTurn("permission", { permissionMode: "deny" }),
+					providerSessionId: "policy-conversation",
+					providerSessionState: state,
+				}),
+			);
+			// A cached child must not pin the policy of the turn that created it.
+			expect(assistantText(second.message)).toBe('decision:{"outcome":"selected","optionId":"reject-once"}');
+		} finally {
+			closeAll(state);
+		}
+	});
+
 	test("forwards caller cancellation as an ACP session/cancel", async () => {
 		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-devin-cancel-"));
 		tempDirs.push(dir);
@@ -377,6 +493,44 @@ describe("devin session lifecycle", () => {
 		expect(message.stopReason).toBe("aborted");
 		const receiptBody = JSON.parse(await waitForFile(receipt)) as { cancelReceived?: boolean };
 		expect(receiptBody.cancelReceived).toBe(true);
+	});
+	test("keys the cached ACP child on the working directory", () => {
+		const argv = ["devin", "acp"];
+		expect(devinAcpBridgeIdentity("chat", "/work/a", argv)).toBe(devinAcpBridgeIdentity("chat", "/work/a", argv));
+		expect(devinAcpBridgeIdentity("chat", "/work/a", argv)).not.toBe(devinAcpBridgeIdentity("chat", "/work/b", argv));
+		expect(devinAcpBridgeIdentity("chat", "/work/a", argv)).not.toBe(
+			devinAcpBridgeIdentity("other", "/work/a", argv),
+		);
+	});
+
+	test("replaces the cached child when the working directory changes", async () => {
+		const dirA = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-devin-cwd-a-"));
+		const dirB = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-devin-cwd-b-"));
+		tempDirs.push(dirA, dirB);
+		const state = new Map<string, ProviderSessionState>();
+		try {
+			await drain(
+				streamDevinAcp(devinModel(), userContext("one"), {
+					...fixtureTurn("session", { cwd: dirA }),
+					providerSessionId: "cwd-conversation",
+					providerSessionState: state,
+				}),
+			);
+			expect(state.size).toBe(1);
+			await drain(
+				streamDevinAcp(devinModel(), userContext("two"), {
+					...fixtureTurn("session", { cwd: dirB }),
+					providerSessionId: "cwd-conversation",
+					providerSessionState: state,
+				}),
+			);
+			// The new directory must miss the cache, and the superseded child must not
+			// stay behind holding the abandoned directory.
+			expect(state.size).toBe(1);
+			expect([...state.keys()][0]).toContain(dirB);
+		} finally {
+			closeAll(state);
+		}
 	});
 });
 

--- a/packages/ai/test/devin-acp-provider.test.ts
+++ b/packages/ai/test/devin-acp-provider.test.ts
@@ -1,0 +1,398 @@
+/**
+ * Devin CLI provider tests.
+ *
+ * Devin CLI is not installable in CI, so the provider runs against
+ * `test/fixtures/devin-acp-agent.ts`: a real subprocess speaking ACP v1 over
+ * stdio through the official `@agentclientprotocol/sdk` — the same protocol
+ * surface `devin acp` implements. Nothing here claims live Devin traffic.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { DEFAULT_MODEL_PER_PROVIDER } from "../src/provider-models/descriptors";
+import { devinModelManagerOptions } from "../src/provider-models/special";
+import {
+	DEVIN_ACP_BASE_URL,
+	DEVIN_ACP_CONTEXT_WINDOW,
+	DEVIN_ACP_MAX_TOKENS,
+	type DevinAcpConfig,
+	fetchDevinAcpModels,
+	streamDevinAcp,
+} from "../src/providers/devin-acp";
+import { stream } from "../src/stream";
+import {
+	type AssistantMessage,
+	type AssistantMessageEvent,
+	type AssistantMessageEventStream,
+	type Context,
+	isKnownProvider,
+	KNOWN_PROVIDERS,
+	type Model,
+	type ProviderSessionState,
+} from "../src/types";
+
+const FIXTURE = path.join(import.meta.dir, "fixtures", "devin-acp-agent.ts");
+const tempDirs: string[] = [];
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+function devinModel(id = "adaptive"): Model<"devin-acp"> {
+	return {
+		id,
+		name: id,
+		api: "devin-acp",
+		provider: "devin",
+		baseUrl: DEVIN_ACP_BASE_URL,
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: DEVIN_ACP_CONTEXT_WINDOW,
+		maxTokens: DEVIN_ACP_MAX_TOKENS,
+	};
+}
+
+function userContext(text: string): Context {
+	return { messages: [{ role: "user", content: [{ type: "text", text }], timestamp: Date.now() }] };
+}
+
+/** Launch configuration for the ACP fixture (`<cliPath> <cliArgs...> acp`). */
+function fixtureCli(scenario: string, receiptPath?: string): { cliPath: string; cliArgs: string[] } {
+	return {
+		cliPath: process.execPath,
+		cliArgs: receiptPath === undefined ? [FIXTURE, scenario] : [FIXTURE, scenario, receiptPath],
+	};
+}
+
+/**
+ * Stream options for one interactive Devin turn. A Devin turn always belongs to
+ * a GJC session, so the session identity is part of the fixture defaults.
+ */
+function fixtureTurn(
+	scenario: string,
+	extra: Partial<DevinAcpConfig> = {},
+	receiptPath?: string,
+): { devinAcp: DevinAcpConfig; providerSessionId: string } {
+	return {
+		devinAcp: { ...fixtureCli(scenario, receiptPath), ...extra },
+		providerSessionId: "test-conversation",
+	};
+}
+
+async function drain(stream: AssistantMessageEventStream): Promise<{
+	events: AssistantMessageEvent[];
+	message: AssistantMessage;
+}> {
+	const events: AssistantMessageEvent[] = [];
+	for await (const event of stream) events.push(event);
+	return { events, message: await stream.result() };
+}
+
+function assistantText(message: AssistantMessage): string {
+	return message.content.map(block => (block.type === "text" ? block.text : "")).join("");
+}
+
+function closeAll(state: Map<string, ProviderSessionState>): void {
+	for (const entry of state.values()) entry.close();
+}
+
+async function waitForFile(file: string, timeoutMs = 5_000): Promise<string> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (fs.existsSync(file)) return fs.readFileSync(file, "utf8");
+		await Bun.sleep(25);
+	}
+	throw new Error(`receipt ${file} was never written`);
+}
+
+describe("devin provider registration", () => {
+	test("is a known provider with a default model and keyless descriptor", () => {
+		expect(isKnownProvider("devin")).toBe(true);
+		expect(KNOWN_PROVIDERS).toContain("devin");
+		expect(DEFAULT_MODEL_PER_PROVIDER.devin).toBe("adaptive");
+	});
+
+	test("dispatches through the provider stream without an API key", async () => {
+		const { message } = await drain(
+			stream(devinModel(), userContext("hi"), fixtureTurn("chat")) as AssistantMessageEventStream,
+		);
+		expect(message.stopReason).toBe("stop");
+		expect(assistantText(message)).toBe("hello world done");
+	});
+});
+
+describe("devin turn mapping", () => {
+	test("streams text, thinking and remote tool calls without dispatching them to GJC", async () => {
+		const { events, message } = await drain(
+			streamDevinAcp(devinModel(), userContext("run the tests"), fixtureTurn("chat")),
+		);
+
+		expect(message.stopReason).toBe("stop");
+		expect(message.content.map(block => block.type)).toEqual(["thinking", "text", "toolCall", "text"]);
+		const thinking = message.content[0];
+		expect(thinking.type === "thinking" && thinking.thinking).toBe("planning");
+		const text = message.content[1];
+		expect(text.type === "text" && text.text).toBe("hello world");
+		const toolCall = message.content[2];
+		expect(toolCall.type).toBe("toolCall");
+		if (toolCall.type === "toolCall") {
+			expect(toolCall.id).toBe("call-1");
+			expect(toolCall.name).toBe("bash");
+			expect(toolCall.arguments.command).toBe("bun test");
+			expect(toolCall.arguments._acp).toEqual({ toolCallId: "call-1", kind: "execute", status: "completed" });
+			expect(toolCall.intent).toBe("Run the test suite");
+		}
+		// The provider must never ask GJC to execute a Devin tool call.
+		expect(message.stopReason).not.toBe("toolUse");
+		expect(events.some(event => event.type === "toolcall_end")).toBe(true);
+		expect(events.filter(event => event.type === "done")).toHaveLength(1);
+	});
+
+	test("maps ACP stop reasons onto GJC stop reasons", async () => {
+		const refusal = await drain(streamDevinAcp(devinModel(), userContext("hi"), fixtureTurn("refusal")));
+		expect(refusal.message.stopReason).toBe("stop");
+
+		const limits = await drain(streamDevinAcp(devinModel(), userContext("hi"), fixtureTurn("limits")));
+		expect(limits.message.stopReason).toBe("length");
+		expect(limits.message.errorMessage).toContain("turn or token limit");
+	});
+
+	test("reports a crashed agent as an error turn with the child's stderr tail", async () => {
+		const { message } = await drain(streamDevinAcp(devinModel(), userContext("hi"), fixtureTurn("crash")));
+		expect(message.stopReason).toBe("error");
+		expect(message.errorMessage).toContain("exited with code 9");
+	});
+
+	test("reports a missing Devin CLI without throwing out of the stream factory", async () => {
+		const { message } = await drain(
+			streamDevinAcp(devinModel(), userContext("hi"), {
+				devinAcp: { cliPath: path.join(os.tmpdir(), "gjc-missing-devin-cli") },
+				providerSessionId: "test-conversation",
+			}),
+		);
+		expect(message.stopReason).toBe("error");
+		expect(`${message.errorMessage}`).toContain("devin auth login");
+	});
+
+	test("surfaces an unauthenticated Devin CLI with the login instruction", async () => {
+		const { message } = await drain(streamDevinAcp(devinModel(), userContext("hi"), fixtureTurn("auth")));
+		expect(message.stopReason).toBe("error");
+		expect(message.errorMessage).toContain("devin auth login");
+	});
+
+	test("rejects a model the account does not advertise", async () => {
+		const { message } = await drain(streamDevinAcp(devinModel("gpt-9"), userContext("hi"), fixtureTurn("model")));
+		expect(message.stopReason).toBe("error");
+		expect(message.errorMessage).toContain("does not offer model");
+	});
+
+	test("applies the selected model to the ACP session", async () => {
+		const { message } = await drain(streamDevinAcp(devinModel("opus"), userContext("hi"), fixtureTurn("model")));
+		expect(message.stopReason).toBe("stop");
+		expect(assistantText(message)).toBe("model:opus");
+	});
+
+	test("keeps the agent's own model when it advertises no model selector", async () => {
+		const { message } = await drain(
+			streamDevinAcp(devinModel("opus"), userContext("hi"), fixtureTurn("no-model-option")),
+		);
+		expect(message.stopReason).toBe("stop");
+	});
+
+	test("refuses a turn with no user message instead of sending an empty prompt", async () => {
+		const { message } = await drain(
+			streamDevinAcp(devinModel(), { systemPrompt: ["summarize"], messages: [] }, fixtureTurn("chat")),
+		);
+		expect(message.stopReason).toBe("error");
+		expect(message.errorMessage).toContain("empty prompt is not sent");
+	});
+
+	test("refuses GJC maintenance calls instead of billing them to Devin", async () => {
+		const { message } = await drain(
+			streamDevinAcp(devinModel(), userContext("summarize the conversation"), {
+				...fixtureTurn("chat"),
+				maintenanceCall: true,
+			}),
+		);
+		expect(message.stopReason).toBe("error");
+		expect(message.errorMessage).toContain("maintenance calls");
+		// The agent must never have seen a prompt: the chat scenario would have
+		// streamed text into the turn.
+		expect(message.content).toEqual([]);
+	});
+
+	test("refuses agent-attributed maintenance calls", async () => {
+		const { message } = await drain(
+			streamDevinAcp(devinModel(), userContext("summarize the conversation"), {
+				...fixtureTurn("chat"),
+				initiatorOverride: "agent",
+			}),
+		);
+		expect(message.stopReason).toBe("error");
+		expect(message.errorMessage).toContain("maintenance calls");
+	});
+
+	test("refuses utility one-shots that carry no session identity", async () => {
+		const { message } = await drain(
+			streamDevinAcp(devinModel(), userContext("title this session"), { devinAcp: fixtureCli("chat") }),
+		);
+		expect(message.stopReason).toBe("error");
+		expect(message.errorMessage).toContain("session identity");
+		expect(message.content).toEqual([]);
+	});
+});
+
+describe("devin permission policy", () => {
+	test("grants allow_once — never allow_always — in the default allow policy", async () => {
+		const { message } = await drain(streamDevinAcp(devinModel(), userContext("clean up"), fixtureTurn("permission")));
+		expect(assistantText(message)).toBe('decision:{"outcome":"selected","optionId":"allow-once"}');
+	});
+
+	test("rejects with reject_once when the caller configures deny", async () => {
+		const { message } = await drain(
+			streamDevinAcp(devinModel(), userContext("clean up"), fixtureTurn("permission", { permissionMode: "deny" })),
+		);
+		expect(assistantText(message)).toBe('decision:{"outcome":"selected","optionId":"reject-once"}');
+	});
+
+	test("cancels the request when no offered option matches the policy", async () => {
+		const { message } = await drain(
+			streamDevinAcp(devinModel(), userContext("clean up"), fixtureTurn("permission-reject-only")),
+		);
+		expect(assistantText(message)).toBe('decision:{"outcome":"cancelled"}');
+	});
+
+	test("honours an explicit permission handler", async () => {
+		const { message } = await drain(
+			streamDevinAcp(
+				devinModel(),
+				userContext("clean up"),
+				fixtureTurn("permission", {
+					permissionMode: "deny",
+					permissionHandler: request => {
+						expect(request.toolCallId).toBe("call-perm");
+						expect(request.options.map(option => option.kind)).toContain("allow_once");
+						return { optionId: "allow-always" };
+					},
+				}),
+			),
+		);
+		expect(assistantText(message)).toBe('decision:{"outcome":"selected","optionId":"allow-always"}');
+	});
+
+	test("never converts a throwing handler into an approval", async () => {
+		const { message } = await drain(
+			streamDevinAcp(
+				devinModel(),
+				userContext("clean up"),
+				fixtureTurn("permission", {
+					permissionHandler: () => {
+						throw new Error("permission UI exploded");
+					},
+				}),
+			),
+		);
+		expect(assistantText(message)).toBe('decision:{"outcome":"cancelled"}');
+	});
+});
+
+describe("devin session lifecycle", () => {
+	test("reuses one ACP session per conversation and isolates different conversations", async () => {
+		const stateA = new Map<string, ProviderSessionState>();
+		const stateB = new Map<string, ProviderSessionState>();
+		try {
+			const first = await drain(
+				streamDevinAcp(devinModel(), userContext("one"), {
+					...fixtureTurn("session"),
+					providerSessionId: "conversation-a",
+					providerSessionState: stateA,
+				}),
+			);
+			const second = await drain(
+				streamDevinAcp(devinModel(), userContext("two"), {
+					...fixtureTurn("session"),
+					providerSessionId: "conversation-a",
+					providerSessionState: stateA,
+				}),
+			);
+			const other = await drain(
+				streamDevinAcp(devinModel(), userContext("three"), {
+					...fixtureTurn("session"),
+					providerSessionId: "conversation-b",
+					providerSessionState: stateB,
+				}),
+			);
+			expect(assistantText(first.message)).toBe("session:fixture-session");
+			expect(assistantText(second.message)).toBe("session:fixture-session");
+			expect(assistantText(other.message)).toBe("session:fixture-session");
+			expect(stateA.size).toBe(1);
+			expect(stateB.size).toBe(1);
+			expect([...stateA.keys()]).not.toEqual([...stateB.keys()]);
+		} finally {
+			closeAll(stateA);
+			closeAll(stateB);
+		}
+	});
+
+	test("forwards caller cancellation as an ACP session/cancel", async () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-devin-cancel-"));
+		tempDirs.push(dir);
+		const receipt = path.join(dir, "cancel-receipt.json");
+		const controller = new AbortController();
+		const streamResult = streamDevinAcp(devinModel(), userContext("wait"), {
+			...fixtureTurn("cancel", {}, receipt),
+			signal: controller.signal,
+		});
+		const events: AssistantMessageEvent[] = [];
+		const consumer = (async () => {
+			for await (const event of streamResult) {
+				events.push(event);
+				if (event.type === "text_delta") controller.abort();
+			}
+		})();
+		const message = await streamResult.result();
+		await consumer;
+		expect(message.stopReason).toBe("aborted");
+		const receiptBody = JSON.parse(await waitForFile(receipt)) as { cancelReceived?: boolean };
+		expect(receiptBody.cancelReceived).toBe(true);
+	});
+});
+
+describe("devin model discovery", () => {
+	test("exposes ACP discovery through the provider's model manager options", async () => {
+		const options = devinModelManagerOptions(fixtureCli("model"));
+		expect(options.providerId).toBe("devin");
+		expect(options.staticModels).toBeUndefined();
+		const models = await options.fetchDynamicModels?.();
+		expect(models?.map(model => model.id)).toEqual(["adaptive", "opus", "sonnet"]);
+	});
+
+	test("lists the account models from the ACP session model config option", async () => {
+		const models = await fetchDevinAcpModels(fixtureCli("model"));
+		expect(models?.map(model => model.id)).toEqual(["adaptive", "opus", "sonnet"]);
+		expect(models?.[0]).toMatchObject({
+			api: "devin-acp",
+			provider: "devin",
+			baseUrl: DEVIN_ACP_BASE_URL,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		});
+	});
+
+	test("advertises image input only when the agent supports it", async () => {
+		const withoutImages = await fetchDevinAcpModels(fixtureCli("model"));
+		expect(withoutImages?.[0].input).toEqual(["text"]);
+		const withImages = await fetchDevinAcpModels(fixtureCli("images"));
+		expect(withImages?.[0].input).toEqual(["text", "image"]);
+	});
+
+	test("returns null instead of guessing when the CLI is missing", async () => {
+		const models = await fetchDevinAcpModels({
+			cliPath: path.join(os.tmpdir(), "gjc-missing-devin-cli"),
+		});
+		expect(models).toBeNull();
+	});
+});

--- a/packages/ai/test/devin-acp-provider.test.ts
+++ b/packages/ai/test/devin-acp-provider.test.ts
@@ -266,6 +266,24 @@ describe("devin permission policy", () => {
 		expect(assistantText(message)).toBe('decision:{"outcome":"cancelled"}');
 	});
 
+	test("cancels rather than escalating to allow_always when allow_once is not offered", async () => {
+		const { message } = await drain(
+			streamDevinAcp(devinModel(), userContext("clean up"), fixtureTurn("permission-allow-always-only")),
+		);
+		expect(assistantText(message)).toBe('decision:{"outcome":"cancelled"}');
+	});
+
+	test("deny may fall back to reject_always when reject_once is not offered", async () => {
+		const { message } = await drain(
+			streamDevinAcp(
+				devinModel(),
+				userContext("clean up"),
+				fixtureTurn("permission-allow-always-only", { permissionMode: "deny" }),
+			),
+		);
+		expect(assistantText(message)).toBe('decision:{"outcome":"selected","optionId":"reject-always"}');
+	});
+
 	test("honours an explicit permission handler", async () => {
 		const { message } = await drain(
 			streamDevinAcp(

--- a/packages/ai/test/devin-acp-provider.test.ts
+++ b/packages/ai/test/devin-acp-provider.test.ts
@@ -18,6 +18,7 @@ import {
 	DEVIN_ACP_BASE_URL,
 	DEVIN_ACP_CONTEXT_WINDOW,
 	DEVIN_ACP_MAX_TOKENS,
+	DEVIN_ACP_PERMISSION_MODE_ENV,
 	type DevinAcpConfig,
 	devinAcpBridgeIdentity,
 	devinAcpResolvePermissionMode,
@@ -168,6 +169,15 @@ describe("devin turn mapping", () => {
 		expect(events.filter(event => event.type === "done")).toHaveLength(1);
 	});
 
+	test("opens the turn with a start event carrying the partial message", async () => {
+		const { events, message } = await drain(streamDevinAcp(devinModel(), userContext("hi"), fixtureTurn("chat")));
+		expect(events[0]?.type).toBe("start");
+		const start = events[0];
+		expect(start?.type === "start" && start.partial).toBeDefined();
+		expect(start?.type === "start" && start.partial.role).toBe("assistant");
+		expect(message.stopReason).toBe("stop");
+	});
+
 	test("maps ACP stop reasons onto GJC stop reasons", async () => {
 		const refusal = await drain(streamDevinAcp(devinModel(), userContext("hi"), fixtureTurn("refusal")));
 		expect(refusal.message.stopReason).toBe("stop");
@@ -287,6 +297,11 @@ describe("devin permission policy", () => {
 			streamDevinAcp(devinModel(), userContext("clean up"), fixtureTurn("permission-allow-always-only")),
 		);
 		expect(assistantText(message)).toBe('decision:{"outcome":"cancelled"}');
+	});
+
+	test("fails closed to deny when an untyped caller passes an unknown permission mode", () => {
+		expect(devinAcpResolvePermissionMode("everything" as never, {})).toBe("deny");
+		expect(devinAcpResolvePermissionMode("allow", { [DEVIN_ACP_PERMISSION_MODE_ENV]: "deny" })).toBe("allow");
 	});
 
 	test("deny may fall back to reject_always when reject_once is not offered", async () => {

--- a/packages/ai/test/fixtures/devin-acp-agent.ts
+++ b/packages/ai/test/fixtures/devin-acp-agent.ts
@@ -27,7 +27,9 @@ import {
 } from "@agentclientprotocol/sdk";
 
 const scenario = process.argv[2] ?? "chat";
-const receiptPath = process.argv[3];
+// The provider appends the `acp` verb after the args, so argv[3] is a receipt path
+// only when the caller actually supplied one.
+const receiptPath = process.argv[3] === "acp" ? undefined : process.argv[3];
 
 function baseModelOptions(): SessionConfigOption[] {
 	return [
@@ -71,11 +73,14 @@ class FixtureAgent implements Agent {
 		};
 	}
 
-	newSession(_params: NewSessionRequest): NewSessionResponse {
+	newSession(_params: NewSessionRequest): NewSessionResponse | Promise<NewSessionResponse> {
 		if (scenario === "auth") {
 			throw RequestError.authRequired(undefined, "fixture requires login");
 		}
-		return { sessionId: `fixture-${scenario}`, configOptions: this.#configOptions };
+		const response = { sessionId: `fixture-${scenario}`, configOptions: this.#configOptions };
+		// A handshake slow enough for the caller to cancel before `session/new` lands.
+		if (scenario === "slow-session") return Bun.sleep(600).then(() => response);
+		return response;
 	}
 
 	authenticate() {
@@ -109,7 +114,38 @@ class FixtureAgent implements Agent {
 
 	async prompt(params: PromptRequest): Promise<PromptResponse> {
 		const sessionId = params.sessionId;
+		// `slow-chunks`/`slow-session` use the receipt to prove whether a prompt was
+		// forwarded at all; the `cancel` scenario owns the receipt elsewhere.
+		if (
+			receiptPath &&
+			(scenario === "slow-chunks" || scenario === "slow-session" || scenario === "chunk-then-silence")
+		) {
+			fs.writeFileSync(receiptPath, JSON.stringify({ scenario, promptReceived: true, pid: process.pid }));
+		}
 		switch (scenario) {
+			case "slow-chunks": {
+				// 8 updates, 120ms apart (~1s of activity): a gap-based idle budget never
+				// expires while a whole-turn deadline would.
+				for (let index = 0; index < 8; index++) {
+					await Bun.sleep(120);
+					await this.#send(sessionId, {
+						sessionUpdate: "agent_message_chunk",
+						content: { type: "text", text: `${index}` },
+					});
+				}
+				return { stopReason: "end_turn" };
+			}
+			case "slow-session":
+				return { stopReason: "end_turn" };
+			case "chunk-then-silence": {
+				// One update, then silence: the re-armed idle budget must still expire.
+				await this.#send(sessionId, {
+					sessionUpdate: "agent_message_chunk",
+					content: { type: "text", text: "alive" },
+				});
+				await Bun.sleep(10_000);
+				return { stopReason: "cancelled" };
+			}
 			case "chat": {
 				await this.#send(sessionId, {
 					sessionUpdate: "agent_thought_chunk",

--- a/packages/ai/test/fixtures/devin-acp-agent.ts
+++ b/packages/ai/test/fixtures/devin-acp-agent.ts
@@ -1,0 +1,222 @@
+/**
+ * Spec-faithful ACP agent used by the Devin provider tests.
+ *
+ * Devin CLI is not installed in CI, so the Devin provider is exercised against
+ * this fixture instead: it speaks the same Agent Client Protocol v1 over stdio
+ * through the official `@agentclientprotocol/sdk`, which is the interface
+ * `devin acp` implements. Scenarios are selected by argv:
+ *
+ *   bun test/fixtures/devin-acp-agent.ts <scenario> [receipt-path] [acp]
+ *
+ * The trailing `acp` verb mirrors the real argv shape the provider builds
+ * (`devin acp`) and is ignored here.
+ */
+import * as fs from "node:fs";
+import * as stream from "node:stream";
+import {
+	type Agent,
+	AgentSideConnection,
+	type NewSessionRequest,
+	type NewSessionResponse,
+	ndJsonStream,
+	type PromptRequest,
+	type PromptResponse,
+	RequestError,
+	type SessionConfigOption,
+	type SetSessionConfigOptionRequest,
+} from "@agentclientprotocol/sdk";
+
+const scenario = process.argv[2] ?? "chat";
+const receiptPath = process.argv[3];
+
+function baseModelOptions(): SessionConfigOption[] {
+	return [
+		{
+			type: "select",
+			id: "model",
+			name: "Model",
+			category: "model",
+			currentValue: "adaptive",
+			options: [
+				{ value: "adaptive", name: "Adaptive" },
+				{ value: "opus", name: "Opus" },
+				{ value: "sonnet", name: "Sonnet" },
+			],
+		},
+		{
+			type: "select",
+			id: "mode",
+			name: "Mode",
+			category: "mode",
+			currentValue: "normal",
+			options: [{ value: "normal", name: "Normal" }],
+		},
+	];
+}
+
+class FixtureAgent implements Agent {
+	readonly #connection: AgentSideConnection;
+	#configOptions: SessionConfigOption[] = scenario === "no-model-option" ? [] : baseModelOptions();
+	#releaseCancel: (() => void) | undefined;
+
+	constructor(connection: AgentSideConnection) {
+		this.#connection = connection;
+	}
+
+	initialize() {
+		return {
+			protocolVersion: 1,
+			agentInfo: { name: "devin-acp-fixture", version: "1.0.0" },
+			agentCapabilities: { promptCapabilities: { image: scenario === "images" } },
+		};
+	}
+
+	newSession(_params: NewSessionRequest): NewSessionResponse {
+		if (scenario === "auth") {
+			throw RequestError.authRequired(undefined, "fixture requires login");
+		}
+		return { sessionId: `fixture-${scenario}`, configOptions: this.#configOptions };
+	}
+
+	authenticate() {
+		return {};
+	}
+
+	setSessionConfigOption(params: SetSessionConfigOptionRequest) {
+		this.#configOptions = this.#configOptions.map(option =>
+			option.id === params.configId && option.type === "select" && typeof params.value === "string"
+				? { ...option, currentValue: params.value }
+				: option,
+		);
+		return { configOptions: this.#configOptions };
+	}
+
+	cancel(): void {
+		// Evidence for the provider's cancellation test: the receipt only appears
+		// once this agent actually received `session/cancel` over ACP.
+		if (receiptPath) {
+			fs.writeFileSync(receiptPath, JSON.stringify({ scenario, cancelReceived: true }));
+		}
+		this.#releaseCancel?.();
+	}
+
+	async #send(
+		sessionId: string,
+		update: Parameters<AgentSideConnection["sessionUpdate"]>[0]["update"],
+	): Promise<void> {
+		await this.#connection.sessionUpdate({ sessionId, update });
+	}
+
+	async prompt(params: PromptRequest): Promise<PromptResponse> {
+		const sessionId = params.sessionId;
+		switch (scenario) {
+			case "chat": {
+				await this.#send(sessionId, {
+					sessionUpdate: "agent_thought_chunk",
+					content: { type: "text", text: "planning" },
+				});
+				await this.#send(sessionId, {
+					sessionUpdate: "agent_message_chunk",
+					content: { type: "text", text: "hello " },
+				});
+				await this.#send(sessionId, {
+					sessionUpdate: "agent_message_chunk",
+					content: { type: "text", text: "world" },
+				});
+				await this.#send(sessionId, {
+					sessionUpdate: "tool_call",
+					toolCallId: "call-1",
+					title: "Run the test suite",
+					kind: "execute",
+					status: "pending",
+					rawInput: { command: "bun test" },
+				});
+				await this.#send(sessionId, {
+					sessionUpdate: "tool_call_update",
+					toolCallId: "call-1",
+					status: "completed",
+					content: [{ type: "content", content: { type: "text", text: "ok" } }],
+				});
+				await this.#send(sessionId, {
+					sessionUpdate: "agent_message_chunk",
+					content: { type: "text", text: " done" },
+				});
+				return { stopReason: "end_turn" };
+			}
+			case "permission":
+			case "permission-reject-only": {
+				const allowOnce = { optionId: "allow-once", name: "Allow once", kind: "allow_once" as const };
+				const allowAlways = { optionId: "allow-always", name: "Always allow", kind: "allow_always" as const };
+				const rejectOnce = { optionId: "reject-once", name: "Reject", kind: "reject_once" as const };
+				const options = scenario === "permission-reject-only" ? [rejectOnce] : [allowOnce, allowAlways, rejectOnce];
+				const response = await this.#connection.requestPermission({
+					sessionId,
+					toolCall: { toolCallId: "call-perm", title: "Delete build output", kind: "delete" },
+					options,
+				});
+				await this.#send(sessionId, {
+					sessionUpdate: "agent_message_chunk",
+					content: { type: "text", text: `decision:${JSON.stringify(response.outcome)}` },
+				});
+				return { stopReason: "end_turn" };
+			}
+			case "cancel": {
+				await this.#send(sessionId, {
+					sessionUpdate: "agent_message_chunk",
+					content: { type: "text", text: "waiting-for-cancel" },
+				});
+				await new Promise<void>(resolve => {
+					this.#releaseCancel = resolve;
+				});
+				return { stopReason: "cancelled" };
+			}
+			case "session": {
+				await this.#send(sessionId, {
+					sessionUpdate: "agent_message_chunk",
+					content: { type: "text", text: `session:${sessionId}` },
+				});
+				return { stopReason: "end_turn" };
+			}
+			case "model": {
+				const modelOption = this.#configOptions.find(option => option.category === "model");
+				const current = modelOption?.type === "select" ? modelOption.currentValue : "none";
+				await this.#send(sessionId, {
+					sessionUpdate: "agent_message_chunk",
+					content: { type: "text", text: `model:${current}` },
+				});
+				return { stopReason: "end_turn" };
+			}
+			case "images": {
+				const imageCount = params.prompt.filter(block => block.type === "image").length;
+				const textCount = params.prompt.filter(block => block.type === "text").length;
+				await this.#send(sessionId, {
+					sessionUpdate: "agent_message_chunk",
+					content: { type: "text", text: `images:${imageCount}:texts:${textCount}` },
+				});
+				return { stopReason: "end_turn" };
+			}
+			case "crash": {
+				await this.#send(sessionId, {
+					sessionUpdate: "agent_message_chunk",
+					content: { type: "text", text: "about to crash" },
+				});
+				// Kills the agent process mid-turn so the provider must report a crash.
+				process.exit(9);
+				break;
+			}
+			case "refusal":
+				return { stopReason: "refusal" };
+			case "limits":
+				return { stopReason: "max_tokens" };
+			default:
+				break;
+		}
+		return { stopReason: "end_turn" };
+	}
+}
+
+const connection = new AgentSideConnection(
+	conn => new FixtureAgent(conn),
+	ndJsonStream(stream.Writable.toWeb(process.stdout), stream.Readable.toWeb(process.stdin)),
+);
+await connection.closed;

--- a/packages/ai/test/fixtures/devin-acp-agent.ts
+++ b/packages/ai/test/fixtures/devin-acp-agent.ts
@@ -220,6 +220,25 @@ class FixtureAgent implements Agent {
 				});
 				return { stopReason: "end_turn" };
 			}
+			case "toolcall-then-wait": {
+				await this.#send(sessionId, {
+					sessionUpdate: "tool_call",
+					toolCallId: "call-abort",
+					title: "Run the test suite",
+					kind: "execute",
+					status: "pending",
+					rawInput: { command: "bun test" },
+				});
+				// Receipt on the agent side so a test can abort only after the client has
+				// been sent the call, without polling client-internal state.
+				if (receiptPath) {
+					fs.writeFileSync(receiptPath, JSON.stringify({ scenario, toolCallSent: true }));
+				}
+				await new Promise<void>(resolve => {
+					this.#releaseCancel = resolve;
+				});
+				return { stopReason: "cancelled" };
+			}
 			case "model": {
 				const modelOption = this.#configOptions.find(option => option.category === "model");
 				const current = modelOption?.type === "select" ? modelOption.currentValue : "none";

--- a/packages/ai/test/fixtures/devin-acp-agent.ts
+++ b/packages/ai/test/fixtures/devin-acp-agent.ts
@@ -144,11 +144,18 @@ class FixtureAgent implements Agent {
 				return { stopReason: "end_turn" };
 			}
 			case "permission":
-			case "permission-reject-only": {
+			case "permission-reject-only":
+			case "permission-allow-always-only": {
 				const allowOnce = { optionId: "allow-once", name: "Allow once", kind: "allow_once" as const };
 				const allowAlways = { optionId: "allow-always", name: "Always allow", kind: "allow_always" as const };
 				const rejectOnce = { optionId: "reject-once", name: "Reject", kind: "reject_once" as const };
-				const options = scenario === "permission-reject-only" ? [rejectOnce] : [allowOnce, allowAlways, rejectOnce];
+				const rejectAlways = { optionId: "reject-always", name: "Always reject", kind: "reject_always" as const };
+				const options =
+					scenario === "permission-reject-only"
+						? [rejectOnce]
+						: scenario === "permission-allow-always-only"
+							? [allowAlways, rejectAlways]
+							: [allowOnce, allowAlways, rejectOnce];
 				const response = await this.#connection.requestPermission({
 					sessionId,
 					toolCall: { toolCallId: "call-perm", title: "Delete build output", kind: "delete" },

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Added
 
+- Devin CLI models are selectable through the ordinary provider/model path. When `devin acp` is installed and authenticated, `devin` models are discovered from the account (`gjc models`, `/model`), resolve without a GJC credential (authentication stays in the CLI), and can be pointed at a non-PATH executable with `GJC_DEVIN_CLI_PATH`. See `docs/devin-provider.md` for the agent-level boundary, permissions, and billing.
+
 - Successful macOS installs and updates can offer the optional experimental, third-party community Gajae Code App (#5140), defaulting to No. The shared installer requires canonical release checksums and a verified bundle/signature, skips installed apps and automation, and supports `GJC_NO_COMMUNITY_APP=1`; app failures leave GJC installed.
 
 ### Fixed

--- a/packages/coding-agent/src/config/model-preset-registry.ts
+++ b/packages/coding-agent/src/config/model-preset-registry.ts
@@ -374,6 +374,7 @@ const RegistryPresetSchema = z
 			"azure-openai-responses",
 			"bedrock-converse-stream",
 			"cursor-agent",
+			"devin-acp",
 			"google-gemini-cli",
 			"google-generative-ai",
 			"google-vertex",

--- a/packages/coding-agent/src/config/models-config-schema.ts
+++ b/packages/coding-agent/src/config/models-config-schema.ts
@@ -141,6 +141,7 @@ const ModelDefinitionSchema = z
 				"google-gemini-cli",
 				"ollama-chat",
 				"cursor-agent",
+				"devin-acp",
 			])
 			.optional(),
 		baseUrl: z.string().min(1).optional(),
@@ -234,6 +235,7 @@ const ProviderConfigSchema = z
 				"google-gemini-cli",
 				"ollama-chat",
 				"cursor-agent",
+				"devin-acp",
 			])
 			.optional(),
 		headers: z.record(z.string(), z.string()).optional(),

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -19841,6 +19841,10 @@ export class AgentSession {
 	 * provider session state and configured WebSocket transport preference
 	 * instead of falling back to a fresh HTTP/SSE session. Mirrors the
 	 * `providerSessionId ?? sessionId` affinity the agent loop sends per turn.
+	 *
+	 * `maintenanceCall` is what lets an agent-level provider (for example Devin
+	 * over ACP) refuse work it cannot serve instead of forwarding a
+	 * summarization prompt to a billed upstream agent.
 	 */
 	#maintenanceProviderTransport(): {
 		sessionId: string | undefined;
@@ -19848,6 +19852,7 @@ export class AgentSession {
 		providerSessionState: Map<string, ProviderSessionState>;
 		preferWebsockets: boolean | undefined;
 		remoteCompactionFallbackHealth: RemoteCompactionFallbackHealthHooks;
+		maintenanceCall: boolean;
 	} {
 		const providerSessionId = this.agent.providerSessionId ?? this.agent.sessionId;
 		return {
@@ -19856,6 +19861,7 @@ export class AgentSession {
 			providerSessionState: this.#providerSessionState,
 			preferWebsockets: this.agent.preferWebsockets,
 			remoteCompactionFallbackHealth: this.#remoteCompactionFallbackHealth,
+			maintenanceCall: true,
 		};
 	}
 

--- a/packages/coding-agent/test/devin-provider-surface.test.ts
+++ b/packages/coding-agent/test/devin-provider-surface.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Devin provider surface (coding-agent side).
+ *
+ * Proves the user-visible path: once `devin acp` is on PATH, Devin models are
+ * discovered through the ordinary provider/model selection path and are
+ * credentialless — GJC never asks for a Devin API key, because authentication
+ * belongs to the CLI (`devin auth login`).
+ *
+ * `test/fixtures/devin` is a stand-in executable that speaks ACP v1 over stdio
+ * using the same fixture the ai package tests use. Devin CLI itself is not
+ * installable here, so no live Devin traffic is claimed.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { kNoAuth, ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
+import { resetSettingsForTest } from "@gajae-code/coding-agent/config/settings";
+import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
+import { Snowflake } from "@gajae-code/utils";
+
+const DEVIN_STANDIN_DIR = path.resolve(import.meta.dir, "fixtures");
+const WINDOWS_SKIP = "the Devin CLI stand-in is a POSIX shebang executable";
+
+describe("devin provider surface", () => {
+	let tempDir: string;
+	let modelsJsonPath: string;
+	let authStorage: AuthStorage;
+
+	beforeEach(async () => {
+		resetSettingsForTest();
+		tempDir = path.join(os.tmpdir(), `gjc-test-devin-surface-${Snowflake.next()}`);
+		fs.mkdirSync(tempDir, { recursive: true });
+		modelsJsonPath = path.join(tempDir, "models.json");
+		fs.writeFileSync(modelsJsonPath, JSON.stringify({ providers: {} }));
+		authStorage = await AuthStorage.create(path.join(tempDir, "testauth.db"));
+	});
+
+	afterEach(() => {
+		resetSettingsForTest();
+		authStorage.close();
+		if (tempDir && fs.existsSync(tempDir)) {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	function setEnvForTest(key: string, value: string): () => void {
+		const previous = Bun.env[key];
+		Bun.env[key] = value;
+		return () => {
+			if (previous === undefined) delete Bun.env[key];
+			else Bun.env[key] = previous;
+		};
+	}
+
+	function unsetEnvForTest(key: string): () => void {
+		const previous = Bun.env[key];
+		delete Bun.env[key];
+		return () => {
+			if (previous !== undefined) Bun.env[key] = previous;
+		};
+	}
+
+	test.skipIf(process.platform === "win32")(
+		`discovers Devin models as a credentialless provider (${WINDOWS_SKIP})`,
+		async () => {
+			const restorePath = setEnvForTest("PATH", `${DEVIN_STANDIN_DIR}${path.delimiter}${Bun.env.PATH ?? ""}`);
+			const restorePresetRegistry = setEnvForTest("GJC_MODEL_PRESET_REGISTRY_DISABLED", "true");
+			const restoreCliPath = unsetEnvForTest("GJC_DEVIN_CLI_PATH");
+			try {
+				const registry = new ModelRegistry(authStorage, modelsJsonPath);
+				await registry.refreshProvider("devin", "online");
+
+				const models = registry.getAll().filter(model => model.provider === "devin");
+				expect(models.map(model => model.id).sort()).toEqual(["adaptive", "opus", "sonnet"]);
+				expect(models.every(model => model.api === "devin-acp")).toBe(true);
+				expect(registry.getActiveProviders().filter(entry => entry.provider === "devin")).toEqual([
+					{ provider: "devin", connectionKind: "credentialless" },
+				]);
+				expect(await registry.getApiKey(models[0])).toBe(kNoAuth);
+				expect(registry.getAvailable().map(model => model.id)).toContain("adaptive");
+			} finally {
+				restoreCliPath();
+				restorePresetRegistry();
+				restorePath();
+			}
+		},
+	);
+
+	test.skipIf(process.platform === "win32")(
+		`discovers no Devin models when the CLI is missing (${WINDOWS_SKIP})`,
+		async () => {
+			const missing = path.join(tempDir, "missing-devin");
+			const restoreCliPath = setEnvForTest("GJC_DEVIN_CLI_PATH", missing);
+			const restorePresetRegistry = setEnvForTest("GJC_MODEL_PRESET_REGISTRY_DISABLED", "true");
+			try {
+				const registry = new ModelRegistry(authStorage, modelsJsonPath);
+				await registry.refreshProvider("devin", "online");
+				expect(registry.getAll().filter(model => model.provider === "devin")).toEqual([]);
+			} finally {
+				restorePresetRegistry();
+				restoreCliPath();
+			}
+		},
+	);
+});

--- a/packages/coding-agent/test/devin-toolcall-dispatch.test.ts
+++ b/packages/coding-agent/test/devin-toolcall-dispatch.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Regression test: the GJC agent loop must never dispatch a Devin tool call.
+ *
+ * ACP agents execute their own tools, so the Devin provider renders
+ * `tool_call`/`tool_call_update` notifications as display-only transcript
+ * entries. The agent loop dispatches every `toolCall` block it is not told to
+ * skip, so this test drives the real loop with the real provider (against the
+ * ACP agent fixture over stdio) and a recording `bash` tool whose only job is to
+ * prove local execution never happens.
+ *
+ * Devin CLI itself is not installed here: the traffic is fixture traffic and no
+ * live Devin session is claimed.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import * as path from "node:path";
+
+import { Agent, type AgentEvent, type AgentTool } from "@gajae-code/agent-core";
+import type { AssistantMessage, AssistantMessageEvent, Context, Model } from "@gajae-code/ai";
+import {
+	DEVIN_ACP_BASE_URL,
+	DEVIN_ACP_CONTEXT_WINDOW,
+	DEVIN_ACP_MAX_TOKENS,
+	streamDevinAcp,
+} from "@gajae-code/ai/providers/devin-acp";
+import { isProviderResolvedToolCall } from "@gajae-code/ai/utils/block-symbols";
+import { AssistantMessageEventStream } from "@gajae-code/ai/utils/event-stream";
+
+const ACP_FIXTURE = path.resolve(import.meta.dir, "../../ai/test/fixtures/devin-acp-agent.ts");
+
+const ZERO_USAGE: AssistantMessage["usage"] = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+function devinModel(): Model<"devin-acp"> {
+	return {
+		id: "adaptive",
+		name: "adaptive",
+		api: "devin-acp",
+		provider: "devin",
+		baseUrl: DEVIN_ACP_BASE_URL,
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: DEVIN_ACP_CONTEXT_WINDOW,
+		maxTokens: DEVIN_ACP_MAX_TOKENS,
+	};
+}
+
+function scriptedStop(text: string): AsyncIterable<AssistantMessageEvent> & {
+	result(): Promise<AssistantMessage>;
+} {
+	const stream = new AssistantMessageEventStream();
+	queueMicrotask(() => {
+		stream.push({
+			type: "done",
+			reason: "stop",
+			message: {
+				role: "assistant",
+				content: [{ type: "text", text }],
+				api: "devin-acp",
+				provider: "devin",
+				model: "adaptive",
+				usage: ZERO_USAGE,
+				stopReason: "stop",
+				timestamp: Date.now(),
+			},
+		});
+		stream.end();
+	});
+	return stream;
+}
+
+const cleanup: Array<() => void> = [];
+
+afterEach(() => {
+	for (const dispose of cleanup.splice(0)) dispose();
+});
+
+describe("devin tool-call dispatch boundary", () => {
+	test("the agent loop executes no Devin tool call and emits no tool result", async () => {
+		await expectNoDevinDispatch(undefined);
+	});
+
+	test("managed fallback runs still execute no Devin tool call", async () => {
+		await expectNoDevinDispatch({ fallbackManaged: true });
+	});
+
+	async function expectNoDevinDispatch(promptOptions: { fallbackManaged: boolean } | undefined): Promise<void> {
+		const invocations: unknown[] = [];
+		const bashTool = {
+			name: "bash",
+			label: "bash",
+			description: "records any local execution of a Devin-issued tool call",
+			parameters: { type: "object", properties: { command: { type: "string" } }, additionalProperties: true },
+			async execute(_id: string, params: unknown) {
+				invocations.push(params);
+				return { content: [{ type: "text" as const, text: "LOCAL_BASH_EXECUTED" }] };
+			},
+		} as unknown as AgentTool;
+
+		let calls = 0;
+		let providerStream: AssistantMessageEventStream | undefined;
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model: devinModel(), systemPrompt: ["test"], tools: [bashTool], messages: [] },
+			streamFn: ((model: unknown, context: Context, options: Record<string, unknown>) => {
+				calls += 1;
+				if (calls > 1) return scriptedStop("second turn");
+				providerStream = streamDevinAcp(model as Model<"devin-acp">, context, {
+					...options,
+					devinAcp: { cliPath: process.execPath, cliArgs: [ACP_FIXTURE, "chat"] },
+					providerSessionId: "devin-dispatch-regression",
+				});
+				return providerStream;
+			}) as never,
+		});
+
+		const toolEvents: AgentEvent[] = [];
+		let firstAssistant: AssistantMessage | undefined;
+		agent.subscribe(event => {
+			if (event.type === "tool_execution_start" || event.type === "tool_execution_end") toolEvents.push(event);
+			if (event.type === "message_end" && (event as { message?: AssistantMessage }).message?.role === "assistant") {
+				firstAssistant ??= (event as { message: AssistantMessage }).message;
+			}
+		});
+
+		await agent.prompt("run the tests", promptOptions as never);
+		const providerMessage = await providerStream!.result();
+
+		const providerToolCall = providerMessage.content.find(block => block.type === "toolCall");
+		// The fixture's `chat` scenario reports a `kind: execute` tool call, so the
+		// provider renders it under the local `bash` display name — and marks it so
+		// the loop cannot dispatch it.
+		expect(providerToolCall?.type === "toolCall" && providerToolCall.name).toBe("bash");
+		expect(providerToolCall !== undefined && isProviderResolvedToolCall(providerToolCall)).toBe(true);
+		expect(providerMessage.stopReason).not.toBe("toolUse");
+		// The loop-visible message is an event snapshot (spreads drop symbol keys),
+		// so the dispatch boundary is proven by what the loop did, not by that copy.
+		expect(firstAssistant?.content.some(block => block.type === "toolCall")).toBe(true);
+		expect(invocations).toEqual([]);
+		expect(toolEvents).toEqual([]);
+	}
+
+	test("marks Devin tool calls as provider-resolved while plain tool calls still dispatch", async () => {
+		const invocations: unknown[] = [];
+		const bashTool = {
+			name: "bash",
+			label: "bash",
+			description: "records local execution",
+			parameters: { type: "object", properties: { command: { type: "string" } }, additionalProperties: true },
+			async execute(_id: string, params: unknown) {
+				invocations.push(params);
+				return { content: [{ type: "text" as const, text: "LOCAL_BASH_EXECUTED" }] };
+			},
+		} as unknown as AgentTool;
+
+		// Control: an unmarked tool call with the same name and arguments must still
+		// be dispatched, so the assertion above cannot pass for the wrong reason.
+		let calls = 0;
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model: devinModel(), systemPrompt: ["test"], tools: [bashTool], messages: [] },
+			streamFn: ((model: Model<"devin-acp">) => {
+				calls += 1;
+				if (calls > 1) return scriptedStop("done");
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(() => {
+					const message: AssistantMessage = {
+						role: "assistant",
+						content: [{ type: "toolCall", id: "local-1", name: "bash", arguments: { command: "echo local" } }],
+						api: "devin-acp",
+						provider: "devin",
+						model: model.id,
+						usage: ZERO_USAGE,
+						stopReason: "toolUse",
+						timestamp: Date.now(),
+					};
+					stream.push({
+						type: "toolcall_end",
+						contentIndex: 0,
+						toolCall: message.content[0] as never,
+						partial: message,
+					});
+					stream.push({ type: "done", reason: "toolUse", message });
+					stream.end();
+				});
+				return stream;
+			}) as never,
+		});
+
+		await agent.prompt("run a local command");
+		expect(invocations).toEqual([{ command: "echo local" }]);
+	});
+});

--- a/packages/coding-agent/test/devin-toolcall-dispatch.test.ts
+++ b/packages/coding-agent/test/devin-toolcall-dispatch.test.ts
@@ -13,6 +13,8 @@
  */
 
 import { afterEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 
 import { Agent, type AgentEvent, type AgentTool } from "@gajae-code/agent-core";
@@ -27,6 +29,11 @@ import { isProviderResolvedToolCall } from "@gajae-code/ai/utils/block-symbols";
 import { AssistantMessageEventStream } from "@gajae-code/ai/utils/event-stream";
 
 const ACP_FIXTURE = path.resolve(import.meta.dir, "../../ai/test/fixtures/devin-acp-agent.ts");
+const tempDirs: string[] = [];
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
 
 const ZERO_USAGE: AssistantMessage["usage"] = {
 	input: 0,
@@ -146,6 +153,68 @@ describe("devin tool-call dispatch boundary", () => {
 		expect(invocations).toEqual([]);
 		expect(toolEvents).toEqual([]);
 	}
+
+	test("an aborted turn fabricates no tool result for a Devin tool call", async () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-devin-abort-"));
+		tempDirs.push(dir);
+		const receipt = path.join(dir, "toolcall-receipt.json");
+		const invocations: unknown[] = [];
+		const bashTool = {
+			name: "bash",
+			label: "bash",
+			description: "records local execution",
+			parameters: { type: "object", properties: { command: { type: "string" } }, additionalProperties: true },
+			async execute(_id: string, params: unknown) {
+				invocations.push(params);
+				return { content: [{ type: "text" as const, text: "LOCAL_BASH_EXECUTED" }] };
+			},
+		} as unknown as AgentTool;
+
+		const toolEvents: AgentEvent[] = [];
+		let providerStream: AssistantMessageEventStream | undefined;
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model: devinModel(), systemPrompt: ["test"], tools: [bashTool], messages: [] },
+			streamFn: ((model: unknown, context: Context, options: Record<string, unknown>) => {
+				providerStream = streamDevinAcp(model as Model<"devin-acp">, context, {
+					...options,
+					devinAcp: {
+						cliPath: process.execPath,
+						cliArgs: [ACP_FIXTURE, "toolcall-then-wait", receipt],
+					},
+					providerSessionId: "devin-abort-regression",
+				});
+				return providerStream;
+			}) as never,
+		});
+		agent.subscribe(event => {
+			if (event.type === "tool_execution_start" || event.type === "tool_execution_end") toolEvents.push(event);
+		});
+
+		const sawToolCall = (): boolean => {
+			try {
+				return (JSON.parse(fs.readFileSync(receipt, "utf8")) as { toolCallSent?: boolean }).toolCallSent === true;
+			} catch {
+				return false;
+			}
+		};
+		const run = agent.prompt("run the tests");
+		for (let attempt = 0; attempt < 120 && !sawToolCall(); attempt += 1) await Bun.sleep(25);
+		expect(sawToolCall()).toBe(true);
+		agent.abort();
+		await run;
+
+		const aborted = agent.state.messages.findLast(message => message.role === "assistant") as
+			| AssistantMessage
+			| undefined;
+		const phantomResults = agent.state.messages.filter(
+			message => message.role === "toolResult" && message.toolCallId === "call-abort",
+		);
+		expect(aborted?.stopReason).toBe("aborted");
+		expect(invocations).toEqual([]);
+		expect(toolEvents).toEqual([]);
+		expect(phantomResults).toEqual([]);
+	});
 
 	test("marks Devin tool calls as provider-resolved while plain tool calls still dispatch", async () => {
 		const invocations: unknown[] = [];

--- a/packages/coding-agent/test/fixtures/devin
+++ b/packages/coding-agent/test/fixtures/devin
@@ -1,0 +1,10 @@
+#!/usr/bin/env bun
+// Test stand-in for the Devin CLI.
+//
+// The Devin provider always spawns `<cli> acp`, matching `devin acp`
+// (https://docs.devin.ai/cli/reference/commands#devin-acp). An unrecognized
+// scenario argument makes the shared ACP fixture behave as its default agent,
+// which is everything model discovery needs: initialize, then session/new with
+// a `model` config option. It reuses the ACP fixture from the ai package so the
+// coding-agent surface tests speak the same protocol implementation.
+import "../../../ai/test/fixtures/devin-acp-agent.ts";

--- a/schemas/models.schema.json
+++ b/schemas/models.schema.json
@@ -38,7 +38,8 @@
 							"google-vertex",
 							"google-gemini-cli",
 							"ollama-chat",
-							"cursor-agent"
+							"cursor-agent",
+							"devin-acp"
 						]
 					},
 					"headers": {
@@ -362,7 +363,8 @@
 										"google-vertex",
 										"google-gemini-cli",
 										"ollama-chat",
-										"cursor-agent"
+										"cursor-agent",
+										"devin-acp"
 									]
 								},
 								"baseUrl": {


### PR DESCRIPTION
## What and why

Closes #5480. The issue asks GJC to support Devin CLI as a selectable provider, and asks explicitly whether a genuine model-provider integration is possible or only an external-agent/ACP boundary is feasible. Assessment first, then the implementation that follows from it.

**Assessment.** Devin CLI publishes no model-inference endpoint. Its documented programmatic surfaces are `devin acp` (Agent Client Protocol server over stdio), `devin -p`, `devin models list`, and `devin auth login`. ACP exposes a complete agent, not a raw model API, and Devin CLI credentials cannot be reused for arbitrary inference (GitHub Copilot-style credential reuse does not apply here). So the feasible integration is an **agent-level** provider, and this PR implements exactly that instead of pretending Devin is a model backend.

**Implementation.**

- `packages/ai/src/providers/devin-acp.ts` (new): ACP client bridge. Spawns `devin acp` over stdio via `@agentclientprotocol/sdk@1.3.0`, negotiates `initialize`, keeps one ACP session per GJC conversation (`providerSessionId` + `providerSessionState`, child killed on `close()`), forwards only the newest user message, maps `session/update` (agent text, agent thoughts, remote tool calls) into `AssistantMessageEventStream`, answers `session/request_permission`, forwards cancellation as `session/cancel`, and discovers/selects models from the ACP session's own `model` config option (`session/set_config_option`).
- Turn lifecycle is bounded and cancellable. The ACP child is spawned in — and cached per — the session working directory (`cwd` is part of the bridge identity, so `/move` starts a fresh ACP session in the new directory and closes the child it replaced). The idle budget measures the **gap between agent updates** and is re-armed by every `session/update`, so a long but active turn is not killed by a whole-turn deadline — while a turn that goes genuinely silent still expires. Cancellation delivers `session/cancel` with a bounded wait for the handshake, wakes a parked handshake or prompt, and settles the stream; a disposable child is reaped as soon as the turn unwinds, even when the agent never answers. The cached bridge re-applies the permission policy per turn, so a later turn that tightens to `deny` (or supplies its own handler) is honoured instead of inheriting the turn that created the child.
- Tool calls stay inside Devin. ACP agents execute their own tools, so GJC renders `tool_call`/`tool_call_update` as display-only transcript entries (`_acp` annotation with `toolCallId`/`kind`/`status`) and always ends the turn with a normal stop. GJC never executes a Devin tool call: every Devin tool call carries the in-process `kProviderResolvedToolCall` marker, the agent loop excludes marked calls from dispatch, and the marker is re-attached by tool-call identity across managed and lossless snapshot rebuilds. The marker was Cursor-specific (`kCursorExecResolved`) and did not survive a snapshot rebuild, which would have let the loop dispatch a Devin tool call locally; it is now provider-neutral and preserved for both providers.
- Marker preservation covers every rebuild. The provider-resolved marker is re-attached by tool-call identity on each path that rebuilds an assistant message between the provider response and dispatch: the managed shell, the lossless snapshot constructor, `sanitizeProviderSafetyStopProvenance`'s detached rebuild, and the abort path's partial-content clone. Restoration is fail-closed (an ambiguous identity match suppresses dispatch rather than dropping the mark), and the marker is registered with `Symbol.for` so two loaded copies of `@gajae-code/ai` cannot disagree about it.
- Permissions are explicit, never implicit: `GJC_DEVIN_PERMISSION_MODE=allow` (default) grants `allow_once`; a request that offers no `allow_once` is **cancelled**, because GJC never escalates itself to a persistent `allow_always`. `deny` selects `reject_once` (or `reject_always`, a persistent refusal only narrows what the agent may do); an unrecognized value fails closed to `deny`; no matching option, a throwing handler, or an unoffered option id all resolve to `cancelled`.
- Maintenance boundary. Compaction, handoff, branch summaries, session titles, commit messages, and prompt suggestions are GJC work, not Devin turns: the new `StreamOptions.maintenanceCall` marker (set by `#maintenanceProviderTransport()`, threaded through `packages/agent` compaction/handoff/branch-summary) plus the session-identity requirement make the provider refuse them with an actionable error instead of spending the user's Devin quota and storing a bogus summary. Request attribution is untouched — manual compaction stays user-attributed for Copilot `x-initiator`.
- Coding-agent surfaces: `devin` is registered as a keyless provider (`allowUnauthenticated`), so once the CLI is installed and authenticated its models appear through the normal `/model` and `gjc models` path with no GJC credential; `models.yml`/preset schema enums accept `devin-acp` (regenerated `schemas/models.schema.json`).
- Docs: `docs/devin-provider.md` states the full boundary (which GJC surfaces apply, permission policy, billing on the Devin account, troubleshooting), plus `docs/environment-variables.md` and `docs/models.md`.

## Verification

- `bun --cwd=packages/ai run check`, `bun --cwd=packages/agent run check`, `bun --cwd=packages/coding-agent run check`: biome + tsc clean.
- `bun run check:schemas`, `bun scripts/check-visible-definitions.ts`, `bun scripts/rebrand-inventory.ts --strict`: clean.
- `bun test test/devin-acp-provider.test.ts` (packages/ai): 37 pass / 0 fail — turn mapping (text, thinking, display-only tool call, `stopReason: "stop"`, the opening `start` event), stop-reason mapping, real ACP `session/cancel` with an agent-side receipt, crash/auth/missing-CLI/unknown-model error mapping, permission policy (`allow_once` only, cancel when it is not offered, deny with `reject_always` fallback, no-match cancel, explicit handler, throwing handler, the environment matrix, per-turn policy on a cached conversation, and an explicit out-of-type mode failing closed), model selection/discovery, per-conversation session reuse, maintenance/identity refusals, a gap-based idle budget on an active turn and its expiry after activity, a cancel racing the ACP handshake, disposable-child reaping, and the cwd-scoped bridge identity plus replacement.
- `bun test test/devin-toolcall-dispatch.test.ts` (packages/coding-agent): 4 pass / 0 fail — drives the real agent loop against the real provider (an ACP agent subprocess over stdio) in unmanaged and managed modes, plus the abort path and an unmarked control, and fails if any local tool runs for a provider-executed call.
- `bun test test/devin-provider-surface.test.ts` (packages/coding-agent): 2 pass / 0 fail — real `ModelRegistry` discovery from a PATH-resolved `devin acp` stand-in (adaptive/opus/sonnet, `api: devin-acp`, `connectionKind: credentialless`, `kNoAuth`), and no models when the CLI is missing.
- `bun test test/compaction-transport.test.ts` (packages/agent): 9 pass / 0 fail — every maintenance call reaches the provider with `maintenanceCall: true`.
- `bun test` in `packages/agent` (full suite): 917 pass / 0 fail.
- `agent-session-auto-compaction-x-initiator.test.ts`: 4 pass / 0 fail (manual compaction attribution unchanged).
- Base flake, not a PR failure: `agent-session-terminal-abort-chain.test.ts` intermittently fails with `SessionDisposalIncompleteError` (bounded teardown deadline) at every head including clean `dev`. Reproduced on this machine at clean `origin/dev` `54e8cc3f` (4/43 fail) and on the immutable base `6eaf7810` (dev CI shard-3 run 34602928915 fails the same two cases at `agent-session.ts:9162`); the file is untouched by this PR and the individual cases pass in isolation.

## Not tested / limits

- **No live Devin traffic.** Devin CLI is not installable in this environment and there is no Devin account, so nothing here claims a real `devin acp` session. The provider is verified against a spec-faithful ACP v1 agent subprocess built on the official `@agentclientprotocol/sdk` (the interface `devin acp` implements), including a real stdio handshake, session, prompt, permission exchange, and cancel.
- Devin's account-specific model catalog, enterprise allowlists, and ACU billing were not exercised against the live service.
- GJC-side compaction is not supported on a Devin model (refused, documented); it is also unnecessary because GJC forwards only the newest message and Devin manages its own context.
- Devin's tools, skills, hooks, and MCP servers run inside Devin; GJC tools, workflows, role agents, and hooks do not apply to a Devin turn. Documented rather than implied.

## Risk classification

- [x] `low-risk` — additive provider, plus focused existing-path changes that make the provider's own documented contract true: the additive `maintenanceCall` marker (with two enum additions), the provider-neutral `kProviderResolvedToolCall` marker threading that keeps a provider-executed tool call out of local dispatch, and the Devin turn lifecycle (gap-based idle budget, cancellation that settles a racing handshake, cwd-scoped bridge identity). Each is covered by its own regression test.
- [ ] `regression-risk`
- [ ] `high-risk`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:2a71c41388bfe29c59c5eb6df1a26acc4ed9b8396696054f35b48b1b52b227d1 reviewer:human reviewer-id:Yeachan-Heo evidence:exact-head-ci-pending;packages-check-clean;ai-provider-37-pass;toolcall-dispatch-4-pass;coding-agent-surface-2-pass;agent-compaction-transport-9-pass;docs-index-5-pass;base-flake-abort-chain-reproduced-on-dev;no-live-devin-traffic
```

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*

