### PR TITLE
test(extensions): distinguish explicit paths from automatic discovery

### DIFF
--- a/packages/coding-agent/test/grok-third-party-sequence.test.ts
+++ b/packages/coding-agent/test/grok-third-party-sequence.test.ts
@@ -27,12 +27,16 @@ function registerTestProvider(api: ExtensionAPI, providerName: string): void {
 }
 
 describe("Grok Build with explicit third-party extensions", () => {
-	it("loads bundled and inline extensions while keeping filesystem paths quarantined", async () => {
+	it("loads bundled, inline, and explicit extensions without automatic discovery", async () => {
 		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-grok-third-party-"));
 		const extensionPath = path.join(root, "third-party.ts");
 		await Bun.write(
 			extensionPath,
 			`export default function thirdParty(api) { api.registerProvider("filesystem-test", { name: "Filesystem", baseUrl: "https://example.invalid/v1", apiKey: "$THIRD_PARTY_TEST_KEY", api: "openai-responses", models: [{ id: "model", name: "Model", reasoning: false, input: ["text"], cost: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0 }, contextWindow: 1000, maxTokens: 100 }] }); }`,
+		);
+		await Bun.write(
+			path.join(root, ".gjc", "extensions", "automatic", "index.ts"),
+			(await Bun.file(extensionPath).text()).replaceAll("filesystem-test", "automatic-test"),
 		);
 		try {
 			const { session } = await createAgentSession({
@@ -55,7 +59,12 @@ describe("Grok Build with explicit third-party extensions", () => {
 			try {
 				expect(session.modelRegistry.find("grok-build", "grok-composer-2.5-fast")).toBeTruthy();
 				expect(session.modelRegistry.find("inline-test", "model")).toBeTruthy();
-				expect(session.modelRegistry.find("filesystem-test", "model")).toBeUndefined();
+				expect(session.modelRegistry.find("filesystem-test", "model")).toMatchObject({
+					provider: "filesystem-test",
+					id: "model",
+					baseUrl: "https://example.invalid/v1",
+				});
+				expect(session.modelRegistry.find("automatic-test", "model")).toBeUndefined();
 			} finally {
 				await session.dispose();
 			}


### PR DESCRIPTION
## Summary
Fix the stale quarantine assertion causing current dev CI34722718234 to fail. Merged #5509 intentionally restored filesystem modules: `disableExtensionDiscovery` disables automatic discovery, while explicitly supplied `additionalExtensionPaths` still load (sdk/session.ts3598-3618).

The test now verifies explicit filesystem provider admission alongside bundled/inline providers, and places a separate provider in the canonical discovery directory to ensure automatic discovery remains disabled. No product loading policy changes.

## Verification
Original test failed. Corrected test passes. Negative control changing only disableExtensionDiscovery tofalse fails specifically because the canonical automatic provider loads; restoringtrue passes. All original bundled/inline assertions retained. Focused Biome and diff checks passed. No duplicate docs/changelog entry for aligning a fixture with already-documented behavior. Full hosted shard pending.

## Exact head
Base `59cad783f0c580a2c17ce02403fb1ad6bc1fe464`
Head `a24568a944997c5909cce18d731effa3b3b13f18`
Canonical diff SHA256 `0121910f1d6f7596d829bbd30a4b7635bfece962096ebaa6c07b41a9eadcc5ad`

## Risk classification
- [x] `low-risk` —test-only source-contract alignment with negative discovery control.
- [ ] `regression-risk`
- [ ] `high-risk`

## Verdict
gajae.pr-review-verdict.v1 merge-approved sha256:0121910f1d6f7596d829bbd30a4b7635bfece962096ebaa6c07b41a9eadcc5ad reviewer:human reviewer-id:probepark evidence:ci-gate-only;test-only;explicit-vs-auto-discovery-verified;negative-control-checked

Related #5399 release qualification; does not alter extension trust boundaries or claim all release blockers closed.
