### PR TITLE
fix(lock): require durable scrub receipt for orphan adoption

### DIFF
--- a/packages/coding-agent/src/config/file-lock.ts
+++ b/packages/coding-agent/src/config/file-lock.ts
@@ -654,6 +654,7 @@ async function adoptOrphanedFileLockRemovalTransition(lockPath: string, orphanAg
 	// replacement is never deleted.
 	if (
 		removal.code === "cleanup_pending" &&
+		removal.payloadDurable === true &&
 		removal.detachedPath !== undefined &&
 		path.resolve(removal.detachedPath) === path.resolve(transitionPath) &&
 		removal.retainedSuccessorPath === undefined &&

--- a/packages/coding-agent/test/file-lock-gc-toctou.test.ts
+++ b/packages/coding-agent/test/file-lock-gc-toctou.test.ts
@@ -1076,6 +1076,48 @@ describe("file lock cleanup failure handling (#2478)", () => {
 	);
 
 	test.skipIf(process.platform === "win32")(
+		"keeps an aged scrubbed transition when native cleanup lacks durable payload proof",
+		async () => {
+			const lockedFile = path.join(await makeTemp(), "state.json");
+			const lockDir = `${lockedFile}.lock`;
+			const detachedPath = `${lockDir}.removing`;
+			const infoPath = path.join(detachedPath, "info");
+			await fs.mkdir(detachedPath);
+			await Bun.write(infoPath, "");
+			const old = new Date(Date.now() - 120_000);
+			await fs.utimes(infoPath, old, old);
+			FileLockTestHooks.nativeQuarantineBindings = () => ({
+				snapshotDirectoryTree,
+				exactRemoveDirectoryTree: () => ({
+					ok: false,
+					code: "cleanup_pending",
+					payloadDurable: false,
+					detachedPath,
+				}),
+			});
+
+			let entered = false;
+			const failure = await withFileLock(
+				lockedFile,
+				async () => {
+					entered = true;
+				},
+				{ retries: 1, retryDelayMs: 1 },
+			).catch(error => error);
+			expect(failure).toBeInstanceOf(FileLockAcquireError);
+			expect(failure).toMatchObject({
+				code: "orphan_transition",
+				reason: "orphan_transition",
+				orphanPath: detachedPath,
+				attempts: 1,
+			});
+			expect(entered).toBe(false);
+			expect(await fs.exists(detachedPath)).toBe(true);
+			expect(await fs.readFile(infoPath, "utf8")).toBe("");
+		},
+	);
+
+	test.skipIf(process.platform === "win32")(
 		"keeps the typed orphan diagnostic when a transition payload was never scrubbed",
 		async () => {
 			const lockedFile = path.join(await makeTemp(), "state.json");


### PR DESCRIPTION
## What
Follow-up hardening for #5474 and #5504: require the native removal result's explicit `payloadDurable: true` marker before adopting and recursively removing an orphaned `.lock.removing` transition.

## Why
The merged stage-2 implementation already required an aged empty/unparseable `info`, an all-zero native snapshot, the deterministic retained path, and no successor/placeholder/unknown path. Final red-team review found one remaining authority gap: native POSIX exact removal can return `cleanup_pending` at the same retained path before payload scrub is durable. The root identity check alone is not enough to authorize recursive filesystem removal in that case.

This correction preserves `orphan_transition` and leaves the transition untouched for every `cleanup_pending` result without `payloadDurable === true`. A focused regression injects the pre-scrub result and verifies the exact diagnostic/path and retained `info`.

## Exact-head verification
- Base SHA: `89d573caef6a8f776de3dec3f85fafa1693ffec0`
- Final head SHA: `320716a5b7bc3d298774136b0db856c158d3fef2`
- Merge base: `cc17e58f483b8599acd1ca877258d3ece493acc6`
- Exact base…head diff SHA-256: `1ff4a08b911668cbe3a2f43547f6228d47a4d7888a0762f211e5045ee265a764`
- This follow-up contains only the two-file correction on top of the already merged #5504 change.

## Testing
- Focused new regression: `bun test packages/coding-agent/test/file-lock-gc-toctou.test.ts -t "keeps an aged scrubbed transition when native cleanup lacks durable payload proof"` — 1 pass, 0 fail.
- Focused lock/lease/gc suites — 120 pass, 2 platform skips, 0 fail.
- `bun test packages/coding-agent/test/session-state-sidecar.test.ts --timeout 30000` — 175 pass, 0 fail.
- `bun --cwd=packages/coding-agent run check` (Biome + `tsc --noEmit`) — passed.
- `git diff --check` — passed.

## Risk classification

- [ ] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict with a bound low-risk record.
- [x] `regression-risk` — identity-sensitive lock cleanup correction; requires an authenticated exact-head independent approval.
- [ ] `high-risk` — large refactor, feature, or materially high-risk change.

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:1ff4a08b911668cbe3a2f43547f6228d47a4d7888a0762f211e5045ee265a764 reviewer:human reviewer-id:probepark evidence:durable-scrub-marker-regression;focused-tests-120-pass;package-check-pass;exact-head-review-5186723922
```

---

- [x] Target branch is `dev`
- [x] Tested locally
- [x] CHANGELOG unchanged: this is a fail-closed hardening correction to the already released Unreleased entry
- [x] Verdict matches the exact final head
- [x] Risk classification matches the review path