### PR TITLE
feat(browser): declare Aside activity on Bash calls

### DIFF
--- a/docs/aside-integration.md
+++ b/docs/aside-integration.md
@@ -148,6 +148,38 @@ Docs-only remains the smallest safe outcome for the search/context sidecar in is
 
 There is no fallback to the native browser. When the Aside CLI is unavailable, the direct CLI command fails in the Bash tool result and the session has no browser tool.
 
+### Structured activity declaration on Bash
+
+Aside execution is still ordinary Bash: GJC spawns or supervises no Aside
+process, and the Bash executor never inspects the command. What the routing
+contract adds is one optional, model-declared field on the Bash tool call:
+
+```json
+{ "kind": "browser", "provider": "aside", "mode": "repl" | "exec" }
+```
+
+- The `<browser-backend>` prompt block requires the declaration on every Bash
+  invocation that runs Aside — `mode: "repl"` for `aside repl`, `mode: "exec"`
+  for `aside exec` including `--session` follow-ups — and requires omitting it
+  on Bash calls that do not invoke Aside. The declaration names the operation,
+  not the command spelling, so wrappers, env prefixes, absolute CLI paths,
+  quoting, and multiline commands do not change it.
+- The schema is shape-validated only (`BashToolInput.activity` in
+  `src/tools/bash.ts`). A malformed or unsupported declaration is dropped, never
+  coerced, and never fails an otherwise valid command; a call without one is
+  ordinary Bash with unchanged semantics. GJC does **not** verify that the
+  command actually invokes Aside — the declaration is authoritative as part of
+  the model-facing routing contract, not as OS-level process verification.
+- The accepted value is mirrored into `BashToolDetails.activity` on foreground
+  results, background/folded starts, and background job progress/terminal
+  details, so the existing tool-call lifecycle (`tool_execution_start`/`_update`/`_end`
+  with `toolCallId`) transports it with no new event, id, persistence, or state
+  store.
+- Consumers (such as embedding apps) may use the declaration for UI/activity
+  projection. Consumers must not fall back to parsing the command string:
+  quoting, wrappers, variables, aliases, and future CLI or prompt changes make
+  any string match a heuristic, not a contract.
+
 ```sh
 gjc config set browser.backend aside
 ```

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+
+- Bash accepts an optional model-declared activity declaration (`activity: { kind: "browser", provider: "aside", mode: "repl" | "exec" }`) and mirrors the accepted value into `BashToolDetails.activity` on foreground results, background/folded starts, and background job progress/terminal details. The `browser.backend: aside` routing prompt now requires the declaration on every Bash invocation that runs Aside, so embedding consumers can project Aside browser activity from the existing tool-call lifecycle instead of parsing command text. The declaration is schema-validated only: malformed values are dropped (never coerced, never fatal), calls without one are ordinary unchanged Bash, and GJC still neither spawns nor supervises Aside nor inspects the command.
+
 ### Fixed
 
 - A failing `gjc --smoke-test` no longer leaves its isolated-shell worker behind. The readiness bail-out ran a `finally` that only removed marker files, so the probe shell stayed alive and its abandoned run went unobserved; the wider readiness/run deadlines made that window long. Teardown now aborts the probe, retires the worker, and observes the run on every exit path — graceful close alone would have waited out the command’s own sleep.

--- a/packages/coding-agent/src/prompts/agent-fragments/browser-aside.md
+++ b/packages/coding-agent/src/prompts/agent-fragments/browser-aside.md
@@ -5,6 +5,7 @@ Routing:
 - Every task that requires a rendered page, authenticated/private browser state, live tabs, browser UI, screenshots, downloads behind cookies, history, saved credentials, or profile data MUST use Bash to invoke the installed Aside CLI.
 - Default to `aside repl '<JavaScript>'` for deterministic Playwright inspection and actions, even when the answer is unknown but the procedure is discoverable from `snapshot(page, { interactive: true })`.
 - Use `aside exec '<prompt>'` only for runtime judgment, source-heavy research, browser-history search, MFA or opaque password autofill, approval/notification waits, long monitoring, multi-site synthesis, routines, or work worth a second model. Continue with `aside exec --session <id> '<follow-up>'`. Use `--account`, `--model`, `--provider`, `--speed`, or `--effort` only when the task requires overriding user defaults.
