### PR TITLE
test(ai): isolate the direct OAuth refresh failure fixture

### DIFF
--- a/packages/ai/test/auth-storage-oauth-refresh-race.test.ts
+++ b/packages/ai/test/auth-storage-oauth-refresh-race.test.ts
@@ -261,7 +261,7 @@ describe("AuthStorage OAuth refresh race", () => {
 	});
 
 	test("still disables when the failure is real (no concurrent rotation)", async () => {
-		if (!authStorage) throw new Error("test setup failed");
+		if (!authStorage || !store) throw new Error("test setup failed");
 
 		// Single-process scenario: refresh genuinely fails and no peer updated the
 		// row. The credential should still be soft-deleted.
@@ -274,9 +274,10 @@ describe("AuthStorage OAuth refresh race", () => {
 			},
 		]);
 
-		vi.spyOn(oauthUtils, "getOAuthApiKey").mockImplementation(async () => {
-			throw new Error('invalid_grant {"error":"invalid_grant"}');
-		});
+		const refreshSpy = vi
+			.spyOn(oauthUtils, "refreshOAuthToken")
+			.mockRejectedValue(new Error('invalid_grant {"error":"invalid_grant"}'));
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("Unexpected OAuth network request"));
 
 		await withEnv(SUPPRESS_ANTHROPIC_ENV, async () => {
 			const apiKey = await authStorage!.getApiKey("anthropic", "session-real-failure");
@@ -284,6 +285,10 @@ describe("AuthStorage OAuth refresh race", () => {
 			expect(apiKey).toBeUndefined();
 			expect(events).toHaveLength(1);
 			expect(events[0]?.disabledCause).toContain("invalid_grant");
+			expect(refreshSpy).toHaveBeenCalledTimes(1);
+			expect(refreshSpy).toHaveBeenCalledWith("anthropic", expect.objectContaining({ refresh: "stale-refresh" }));
+			expect(fetchSpy).not.toHaveBeenCalled();
+			expect(store!.listAuthCredentials("anthropic")).toHaveLength(0);
 		});
 	});
 


### PR DESCRIPTION
## Summary
Fix a reproducible test-fixture failure found while qualifying merged #5467 for release. The revoked-token test mocked `getOAuthApiKey`, while AuthStorage actually invokes `refreshOAuthToken`; it unintentionally contacted the real Anthropic endpoint and failed with HTTP403 instead of the intended `invalid_grant`.

The fixture now mocks the executed refresh seam and asserts one refresh with the stale token, zero HTTP requests, the original invalid-grant disable event, and removal of the revoked row. Production authentication behavior is unchanged.

## Verification
- Before: exact-root four-file run —119pass/1fail, failure in this fixture reaching the real endpoint.
- After: `bun test ./packages/ai/test/auth-storage-oauth-refresh-race.test.ts` —28pass/0fail,151assertions.
- `bun --cwd=packages/ai run check` —Biome and TypeScript passed.
- `git diff --check` —passed.
- Test-only: existing docs/changelog are unchanged; no product behavior changed.
- No live credential or provider-entitlement validation claimed.

## Exact head
Base: `ea8d48abbeda0c2815eada0e08fdd2d18f2d7347`
Head: `882396a55c15bd9e159b557f3f02c6df6195c583`
Canonical binary/full-index diff SHA256: `b265a5cdc4264f1bcc7c5bc5de64e9974570e02b5aa228326c205ff071dbf5ee`

## Risk classification
- [x] `low-risk` —test-only fixture isolation; no production behavior or authorization boundary changed.
- [ ] `regression-risk`
- [ ] `high-risk`

## Verdict
gajae.pr-review-verdict.v1 merge-approved sha256:b265a5cdc4264f1bcc7c5bc5de64e9974570e02b5aa228326c205ff071dbf5ee reviewer:human reviewer-id:probepark evidence:ci-gate-waiting-only;test-only-mock-seam-fix;refreshOAuthToken-spy-verified;fetch-guard-added;store-guard-added

No merge or release authorization is inferred from local passes. Related release-resolution run01a095dc; does not claim full incident closure for other release blockers.
