### PR TITLE
fix(session): classify replaced managed locks before release recovery

### DIFF
--- a/packages/coding-agent/changelog.d/managed-lock-release-loss-classification.md
+++ b/packages/coding-agent/changelog.d/managed-lock-release-loss-classification.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Report a managed session lock already removed or replaced before release as `migration_busy`, preserving the successor file and existing descriptor-recovery security checks instead of masking ordinary ownership loss as a Linux security error.

--- a/packages/coding-agent/src/session/internal/managed-session-storage.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-storage.ts
@@ -3614,6 +3614,17 @@ export async function acquireManagedLock(
 					let releaseFd = fd;
 					let replacementFd: number | undefined;
 					try {
+						// A named successor means ownership was already lost. Do not let
+						// Linux descriptor recovery mask that condition as a security error.
+						let named: fs.BigIntStats;
+						try {
+							named = fs.lstatSync(lockPath, { bigint: true });
+						} catch (error) {
+							if ((error as NodeJS.ErrnoException).code === "ENOENT") throw new Error("migration_busy");
+							throw error;
+						}
+						if (!named.isFile() || named.isSymbolicLink() || !sameFileIdentity(lockIdentity, named))
+							throw new Error("migration_busy");
 						// Check the descriptor before native security verification: native failures
 						// do not preserve Node's EBADF code for a closed retained descriptor.
 						ManagedLockTestHooks.beforeReleaseDescriptorVerification?.({ path: lockPath, fd });

--- a/packages/coding-agent/test/session/managed-lock-lease.windows.test.ts
+++ b/packages/coding-agent/test/session/managed-lock-lease.windows.test.ts
@@ -70,7 +70,7 @@ describe("managed migration lock lease ownership", () => {
 		fs.writeFileSync(first.path, original, { mode: 0o600 });
 
 		expect(() => first.assertOwned()).toThrow("migration_busy");
-		await expect(first.release()).rejects.toThrow();
+		await expect(first.release()).rejects.toThrow("migration_busy");
 		expect(fs.readFileSync(first.path)).toEqual(original);
 		await first.release();
 	});


### PR DESCRIPTION
## Reproduction
Full source qualification34725745290/shard6 failed three existing managed-session open/delete tests: replacing the named lock before release on Linux produced a ManagedSecurityError(identity_mismatch) instead of the public migration_busy/SessionMigrationBusyError contract.

## Fix
Perform a read-only named-file identity preflight before Linux descriptor recovery. A file already removed/replaced before release is lost ownership: return migration_busy without writing to the successor. Later descriptor recovery, copied-attempt ABA, native mode/security checks, and exact descriptor cleanup remain unchanged. Strengthen the direct replacement test's previously broad rejection to require migration_busy. Existing strict-open/direct-open/delete regressions remain unchanged. Fixed fragment included.

## Verification
- Managed lock lease + session directory:71pass19platformskips0fail433assertions on Darwin.
- coding-agent Biome/TypeScript and diff check passed.
- Linux-only descriptor recovery/security and original full-source failures require hosted rerun; local skip counts are not platform proof.
- No operational locks touched, no historical record repair, no retry/timeout or permission relaxation.

## Exact head
Base `3d8b4c7c7de1108d78f7ede0e2c99a192ba3375f`
Head `b2e3915693b6489b9ea05d3ca5c52e3cfb97b2d4`
Canonical diff SHA256 `9fc31a87bfb0e4044716b35e146783398bd04c2cf009668affc6ca9cef075e16`

## Risk classification
- [ ] `low-risk`
- [ ] `regression-risk`
- [x] `high-risk` —identity-sensitive lock release classification requires independent review and real Linux regressions.

## Verdict
gajae.pr-review-verdict.v1 merge-approved sha256:9fc31a87bfb0e4044716b35e146783398bd04c2cf009668affc6ca9cef075e16 reviewer:human reviewer-id:probepark evidence:authenticated-exact-head-approval;write-permission-verified;remaining-CI-results-not-waived

Related #5399 integrated release qualification. No full-release or original incident closure claimed.


Current integration boundary:forward-only merge of dev `3d8b4c7c7de1108d78f7ede0e2c99a192ba3375f` gives head `b2e3915693b6489b9ea05d3ca5c52e3cfb97b2d4`. Earlier testing and approvals remain historical evidence, not whole-current-head qualification; fresh exact-head CI and independent review are required. No force push or approval bypass.


Current-head review authority verified independently. Any pending platform/affected CI remains required; this body update does not certify those jobs or bypass merge protection.