+- Declare every Aside invocation on the Bash call itself with the structured `activity` argument: `{"kind":"browser","provider":"aside","mode":"repl"}` for `aside repl`, and `{"kind":"browser","provider":"aside","mode":"exec"}` for `aside exec` including `--session <id>` follow-ups. The declaration names the operation, not the command spelling: send it unchanged across wrappers, env prefixes, absolute CLI paths, quoting, and multiline commands, and omit it on Bash calls that do not invoke Aside.
 - Cookie-free public HTTP content that does not require rendered or authenticated browser state may use GJC `read` directly.
 
 Deterministic procedure:

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -481,12 +481,50 @@ export async function saveBashOriginalArtifactForTests(
 	return result.status === "saved" ? result.artifactId : undefined;
 }
 
+/**
+ * Model-declared activity metadata for the browser-backend routing contract
+ * (`browser.backend: aside`). When that contract routes a browser task through
+ * Bash, it requires the call to declare the activity structurally so consumers
+ * can project it without parsing the command text. The declaration is
+ * model-declared and schema-validated only: nothing here verifies that the
+ * command actually invokes Aside, and the executor never inspects `command`.
+ */
+export type BashActivityProvider = "aside";
+export type BashActivityMode = "repl" | "exec";
+export interface BashActivityDeclaration {
+	kind: "browser";
+	provider: BashActivityProvider;
+	mode: BashActivityMode;
+}
+
+const bashActivityDeclarationSchema = z
+	.object({
+		kind: z.literal("browser"),
+		provider: z.literal("aside"),
+		mode: z.enum(["repl", "exec"]),
+	})
+	.strict();
+
+/**
+ * Optional activity declaration. Anything that is not the exact supported
+ * shape is dropped rather than failing the call: the declaration is routing
+ * metadata, and a malformed value must never make an otherwise valid command
+ * unusable. Values are never coerced — `mode: "EXEC"` is dropped, not guessed.
+ */
+const optionalBashActivity = z
+	.preprocess(
+		value => (bashActivityDeclarationSchema.safeParse(value).success ? value : undefined),
+		bashActivityDeclarationSchema.optional(),
+	)
+	.describe("declare browser activity for the aside browser backend: repl or exec");
+
 const bashSchemaBase = z.object({
 	command: z.string().describe("command to execute"),
 	env: z.record(z.string().regex(BASH_ENV_NAME_PATTERN), z.string()).optional().describe("extra env vars"),
 	timeout: z.number().default(300).describe("timeout in seconds, NOT milliseconds (30 = 30s)").optional(),
 	cwd: z.string().describe("working directory").optional(),
 	pty: z.boolean().describe("run in pty mode").optional(),
+	activity: optionalBashActivity,
 });
 
 const bashSchemaWithAsync = bashSchemaBase.extend({
@@ -503,6 +541,8 @@ export interface BashToolInput {
 
 	async?: boolean;
 	pty?: boolean;
+	/** Accepted activity declaration, mirrored into {@link BashToolDetails.activity}. */
+	activity?: BashActivityDeclaration;
 }
 
 export interface BashToolDetails {
@@ -512,6 +552,8 @@ export interface BashToolDetails {
 	terminalId?: string;
 	/** Why the foreground wait was folded, when this result is a background-start after a fold. */
 	foldReason?: FoldReason;
+	/** The accepted model-declared activity declaration, when the call carried one. */
+	activity?: BashActivityDeclaration;
 	async?: {
 		state: "running" | "completed" | "failed";
 		jobId: string;
@@ -924,6 +966,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 			notices?: readonly string[];
 			terminalId?: string;
 			artifactReferenceInBody?: boolean;
+			activity?: BashActivityDeclaration;
 		} = {},
 	): AgentToolResult<BashToolDetails> {
 		const shortArtifactInBody = !result.truncated && result.artifactId !== undefined;
@@ -947,6 +990,9 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 		if (options.terminalId !== undefined) {
 			details.terminalId = options.terminalId;
 		}
+		if (options.activity !== undefined) {
+			details.activity = options.activity;
+		}
 		const resultBuilder = toolResult(details)
 			.text(outputText)
 			.truncationFromSummary(result, {
@@ -967,6 +1013,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 			notices?: readonly string[];
 			terminalId?: string;
 			foldReason?: FoldReason;
+			activity?: BashActivityDeclaration;
 		} = {},
 	): AgentToolResult<BashToolDetails> {
 		const details: BashToolDetails = {
@@ -980,6 +1027,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 			details.requestedTimeoutSeconds = options.requestedTimeoutSec;
 		}
 		if (options.foldReason !== undefined) details.foldReason = options.foldReason;
+		if (options.activity !== undefined) details.activity = options.activity;
 		const lines: string[] = [];
 		const trimmedPreview = previewText.trimEnd();
 		if (trimmedPreview.length > 0) {
@@ -1019,6 +1067,8 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 		onCompletion?: () => void;
 		/** Immutable attempt-scoped tool call id, when executed via a tool call. */
 		toolCallId?: string;
+		/** Accepted activity declaration, mirrored into job progress and result details. */
+		activity?: BashActivityDeclaration;
 	}): ManagedBashJobHandle {
 		const manager = this.#resolveOwnedJobManager();
 		if (!manager) {
@@ -1032,12 +1082,13 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 				: options.command;
 		let latestText = "";
 		let backgrounded = options.startBackgrounded;
+		const activityDetails = options.activity === undefined ? {} : { activity: options.activity };
 		const runningDetails = (jobId: string): Record<string, unknown> | undefined =>
-			backgrounded ? { async: { state: "running", jobId, type: "bash" } } : undefined;
+			backgrounded ? { async: { state: "running", jobId, type: "bash" }, ...activityDetails } : undefined;
 		const completedDetails = (jobId: string): Record<string, unknown> | undefined =>
-			backgrounded ? { async: { state: "completed", jobId, type: "bash" } } : undefined;
+			backgrounded ? { async: { state: "completed", jobId, type: "bash" }, ...activityDetails } : undefined;
 		const failedDetails = (jobId: string): Record<string, unknown> | undefined =>
-			backgrounded ? { async: { state: "failed", jobId, type: "bash" } } : undefined;
+			backgrounded ? { async: { state: "failed", jobId, type: "bash" }, ...activityDetails } : undefined;
 		const completion = Promise.withResolvers<ManagedBashJobCompletion>();
 
 		const jobId = manager.register(
@@ -1088,6 +1139,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 						requestedTimeoutSec: options.requestedTimeoutSec,
 						notices: options.notices,
 						artifactReferenceInBody: true,
+						activity: options.activity,
 					});
 					const finalText = this.#extractTextResult(finalResult);
 					latestText = finalText;
@@ -1110,7 +1162,10 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 					latestText = text;
 					await options.onUpdate?.({
 						content: [{ type: "text", text }],
-						details: backgrounded ? ((details ?? {}) as BashToolDetails) : {},
+						// Backgrounded frames carry the job details verbatim; a foreground
+						// frame has no job facts, but the activity declaration is per-call
+						// metadata and stays attached so partial results are self-describing.
+						details: backgrounded ? ((details ?? {}) as BashToolDetails) : (activityDetails as BashToolDetails),
 					});
 				},
 			},
@@ -1571,9 +1626,10 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 		notices: readonly string[],
 		signal: AbortSignal | undefined,
 		resolvedEnv: Record<string, string>,
+		activity: BashActivityDeclaration | undefined,
 	): Promise<AgentToolResult<BashToolDetails>> {
 		const result = await this.#runDirectMasterSpawn(command, commandCwd, timeoutMs, signal, resolvedEnv);
-		return this.#buildCompletedResult(result, timeoutSec, { requestedTimeoutSec, notices });
+		return this.#buildCompletedResult(result, timeoutSec, { requestedTimeoutSec, notices, activity });
 	}
 
 	/**
@@ -1723,6 +1779,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 
 			async: asyncRequested = false,
 			pty = false,
+			activity,
 		}: BashToolInput,
 		signal?: AbortSignal,
 		onUpdate?: AgentToolUpdateCallback<BashToolDetails>,
@@ -1767,6 +1824,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 				pendingNotices,
 				signal,
 				resolvedEnv,
+				activity,
 			);
 		}
 
@@ -1792,6 +1850,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 				onUpdate,
 				startBackgrounded: true,
 				toolCallId,
+				activity,
 			});
 			const jobGeneration = asyncManager.getJob(job.jobId)?.generation ?? job.jobId;
 			job.setBackgrounded(true);
@@ -1799,6 +1858,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 			return this.#buildBackgroundStartResult(job.jobId, job.label, "", timeoutSec, {
 				requestedTimeoutSec,
 				notices: pendingNotices,
+				activity,
 			});
 		}
 
@@ -1845,6 +1905,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 					managedForegroundSettled = true;
 				},
 				toolCallId,
+				activity,
 			});
 			const jobGeneration = ownedManager.getJob(job.jobId)?.generation ?? job.jobId;
 			if (startBackgrounded) {
@@ -1853,6 +1914,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 				return this.#buildBackgroundStartResult(job.jobId, job.label, "", timeoutSec, {
 					requestedTimeoutSec,
 					notices: pendingNotices,
+					activity,
 				});
 			}
 			const backgroundRequest = Promise.withResolvers<FoldReason>();
@@ -1948,6 +2010,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 				requestedTimeoutSec,
 				notices: pendingNotices,
 				foldReason: waitResult.reason,
+				activity,
 			});
 		}
 
@@ -2246,6 +2309,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 								requestedTimeoutSec,
 								notices: timeoutNotices,
 								terminalId: handle.terminalId,
+								activity,
 							});
 						}
 
@@ -2378,6 +2442,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 					requestedTimeoutSec,
 					notices: bridgeNotices,
 					terminalId: handle.terminalId,
+					activity,
 				});
 			};
 
@@ -2419,7 +2484,12 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 							bridgeCompletion.resolve({ kind: "completed", result });
 							await reportProgress(
 								finalText,
-								bridgeBackgrounded ? { async: { state: "completed", jobId, type: "bash" } } : undefined,
+								bridgeBackgrounded
+									? {
+											async: { state: "completed", jobId, type: "bash" },
+											...(activity === undefined ? {} : { activity }),
+										}
+									: undefined,
 							);
 							return finalText;
 						} catch (error) {
@@ -2429,7 +2499,12 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 							bridgeCompletion.resolve({ kind: "failed", error });
 							await reportProgress(
 								message,
-								bridgeBackgrounded ? { async: { state: "failed", jobId, type: "bash" } } : undefined,
+								bridgeBackgrounded
+									? {
+											async: { state: "failed", jobId, type: "bash" },
+											...(activity === undefined ? {} : { activity }),
+										}
+									: undefined,
 							);
 							throw error;
 						} finally {
@@ -2556,6 +2631,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 				notices: pendingNotices,
 				terminalId: handle.terminalId,
 				foldReason: bridgeWait.reason,
+				activity,
 			});
 		}
 
@@ -2640,6 +2716,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 										outcome = await controls.terminalCompletion;
 										const completed = this.#buildCompletedResult(outcome, timeoutSec, {
 											requestedTimeoutSec,
+											activity,
 										});
 										return this.#extractTextResult(completed);
 									} finally {
@@ -2707,6 +2784,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 									requestedTimeoutSec,
 									notices: pendingNotices,
 									foldReason: receipt.reason,
+									activity,
 								});
 								const outcome = controls.detachObserver(
 									interactiveResultFromText(this.#extractTextResult(started)),
@@ -2790,6 +2868,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 		return this.#buildCompletedResult(result, timeoutSec, {
 			requestedTimeoutSec,
 			notices: pendingNotices,
+			activity,
 		});
 	}
 }

--- a/packages/coding-agent/src/tools/tool-catalog.generated.ts
+++ b/packages/coding-agent/src/tools/tool-catalog.generated.ts
@@ -89,6 +89,33 @@ export const TOOL_CATALOG: Readonly<Record<string, ToolCatalogEntry>> = {
 				"pty": {
 					"type": "boolean",
 					"description": "run in pty mode"
+				},
+				"activity": {
+					"description": "declare browser activity for the aside browser backend: repl or exec",
+					"type": "object",
+					"properties": {
+						"kind": {
+							"type": "string",
+							"const": "browser"
+						},
+						"provider": {
+							"type": "string",
+							"const": "aside"
+						},
+						"mode": {
+							"type": "string",
+							"enum": [
+								"repl",
+								"exec"
+							]
+						}
+					},
+					"required": [
+						"kind",
+						"provider",
+						"mode"
+					],
+					"additionalProperties": false
 				}
 			},
 			"required": [

--- a/packages/coding-agent/test/sdk-browser-aside-backend.test.ts
+++ b/packages/coding-agent/test/sdk-browser-aside-backend.test.ts
@@ -44,6 +44,11 @@ describe("createAgentSession browser.backend", () => {
 			const discoverable = session.getDiscoverableTools({ source: "builtin" });
 			expect(discoverable).toEqual(expect.arrayContaining([expect.objectContaining({ name: "browser" })]));
 			expect(session.systemPrompt.join("\n\n")).not.toContain("<browser-backend>");
+			// The activity declaration requirement belongs to the Aside routing
+			// contract only; the default backend never asks Bash to declare one.
+			const nativePrompt = session.systemPrompt.join("\n\n");
+			expect(nativePrompt).not.toContain('"kind":"browser"');
+			expect(nativePrompt).not.toContain('mode":"repl');
 		} finally {
 			await session.dispose();
 		}
@@ -59,6 +64,13 @@ describe("createAgentSession browser.backend", () => {
 			expect(prompt).toContain("<browser-backend>");
 			expect(prompt).toContain("aside repl");
 			expect(prompt).not.toContain("MCP `repl`");
+			// The routing contract requires a structured declaration on every
+			// Aside Bash call, for repl, for exec, and for exec --session follow-ups.
+			expect(prompt).toContain("`activity` argument");
+			expect(prompt).toContain('{"kind":"browser","provider":"aside","mode":"repl"}');
+			expect(prompt).toContain('{"kind":"browser","provider":"aside","mode":"exec"}');
+			expect(prompt).toContain("`--session <id>` follow-ups");
+			expect(prompt).toContain("omit it on Bash calls that do not invoke Aside");
 		} finally {
 			await session.dispose();
 		}

--- a/packages/coding-agent/test/tools/bash-activity-declaration.test.ts
+++ b/packages/coding-agent/test/tools/bash-activity-declaration.test.ts
@@ -1,0 +1,241 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { AgentToolResult, AgentToolUpdateCallback } from "@gajae-code/agent-core";
+import { toolWireSchema } from "@gajae-code/ai/utils/schema/wire";
+import { validateToolArguments } from "@gajae-code/ai/utils/validation";
+import { AsyncJobManager } from "@gajae-code/coding-agent/async";
+import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
+import { disposeAllShellSessions } from "@gajae-code/coding-agent/exec/bash-executor";
+import { ArtifactManager } from "@gajae-code/coding-agent/session/artifacts";
+import type { ToolSession } from "@gajae-code/coding-agent/tools";
+import { BashTool, type BashToolDetails, type BashToolInput } from "../../src/tools/bash";
+import { stubBashExecutorSettings } from "../helpers/tool-session-settings";
+
+/**
+ * The browser-backend routing contract (`browser.backend: aside`) marks its
+ * Bash calls with a structured `activity` declaration. These tests pin the
+ * contract's three properties: generic Bash is unchanged, only the exact
+ * declaration is accepted (never coerced), and the accepted value rides the
+ * existing result/progress details. No Aside CLI, network, or browser is
+ * involved — the declaration is metadata on ordinary commands.
+ */
+
+const replDeclaration = { kind: "browser", provider: "aside", mode: "repl" } as const;
+const execDeclaration = { kind: "browser", provider: "aside", mode: "exec" } as const;
+
+function createStubBashTool(asyncEnabled = false): BashTool {
+	const session = {
+		settings: {
+			has(key: string) {
+				return this.get(key) !== undefined;
+			},
+			get(key: string) {
+				if (key === "async.enabled") return asyncEnabled;
+				if (key === "bash.autoBackground.enabled") return false;
+				if (key === "bash.autoBackground.thresholdMs") return 60_000;
+				return undefined;
+			},
+			...stubBashExecutorSettings,
+		},
+	} as unknown as ToolSession;
+
+	return new BashTool(session);
+}
+
+function validatedArguments(tool: BashTool, arguments_: Record<string, unknown>): Record<string, unknown> {
+	return validateToolArguments(tool, {
+		type: "toolCall",
+		id: "activity-tool-call",
+		name: tool.name,
+		arguments: arguments_,
+	});
+}
+
+describe("bash activity declaration: input validation", () => {
+	it("keeps generic bash input valid and unchanged without a declaration", () => {
+		for (const command of ["npm test", "git status", "python script.py"]) {
+			const tool = createStubBashTool();
+			const args = validatedArguments(tool, { command });
+			expect(args.command).toBe(command);
+			expect(args.activity).toBeUndefined();
+		}
+	});
+
+	it("accepts the repl declaration verbatim", () => {
+		const tool = createStubBashTool();
+		const args = validatedArguments(tool, {
+			command: "aside repl 'snapshot(page, { interactive: true })'",
+			activity: replDeclaration,
+		});
+		expect(args.command).toBe("aside repl 'snapshot(page, { interactive: true })'");
+		expect(args.activity).toEqual(replDeclaration);
+	});
+
+	it("accepts the exec declaration verbatim", () => {
+		const tool = createStubBashTool();
+		const args = validatedArguments(tool, {
+			command: "aside exec --session aside-1 'continue the research'",
+			activity: execDeclaration,
+		});
+		expect(args.command).toBe("aside exec --session aside-1 'continue the research'");
+		expect(args.activity).toEqual(execDeclaration);
+	});
+
+	it("drops malformed declarations without failing the command or inventing values", () => {
+		const tool = createStubBashTool();
+		const malformed = [
+			{ kind: "browser", provider: "aside", mode: "EXEC" },
+			{ kind: "browser", provider: "aside", mode: "foo" },
+			{ kind: "browser", provider: "aside" },
+			{ kind: "browser", provider: "builtin", mode: "repl" },
+			{ kind: "search", provider: "aside", mode: "repl" },
+			{ kind: "browser", provider: "aside", mode: "repl", url: "https://example.com" },
+			{ kind: "browser", provider: "aside", mode: ["repl"] },
+			"browser",
+			null,
+			true,
+		];
+		for (const activity of malformed) {
+			const args = validatedArguments(tool, { command: "npm test", activity });
+			// The command itself stays valid and untouched; only the metadata is gone.
+			expect(args.command).toBe("npm test");
+			expect(args.activity).toBeUndefined();
+		}
+	});
+
+	it("never coerces an unsupported mode into repl or exec", () => {
+		const tool = createStubBashTool();
+		for (const mode of ["EXEC", "Repl", "run", ""]) {
+			const args = validatedArguments(tool, {
+				command: "npm test",
+				activity: { kind: "browser", provider: "aside", mode },
+			});
+			expect(args.command).toBe("npm test");
+			expect(args.activity).toBeUndefined();
+		}
+	});
+
+	it("exposes the declaration on the model-facing wire schema as optional", () => {
+		const schema = toolWireSchema(createStubBashTool());
+		const properties = (schema.properties ?? {}) as Record<string, Record<string, unknown>>;
+		expect(properties.activity).toMatchObject({
+			type: "object",
+			properties: {
+				kind: { const: "browser" },
+				provider: { const: "aside" },
+				mode: { enum: ["repl", "exec"] },
+			},
+			required: ["kind", "provider", "mode"],
+		});
+		expect(schema.required ?? []).not.toContain("activity");
+	});
+});
+
+describe("bash activity declaration: result and progress details", () => {
+	let tempDir: string;
+	let settings: Settings;
+	let manager: AsyncJobManager;
+
+	function makeToolSession(): ToolSession {
+		const artifacts = new ArtifactManager(path.join(tempDir, "artifacts"));
+		return {
+			cwd: tempDir,
+			hasUI: false,
+			settings,
+			getSessionId: () => "bash-activity-test",
+			getAgentId: () => "0-Test",
+			getSessionFile: () => null,
+			getSessionSpawns: () => null,
+			getArtifactsDir: () => artifacts.dir,
+			getArtifactManager: () => artifacts,
+			allocateOutputArtifact: (toolType: string) => artifacts.allocatePath(toolType),
+		} as unknown as ToolSession;
+	}
+
+	beforeEach(async () => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-bash-activity-"));
+		resetSettingsForTest();
+		settings = await Settings.init({ inMemory: true, cwd: tempDir });
+		manager = new AsyncJobManager({ retentionMs: 20, onJobComplete: async () => {} });
+		AsyncJobManager.setInstance(manager);
+		await disposeAllShellSessions();
+	});
+
+	afterEach(async () => {
+		await manager.dispose({ timeoutMs: 1_000 });
+		AsyncJobManager.resetForTests();
+		await disposeAllShellSessions();
+		resetSettingsForTest();
+		if (fs.existsSync(tempDir)) fs.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it("mirrors the declaration into the foreground result details", async () => {
+		const tool = new BashTool(makeToolSession());
+		const result = await tool.execute("foreground-declared", {
+			command: "printf declared",
+			timeout: 5,
+			activity: replDeclaration,
+		} satisfies BashToolInput);
+		expect(result.content[0]).toMatchObject({ type: "text", text: "declared" });
+		expect(result.details?.activity).toEqual(replDeclaration);
+	});
+
+	it("leaves generic foreground results free of activity", async () => {
+		const tool = new BashTool(makeToolSession());
+		const result = await tool.execute("foreground-plain", {
+			command: "printf plain",
+			timeout: 5,
+		} satisfies BashToolInput);
+		expect(result.content[0]).toMatchObject({ type: "text", text: "plain" });
+		expect(result.details).not.toHaveProperty("activity");
+	});
+
+	it("mirrors the declaration into background start, progress, and terminal details", async () => {
+		settings.set("async.enabled", true);
+		const tool = new BashTool(makeToolSession());
+		const updates: AgentToolResult<BashToolInput>[] = [];
+		const onUpdate = ((partial: AgentToolResult<BashToolDetails>) => {
+			updates.push(partial as unknown as AgentToolResult<BashToolInput>);
+		}) as unknown as AgentToolUpdateCallback<BashToolDetails>;
+
+		const started = await tool.execute(
+			"background-declared",
+			{ command: "printf background", async: true, timeout: 5, activity: execDeclaration },
+			undefined,
+			onUpdate,
+		);
+
+		const jobId = started.details?.async?.jobId;
+		expect(jobId).toBeString();
+		expect(started.details?.async).toMatchObject({ state: "running", type: "bash" });
+		expect(started.details?.activity).toEqual(execDeclaration);
+
+		await manager.waitForAll();
+		expect(manager.getJob(jobId as string)?.status).toBe("completed");
+
+		const detailled = updates.filter(update => update.details && Object.keys(update.details).length > 0);
+		expect(detailled.length).toBeGreaterThan(0);
+		for (const update of detailled) {
+			expect((update.details as unknown as BashToolDetails).activity).toEqual(execDeclaration);
+		}
+		expect(detailled.at(-1)?.details).toMatchObject({ async: { state: "completed", type: "bash" } });
+	});
+
+	it("keeps existing async job behavior for calls without a declaration", async () => {
+		settings.set("async.enabled", true);
+		const tool = new BashTool(makeToolSession());
+		const started = await tool.execute("background-plain", {
+			command: "printf plain-background",
+			async: true,
+			timeout: 5,
+		} satisfies BashToolInput);
+
+		const jobId = started.details?.async?.jobId;
+		expect(jobId).toBeString();
+		expect(started.details).not.toHaveProperty("activity");
+		await manager.waitForAll();
+		expect(manager.getJob(jobId as string)?.status).toBe("completed");
+	});
+});


### PR DESCRIPTION
## Summary

Implements the GJC side of the minimal contract concluded by the Gajae Code App audit ([gajae-code-app #77](https://github.com/devswha/gajae-code-app/pull/77), `docs/plans/aside-activity-contract.md`, `AUDIT RESULT: MINIMAL_CONTRACT_REQUIRED`): the smallest structured declaration that lets a consumer distinguish Aside browser work from ordinary Bash work **without parsing shell command text**.

### What changed

**Bash input** — one optional, model-declared field (`packages/coding-agent/src/tools/bash.ts`):

```ts
BashActivityDeclaration = { kind: "browser"; provider: "aside"; mode: "repl" | "exec" }
```

- `BashToolInput.activity?` — zod strict object on the exact shape, exposed on the model-facing wire schema as an optional property (verified by test).
- **Invalid handling: dropped, never coerced, never fatal.** The field is `z.preprocess(value => exact ? value : undefined, declaration.optional())`: an exact declaration is preserved verbatim; an absent one is ordinary Bash; anything malformed (`mode: "EXEC"`, wrong kind, wrong provider, extra keys, strings, null) is dropped so an otherwise valid command still runs. `mode: "foo"` is never silently coerced into repl or exec. (This mirrors the repo's existing `z.preprocess` normalization convention in `todo-write.ts`; a strict schema was rejected because validation failure would kill the whole command over routing metadata.)
- Generic Bash is unchanged: `npm test` / `git status` / `python script.py` require nothing new and gain no semantics; nothing in the executor is browser-aware.

**Details mirror** — `BashToolDetails.activity?` carries the accepted declaration on every path where Bash details are constructed: foreground completed results (`#buildCompletedResult`), background/folded start results (`#buildBackgroundStartResult`), managed-job progress and terminal details (`runningDetails`/`completedDetails`/`failedDetails` + foreground partial frames), client-bridge progress and fold results, PTY fold results, and the direct-master-spawn result. Failure paths that never emitted structured details still don't (input + terminal lifecycle is sufficient).

**Routing prompt** — `prompts/agent-fragments/browser-aside.md` gains one Routing bullet requiring the declaration on every Aside invocation: `mode:"repl"` for `aside repl`, `mode:"exec"` for `aside exec` including `--session <id>` follow-ups, sent unchanged across wrappers/env prefixes/absolute paths/quoting/multiline, and omitted on Bash calls that do not invoke Aside. The repl-vs-exec policy itself is untouched.

**Generated artifact** — `src/tools/tool-catalog.generated.ts` regenerated with `bun --cwd=packages/coding-agent run generate-tool-catalog` (committed catalog is enforced to match by `tool-catalog.test.ts`).

### Honesty boundary

The declaration is **model-declared and schema-validated only**. Nothing verifies that the command actually invokes Aside: no `command.includes("aside")`, no argv/shell-AST parsing, no resolved-executable or process-name checks. It is authoritative as part of the model-facing routing contract — the same authority level as the routing itself — not as OS-level process verification.

### Not changed

- No new EventBus event, no `browser_activity` event, no worker protocol method, no new ids (`toolCallId` remains the operation id), no persistence, no database, no runtime state store.
- GJC still spawns and supervises no Aside process; no Aside wrapper tool, MCP server, or provider registration; CLI execution stays in Bash.
- No `url`/`domain`/`label`/`session-id`/progress fields — the emitting layer does not know them structurally.
- `browser.backend` defaults, the native backend, built-in browser tool availability, and descriptors behavior are unchanged (asserted by existing + extended tests).

## Tests

New `test/tools/bash-activity-declaration.test.ts` (10 tests, offline — `printf` only, no Aside CLI/browser/network):

- generic input (`npm test`, `git status`, `python script.py`) valid and unchanged without a declaration;
- repl and exec declarations accepted verbatim;
- malformed/unsupported declarations dropped without failing the command or inventing values (10 malformed shapes);
- unsupported modes never coerced (`EXEC`, `Repl`, `run`, `""`);
- wire schema exposes the exact shape as optional;
- declaration mirrored into foreground result details; generic foreground results stay free of activity;
- declaration mirrored into background start, progress, and terminal details (`async.state` transitions intact);
- existing async job behavior unchanged without a declaration.

Extended `test/sdk-browser-aside-backend.test.ts`: the aside prompt now explicitly requires the declaration for `aside repl`, for `aside exec`, and for `--session <id>` follow-ups, and requires omitting it otherwise; the native/default prompt contains no declaration requirement.

## Verification

- `bun test`: bash-activity (10), sdk-browser-aside-backend (2), plus bash/schema suites — interceptor, resource-lifecycle, master-owner-session-id, state-exploit, interactive-fold, steer-fold, acp-terminal (+fold), interactive-tail, execution-clamp, schema-validation, safe-summary, descriptors, provider-schema-compatibility, jtd-to-json-schema, todo-write, tool-catalog, sdk-operation-inventory — **262 passing across 19 files**.
- `bun run check:ts` (all packages) ✅, `lint:ts` (all packages) ✅, biome format/organize-imports clean ✅.
- `check:rs`/`lint:rs` fail on a **pre-existing** clippy lint (`undocumented_unsafe_blocks`, `crates/pi-shell/src/process.rs:698`) — reproduced identically on a clean tree with this branch stashed, i.e. present on `main` and unrelated to this change.
- No paid/live Aside run performed (none needed: the declaration is metadata on ordinary commands).

## Follow-ups (not in this PR)

App-side consumption per the audit's sequence: SDK pin bump + activity fold, then the WORK section rendering (`Browser · Aside` / `Aside agent` rows). Blocked on this contract shipping in a release.

## Risk classification

- [ ] `low-risk` — ordinary fix/maintenance.
- [x] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer.
- [ ] `high-risk` — large refactor, feature, or materially high-risk change; requires one assigned independent domain reviewer.

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:9d2e2f131b48974421a2779c352c387446f88c6faf509180199911f0ff720c28 reviewer:human reviewer-id:Yeachan-Heo evidence:https://github.com/Yeachan-Heo/gajae-code/pull/5521#pullrequestreview-5255837077
```