### PR TITLE
test(agent): exercise unpublished recovery with terminal-only streams

### DIFF
--- a/packages/coding-agent/test/agent-session-escaped-nonascii-metadata.test.ts
+++ b/packages/coding-agent/test/agent-session-escaped-nonascii-metadata.test.ts
@@ -10,6 +10,7 @@ import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
 import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
 import { TempDir } from "@gajae-code/utils";
 import * as z from "zod/v4";
+import { terminalOnlyStream } from "./helpers/terminal-only-stream";
 
 const QUESTION = "마지막 병목";
 const usage = {
@@ -96,7 +97,7 @@ describe("AgentSession escaped non-ASCII metadata fidelity", () => {
 		const agent = new Agent({
 			initialState: { model: mock.model, systemPrompt: ["test"], tools: [askTool()], messages: [] },
 			convertToLlm: identityConverter,
-			streamFn: mock.stream,
+			streamFn: terminalOnlyStream(mock.stream),
 		});
 		session = new AgentSession({
 			agent,

--- a/packages/coding-agent/test/helpers/terminal-only-stream.ts
+++ b/packages/coding-agent/test/helpers/terminal-only-stream.ts
@@ -1,0 +1,17 @@
+import type { MockModel } from "@gajae-code/ai/providers/mock";
+import { AssistantMessageEventStream } from "@gajae-code/ai/utils/event-stream";
+
+/** Exercise recovery before any assistant content has been published. */
+export function terminalOnlyStream(stream: MockModel["stream"]): MockModel["stream"] {
+	return (model, context, options) => {
+		const upstream = stream(model, context, options);
+		const terminal = new AssistantMessageEventStream();
+		void (async () => {
+			for await (const event of upstream) {
+				if (event.type === "done" || event.type === "error") terminal.push(event);
+			}
+			terminal.end();
+		})().catch(error => terminal.fail(error));
+		return terminal;
+	};
+}

--- a/packages/coding-agent/test/tools/ask-escaped-durability.test.ts
+++ b/packages/coding-agent/test/tools/ask-escaped-durability.test.ts
@@ -10,6 +10,7 @@ import { readWorkflowStateJson } from "@gajae-code/coding-agent/gjc-runtime/stat
 import type { ToolSession } from "@gajae-code/coding-agent/tools";
 import { AskTool } from "@gajae-code/coding-agent/tools/ask";
 import { TempDir } from "@gajae-code/utils";
+import { terminalOnlyStream } from "../helpers/terminal-only-stream";
 
 function identityConverter(messages: AgentMessage[]): Message[] {
 	return messages.filter(
@@ -131,7 +132,7 @@ describe("AskTool escaped deep-interview durability (#4926)", () => {
 			const toolResults: Array<{ isError?: boolean; text: string }> = [];
 			const userMessage = { role: "user" as const, content: "Ask the durability question", timestamp: 1 };
 
-			const stream = agentLoop([userMessage], context, config, undefined, mock.stream);
+			const stream = agentLoop([userMessage], context, config, undefined, terminalOnlyStream(mock.stream));
 			for await (const event of stream) {
 				if (event.type === "tool_execution_end") {
 					const first = event.result.content?.[0];


### PR DESCRIPTION
## Summary
Fix two current-dev CI fixtures stranded in closed #5452 without reviving its implementation. Agent-loop intentionally resamples/discards escaped arguments only before content publication; already-published attempts must remain visible and be rejected, not silently erased. These two metadata/durability tests expected pre-publication recovery but used the mock's published stream.

Use one shared test-only terminal stream adapter, following the existing agent-loop escaped-argument suite pattern. Keep every metadata, persistence, reload and bounded resampling assertion unchanged. No production retry/visibility/escape policy changes.

## Verification
- Original two fixtures fail at published-attempt count/history assumptions.
- Corrected fixtures plus the existing full agent-loop escaped-nonascii suite:58pass0fail323assertions. This also retains published-attempt protection coverage.
- coding-agent Biome/TypeScript and diff check pass.
- Forward-only current-dev integration preserves unchanged three-file diff.
- No product changelog or docs change for test-only fixture scope. Hosted matrix pending.

## Exact head
Base `3e992d39518674b3b3900cef5b9621082e8d165e`
Head `fd2d7daf27d854a0c4eaeadf0ecb0a9feaa03fe7`
Canonical diff SHA256 `e3a8fe39f5dc10e24c19c113abde6bbf9f79cc654ed7923a294f239ed508977b`

## Risk classification
- [x] `low-risk` —test-only provider event fixture, preserving all existing assertions and production policy.
- [ ] `regression-risk`
- [ ] `high-risk`

## Verdict
gajae.pr-review-verdict.v1 merge-approved sha256:e3a8fe39f5dc10e24c19c113abde6bbf9f79cc654ed7923a294f239ed508977b reviewer:human reviewer-id:probepark evidence:ci-gate-waiting-only;test-only-3files;terminal-stream-helper-checked;error-propagation-checked

Related #5399. No test suppression, retries or increased timeout; no broader incident closure claimed.