### PR TITLE
test(coordinator): await owned persistence before terminal snapshots

### DIFF
--- a/packages/coding-agent/test/agent-session-coordinator-activity.test.ts
+++ b/packages/coding-agent/test/agent-session-coordinator-activity.test.ts
@@ -299,15 +299,10 @@ async function readActivity(stateFile: string): Promise<Record<string, unknown> 
 	throw new Error("coordinator activity snapshot was never readable");
 }
 
-/** Wait until the sidecar stops writing, so the LAST published snapshot can be asserted. */
-async function settledActivity(stateFile: string): Promise<Record<string, unknown> | undefined> {
-	let previous = JSON.stringify(await readActivity(stateFile));
-	for (let quiet = 0; quiet < 20; quiet++) {
-		await Bun.sleep(10);
-		const current = JSON.stringify(await readActivity(stateFile));
-		if (current !== previous) quiet = 0;
-		previous = current;
-	}
+/** Join event handling and sidecar persistence before asserting the LAST published snapshot. */
+async function settledActivity(session: AgentSession, stateFile: string): Promise<Record<string, unknown> | undefined> {
+	await session.awaitSessionSettlement();
+	await session.awaitCoordinatorRuntimeStatePersistenceForTests();
 	return await readActivity(stateFile);
 }
 
@@ -654,7 +649,7 @@ describe("AgentSession coordinator activity labels", () => {
 		release.resolve();
 		await syntheticPaired.promise;
 		await run;
-		const settled = await settledActivity(stateFile);
+		const settled = await settledActivity(session, stateFile);
 		sampling = false;
 		await sampler;
 
@@ -833,7 +828,7 @@ describe("AgentSession coordinator activity labels", () => {
 		pendingCalls = [toolCall("call-transform-rejected", "read")];
 		await session.agent.prompt("emit a call the argument transform rejects");
 
-		const settled = JSON.stringify(await settledActivity(stateFile));
+		const settled = JSON.stringify(await settledActivity(session, stateFile));
 		sampling = false;
 		await sampler;
 


### PR DESCRIPTION
## Summary
Fix the full-source qualification race in agent-session-coordinator-activity.test.ts. A sidecar unchanged for20samples does not prove queued event handling and persistence have completed; the failed Linux job observed read/started seq1 instead of the required read/finished seq2.

Replace only the test helper's elapsed quiet-window inference with the existing awaitSessionSettlement and awaitCoordinatorRuntimeStatePersistenceForTests barriers. Keep continuous sampling active, every semantic/privacy/identity assertion, and all test deadlines and read budgets unchanged. No product persistence behavior change.

## Verification
- Original failure:full-source34728277865, shard11, final snapshot remained active/read/started.
- Focused complete file:13pass0fail53assertions.
- coding-agent Biome/TypeScript and diff checks passed.
- Separate retry-disposal deadline failure remains unresolved; it was not weakened or bundled into this fix.
- Test-only change; no duplicate changelog/docs required. Full hosted matrix pending.

## Exact head
Base `3d8b4c7c7de1108d78f7ede0e2c99a192ba3375f`
Head `64059e366c5b2552aeb6e3de2b1cda19a763ee8d`
Canonical diff SHA256 `bf5607bfd1c509bddece5e883c4f022d22b2418b4a865a75c9ec81d2d669095d`

## Risk classification
- [x] `low-risk` —one test helper joins existing authoritative completion owners instead of sleeping.
- [ ] `regression-risk`
- [ ] `high-risk`

## Verdict
gajae.pr-review-verdict.v1 merge-approved sha256:bf5607bfd1c509bddece5e883c4f022d22b2418b4a865a75c9ec81d2d669095d reviewer:human reviewer-id:probepark evidence:ci-gate-only;test-only;poll-replaced-with-authoritative-barriers;both-callsites-updated

Related #5399 release qualification. No full-source pass or aggregate closure claimed.
