### PR TITLE
fix(sdk): retain skill.invoke final text in durable turn results

### DIFF
--- a/packages/coding-agent/changelog.d/sdk-skill-result-text.md
+++ b/packages/coding-agent/changelog.d/sdk-skill-result-text.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- SDK: `turn.result` / `skill.invoke_status` retain the bounded final assistant text for completed `skill.invoke` invocations (ralplan, ultragoal); a content-less promise-settlement terminal no longer pre-empts the correlated `agent_end` finalization.

--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -3425,15 +3425,15 @@ function sdkControlSurface(
 							...(typeof result === "object" && result ? (result as object) : {}),
 							...(trimmedClientRef ? { clientRef: trimmedClientRef } : {}),
 						});
-					} else if (durableSkillAccepted && skillRecon) {
-						trackReconciliationProducer?.(
-							skillRecon.noteTransition(correlation, {
-								type: "agent_end",
-								...(typeof result === "string"
-									? { content: { version: 1, type: "text", text: result, byteLength: 0, truncated: false } }
-									: {}),
-							}),
-						);
+					} else if (durableSkillAccepted && skillRecon && !promptOwned) {
+						// A lifecycle-owned skill (requester connection present, submission
+						// registered by onPromptAccepted) is terminalized solely by the
+						// correlated agent_end handler (terminalizePrompt -> claim ->
+						// finalize with the final text). This promise-settlement transition
+						// carries no text and would pre-empt that finalization, dropping the
+						// durable content; it remains only for ownerless acceptance, where
+						// no lifecycle handler will ever fire.
+						trackReconciliationProducer?.(skillRecon.noteTransition(correlation, { type: "agent_end" }));
 					}
 					executionSettled.resolve();
 				},

--- a/packages/coding-agent/test/sdk-host-wiring.test.ts
+++ b/packages/coding-agent/test/sdk-host-wiring.test.ts
@@ -5,7 +5,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import type { AgentSideConnection } from "@agentclientprotocol/sdk";
 import { Agent, type AgentTool, type RunSettlementProof } from "@gajae-code/agent-core";
-import { closeModelCache, getBundledModel } from "@gajae-code/ai";
+import { type AssistantMessage, closeModelCache, getBundledModel } from "@gajae-code/ai";
 import { createMockModel } from "@gajae-code/ai/providers/mock";
 import { NotificationServer } from "@gajae-code/natives";
 import { logger } from "@gajae-code/utils";
@@ -14,6 +14,7 @@ import { ModelRegistry } from "../src/config/model-registry";
 import { Settings } from "../src/config/settings";
 import { ExtensionRunner } from "../src/extensibility/extensions/runner";
 import type {
+	AgentEndEvent,
 	ExtensionActions,
 	ExtensionAPI,
 	ExtensionContextActions,
@@ -2765,6 +2766,194 @@ test("SDK host waits for accepted handleless skill settlement before publishing 
 	expect(executionStarted).toBe(false);
 	await handlers.get("session_shutdown")?.({ type: "session_shutdown" }, sessionContext);
 });
+
+function assistantEndEvent(text: string): AgentEndEvent {
+	const message: AssistantMessage = {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "openai-completions",
+		provider: "fixture-provider",
+		model: "reasoning-model",
+		usage: {
+			input: 1,
+			output: 1,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 2,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+	return { type: "agent_end", messages: [message], stopReason: "completed" };
+}
+
+function acceptedCorrelation(frame: Record<string, unknown> | undefined): { commandId: string; turnId: string } {
+	const result = (frame as { result?: { commandId?: unknown; turnId?: unknown } } | undefined)?.result;
+	if (typeof result?.commandId !== "string" || typeof result.turnId !== "string")
+		throw new Error(`acceptance frame carries no correlation: ${JSON.stringify(frame)}`);
+	return { commandId: result.commandId, turnId: result.turnId };
+}
+
+test("SDK host retains the final assistant text for a skill whose invocation settles before its terminal is finalized", async () => {
+	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-skill-result-text-"));
+	dirs.push(cwd);
+	const sessionId = `sdk-skill-result-text-${Date.now()}`;
+	const sessionFile = path.join(cwd, "session.jsonl");
+	const sessionContext = context(cwd, sessionId);
+	const sessionManager = sessionContext.sessionManager as Record<string, unknown>;
+	sessionContext.sessionManager = {
+		...sessionManager,
+		getSessionFile: () => sessionFile,
+	};
+	const baseBindings = sessionContext.sdkBindings as () => string[];
+	sessionContext.sdkBindings = () => [...baseBindings(), "invokeSkill"];
+	// The invocation promise settles only when the test releases it, so the
+	// runtime order (durable claim enqueued, invocation resolves, finalize) is
+	// reproduced deterministically instead of depending on the agent loop.
+	let release = Promise.withResolvers<void>();
+	sessionContext.invokeSkill = async (
+		name: string,
+		args: string | undefined,
+		options?: {
+			onSkillPrepared?: (meta: { name: string; path: string }) => void;
+			onPreflightAcceptCommit?: () => void | Promise<void>;
+		},
+	) => {
+		options?.onSkillPrepared?.({ name, path: "/fixture/SKILL.md" });
+		await options?.onPreflightAcceptCommit?.();
+		await release.promise;
+		return { name, path: "/fixture/SKILL.md", args };
+	};
+	const handlers = start(sessionContext);
+	const endpointFile = path.join(cwd, ".gjc", "state", "sdk", `${sessionId}.json`);
+	await waitFor(() => fs.existsSync(endpointFile), "SDK endpoint");
+	const endpoint = JSON.parse(fs.readFileSync(endpointFile, "utf8")) as { url: string; token: string };
+	const frames: Record<string, unknown>[] = [];
+	const socket = new WebSocket(`${endpoint.url}/?token=${encodeURIComponent(endpoint.token)}`);
+	sockets.push(socket);
+	socket.addEventListener("message", event => frames.push(JSON.parse(String(event.data))));
+	await new Promise<void>((resolve, reject) => {
+		socket.addEventListener("open", () => resolve(), { once: true });
+		socket.addEventListener("error", () => reject(new Error("WS error")), { once: true });
+	});
+	const request = async (frame: Record<string, unknown>): Promise<Record<string, unknown> | undefined> => {
+		socket.send(JSON.stringify(frame));
+		await waitFor(() => frames.some(candidate => candidate.id === frame.id), `${String(frame.id)} response`);
+		return frames.find(candidate => candidate.id === frame.id);
+	};
+	const terminalFrame = (correlation: { commandId: string; turnId: string }): Record<string, unknown> | undefined =>
+		frames.find(
+			frame =>
+				frame.type === "agent_end" &&
+				frame.commandId === correlation.commandId &&
+				frame.turnId === correlation.turnId,
+		);
+	const skillText = "skill final answer";
+	const directText = "direct final answer";
+	try {
+		const skill = acceptedCorrelation(
+			await request({
+				type: "control_request",
+				id: "skill-text",
+				operation: "skill.invoke",
+				input: { name: "fixture-skill", args: "keep text", clientRef: "skill-text-ref" },
+			}),
+		);
+		await handlers.get("agent_start")?.({ type: "agent_start" }, sessionContext);
+		const skillEnding = handlers.get("agent_end")?.(assistantEndEvent(skillText), sessionContext);
+		release.resolve();
+		await skillEnding;
+		await waitFor(() => terminalFrame(skill) !== undefined, "correlated skill terminal");
+		const skillByClientRef = await request({
+			type: "query_request",
+			id: "skill-text-by-client-ref",
+			query: "turn.result",
+			input: { kind: "skill", clientRef: "skill-text-ref" },
+		});
+		const skillByPair = await request({
+			type: "query_request",
+			id: "skill-text-by-pair",
+			query: "turn.result",
+			input: { kind: "skill", ...skill },
+		});
+
+		const direct = acceptedCorrelation(
+			await request({
+				type: "control_request",
+				id: "direct-text",
+				operation: "turn.prompt",
+				input: { text: "direct", clientRef: "direct-text-ref" },
+			}),
+		);
+		await handlers.get("agent_start")?.({ type: "agent_start" }, sessionContext);
+		await handlers.get("agent_end")?.(assistantEndEvent(directText), sessionContext);
+		await waitFor(() => terminalFrame(direct) !== undefined, "correlated direct prompt terminal");
+		const directByClientRef = await request({
+			type: "query_request",
+			id: "direct-text-by-client-ref",
+			query: "turn.result",
+			input: { kind: "prompt", clientRef: "direct-text-ref" },
+		});
+
+		release = Promise.withResolvers<void>();
+		const blank = acceptedCorrelation(
+			await request({
+				type: "control_request",
+				id: "skill-blank",
+				operation: "skill.invoke",
+				input: { name: "fixture-skill", args: "blank text", clientRef: "skill-blank-ref" },
+			}),
+		);
+		await handlers.get("agent_start")?.({ type: "agent_start" }, sessionContext);
+		const blankEnding = handlers.get("agent_end")?.(assistantEndEvent(" "), sessionContext);
+		release.resolve();
+		await blankEnding;
+		await waitFor(() => terminalFrame(blank) !== undefined, "correlated blank skill terminal");
+		const blankByClientRef = await request({
+			type: "query_request",
+			id: "skill-blank-by-client-ref",
+			query: "turn.result",
+			input: { kind: "skill", clientRef: "skill-blank-ref" },
+		});
+
+		// Event association is intact in both states: the correlated terminal
+		// carries the skill's final text on the wire.
+		expect(terminalFrame(skill)).toMatchObject({
+			finalText: skillText,
+			outcome: { kind: "stopped", reason: "end_turn", provenance: "agent" },
+		});
+		// Direct-prompt parity guard: the single-owner prompt path keeps its text.
+		expect(directByClientRef).toMatchObject({
+			ok: true,
+			result: {
+				status: "terminal_ok",
+				receiptState: "present",
+				content: { text: directText, byteLength: new TextEncoder().encode(directText).length, truncated: false },
+			},
+		});
+		// Blank final text keeps the existing missing-receipt semantics.
+		expect(blankByClientRef).toMatchObject({ ok: true, result: { status: "terminal_ok", receiptState: "missing" } });
+		expect((blankByClientRef?.result as { content?: unknown } | undefined)?.content).toBeUndefined();
+		// The durable skill result must carry the bounded final text through both
+		// public selectors.
+		const expectedSkillContent = {
+			text: skillText,
+			byteLength: new TextEncoder().encode(skillText).length,
+			truncated: false,
+		};
+		expect(skillByClientRef).toMatchObject({
+			ok: true,
+			result: { status: "terminal_ok", receiptState: "present", content: expectedSkillContent },
+		});
+		expect(skillByPair).toMatchObject({
+			ok: true,
+			result: { status: "terminal_ok", receiptState: "present", content: expectedSkillContent },
+		});
+	} finally {
+		await handlers.get("session_shutdown")?.({ type: "session_shutdown" }, sessionContext);
+	}
+});
 test("SDK host waits for durable prompt acceptance before completing concurrent cancellation", async () => {
 	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-prompt-durable-accept-cancel-"));
 	dirs.push(cwd);
@@ -3168,10 +3357,14 @@ test("session_shutdown awaits a late reconciliation publication before teardown 
 	expect(
 		frames.find(frame => frame.type === "control_response" && frame.id === "skill-late-publication"),
 	).toMatchObject({ ok: true, result: { accepted: true } });
-	// The acceptance publication has settled; the next commit to this store file
-	// is the late fire-and-forget agent_end transition. Arm the pause, then let
-	// the run resolve so that publication starts and is held mid-rename.
+	await handlers.get("agent_start")?.({ type: "agent_start" }, sessionContext);
+	// The acceptance and agent_start publications have settled; the next commit
+	// to this store file is the correlated agent_end terminal claim, the sole
+	// terminal owner of a lifecycle-owned skill. Arm the pause, deliver the
+	// terminal, then let the run resolve so that publication starts and is
+	// held mid-rename.
 	pausedCommit.arm();
+	void handlers.get("agent_end")?.(assistantEndEvent("held"), sessionContext);
 	resumeExecution.resolve();
 	await pausedCommit.started;
 	// Teardown must not report the session stopped while a durable publication it
@@ -3339,9 +3532,11 @@ test("session_shutdown bounds a hung reconciliation publication and reports the 
 			() => frames.some(frame => frame.type === "control_response" && frame.id === "skill-drain-deadline"),
 			"accepted skill response",
 		);
-		// The publication is armed and held mid-rename; shutdown begins with the
-		// rename still never released.
+		await handlers.get("agent_start")?.({ type: "agent_start" }, sessionContext);
+		// The correlated agent_end terminal claim is armed and held mid-rename;
+		// shutdown begins with the rename still never released.
 		pausedCommit.arm();
+		void handlers.get("agent_end")?.(assistantEndEvent("held"), sessionContext);
 		resumeExecution.resolve();
 		await pausedCommit.started;
 		const shutdownStarted = Date.now();
@@ -3428,11 +3623,15 @@ test("session_shutdown propagates a rejected reconciliation publication without 
 			() => frames.some(frame => frame.type === "control_response" && frame.id === "skill-publish-failure"),
 			"accepted skill response",
 		);
-		// The acceptance write has committed; the NEXT commit is the terminal
-		// agent_end publication, and it is made to fail at its atomic rename.
+		await handlers.get("agent_start")?.({ type: "agent_start" }, sessionContext);
+		// The acceptance and agent_start writes have committed; the NEXT commit is
+		// the correlated agent_end terminal claim, and it is made to fail at its
+		// atomic rename.
 		failedCommit.arm();
+		const ending = handlers.get("agent_end")?.(assistantEndEvent("lost"), sessionContext);
 		resumeExecution.resolve();
 		await failedCommit.failed;
+		await ending;
 		const shutdownFailure = await Promise.resolve(
 			handlers.get("session_shutdown")?.({ type: "session_shutdown" }, sessionContext),
 		).then(
@@ -3521,13 +3720,26 @@ test("a recovered reconciliation publication lets a later teardown drain report 
 			() => frames.some(frame => frame.type === "control_response" && frame.id === "skill-recovery-first"),
 			"first accepted skill response",
 		);
+		await handlers.get("agent_start")?.({ type: "agent_start" }, sessionContext);
 		failedCommit.arm();
+		const firstEnding = handlers.get("agent_end")?.(assistantEndEvent("lost"), sessionContext);
 		resumeFirst.resolve();
 		await failedCommit.failed;
+		await firstEnding;
+		// The failed terminal claim fenced its requester connection (fail closed,
+		// as for prompts), so the later publication comes from a fresh connection.
 		// The failure window closes with the failing publication; the store is
 		// writable again, so a subsequent publication persists and the teardown
 		// drain reports quiescence rather than staying poisoned by the past failure.
-		socket.send(
+		const secondFrames: Record<string, unknown>[] = [];
+		const secondSocket = new WebSocket(`${endpoint.url}/?token=${encodeURIComponent(endpoint.token)}`);
+		sockets.push(secondSocket);
+		secondSocket.addEventListener("message", event => secondFrames.push(JSON.parse(String(event.data))));
+		await new Promise<void>((resolve, reject) => {
+			secondSocket.addEventListener("open", () => resolve(), { once: true });
+			secondSocket.addEventListener("error", () => reject(new Error("WS error")), { once: true });
+		});
+		secondSocket.send(
 			JSON.stringify({
 				type: "control_request",
 				id: "skill-recovery-second",
@@ -3536,9 +3748,14 @@ test("a recovered reconciliation publication lets a later teardown drain report 
 			}),
 		);
 		await waitFor(
-			() => frames.some(frame => frame.type === "control_response" && frame.id === "skill-recovery-second"),
+			() => secondFrames.some(frame => frame.type === "control_response" && frame.id === "skill-recovery-second"),
 			"second accepted skill response",
 		);
+		expect(
+			secondFrames.find(frame => frame.type === "control_response" && frame.id === "skill-recovery-second"),
+		).toMatchObject({ ok: true, result: { accepted: true } });
+		await handlers.get("agent_start")?.({ type: "agent_start" }, sessionContext);
+		await handlers.get("agent_end")?.(assistantEndEvent("recovered"), sessionContext);
 		// The first teardown still reports the earlier lost write: a publication that
 		// never reached disk is state loss even though a later one succeeded, and
 		// evidence is retained until an owner is actually told about it.


### PR DESCRIPTION
## What

`turn.result` / `skill.invoke_status` for a completed `skill.invoke` (ralplan, ultragoal, any skill) now carry the bounded final assistant text, exactly as `turn.prompt` rows do, in-session and after a real process restart. One condition and one call change in `packages/coding-agent/src/sdk/bus/index.ts` (+9/−9); a new host-level regression test; four existing #4743 teardown-drain tests adapted to the single terminal owner; a changelog fragment.

## Why

**Problem.** Two writers terminalized the same durable skill record. The correlated `agent_end` handler is the canonical owner (`terminalizePrompt` → `claimPendingOutcome` → `finalizeOutcome(…, finalText)`), but the `skill.invoke` success continuation also issued a content-less `agent_end` transition when `AgentSession.invokeSkill` resolved. The runtime order is claim → promise settlement → finalize, so the text-less writer terminalized the record first, `finalizeOutcome` refused the already-terminal record, and the text was dropped durably. Observed through the public SDK on base: `ralplan` and `ultragoal` rows `terminal_ok` / `present` with no `content`, before and after restart; the direct prompt row on the same session kept its text. Full diagnosis and reproduction: #5539.

**Solution.** Lifecycle-owned skills get a single terminal owner, as prompts already have. The promise-settlement transition now fires only when `!promptOwned` (no requester connection registered a submission, so no lifecycle handler will ever finalize the record). The unreachable `typeof result === "string"` content spread is removed (`invokeSkill` returns metadata, never a string). The error continuation and every cleanup path (requester disconnect, deadline lease, cancel, teardown drain) already terminalize through `terminalizePrompt` or `onPromptFailed` and are untouched.

**Rejected:** enriching terminal records inside `finalizeOutcome`. That would tolerate the race instead of removing the second owner and would widen reconciler semantics.

## Scope

- Public `TurnResultPage` shape, selectors, statuses, `receiptState` semantics and the 16 KiB bound are unchanged (`turn-result.ts` untouched). `turn.prompt` / direct path has zero diff lines. `kind-aware-reconciliation.ts`, `reconciliation-store.ts`, `agent-session.ts`, `host/session-runtime.ts` untouched.
- **One intended behavior correction on a failure path.** A skill whose terminal claim fails to persist no longer gets a false `terminal_ok` / `receiptState: "missing"` row from the removed writer. It stays `in_flight` / `absent` and settles to `failed` / `error.code: "process_restart"` on the next load, matching the prompt path's fail-closed behavior. The requester was already told `agent_failed` (`terminal_uncertain`) in that case on base, and the requester connection was already fenced on base (same-input base/candidate comparison, 4/4 runs, identical fence code). Verified across genuinely separate client/broker/session-host OS processes: base persists the false success through the restart; this branch reports `failed` / `process_restart` on the first public read, refuses the retained `clientRef` with `client_ref_conflict`, and replays nothing.
- Ownerless acceptance (`promptOwned === false`) keeps the promise-settlement terminal; it could not carry text before either. Not exercised in a live runtime (see Not-tested).
- Four #4743 tests in `sdk-host-wiring.test.ts` (late publication, hung drain, rejected publication, recovered publication) drove their "late publication" through the removed writer. Their harness now delivers `agent_start` / `agent_end` so the terminal claim from `terminalizePrompt` is the publication under test. Every original assertion is retained (the 10 removed lines are 1 import, 7 comment lines and 2 renames). The recovered-publication test resubmits on a fresh socket because a failed claim fences the requester on base as well, and asserts the resubmission is accepted. With the fix and the unadapted tests, those four timed out at 60 s (with only `bus/index.ts` reverted they pass 5/5), which isolates the coupling to the removed writer, not the environment.

## Testing

All runs through an isolated environment (`env -i`, disposable HOME / agent dirs, no credentials, no paid model calls, loopback-only fixture provider). Per repository policy, targeted tests and the package check were run; the full suite was not.

| Check | Command | Outcome |
|---|---|---|
| New regression, base | `bun test packages/coding-agent/test/sdk-host-wiring.test.ts -t "retains the final assistant text"` (base `bus/index.ts`) | 0 pass / 1 fail, exit 1; fails only at the skill-content assertion (received `terminal_ok` / `present` / no `content`); prompt-parity and blank-text assertions pass |
| New regression, fix | same | 1 pass / 0 fail, 6 expect() calls, exit 0 |
| Focused suites | `bun test packages/coding-agent/test/sdk-host-wiring.test.ts packages/coding-agent/test/sdk-kind-aware-reconciliation.test.ts packages/coding-agent/test/sdk-q26-prompt-status.test.ts packages/coding-agent/test/master-mode.test.ts` | 162 pass / 0 fail, 4 files, exit 0 (independent reviewer rerun of the two SDK files on a clean clone: 125 pass / 0 fail) |
| Package check | `bun --cwd=packages/coding-agent run check` | biome 3114 files, `tsc --noEmit`, exit 0 |
| Public-SDK probe, normal path | producer: `turn.prompt` direct-1, `skill.invoke` ralplan-1, `skill.invoke` ultragoal-1; reader in new processes after `session.resume` | all three rows `terminal_ok` / `present` with the exact per-marker text by `clientRef` and by `{commandId, turnId}`, identical after restart; provider 1 GET + 3 POST (producer), 1 GET + 0 POST (reader); kind-isolation reads `unknown` unchanged |
| Public-SDK probe, faulted terminal claim, real OS restart | same shape with an injected persistence fault on the skill terminal claim, base vs fix | base: durable false `terminal_ok` / `missing`; fix: `in_flight` / `absent` then `failed` / `process_restart` after restart; direct row byte-identical in both; 0 reader POSTs in both |
| Not run | full `bun run test`; bare `tsc`; `check:sdk-closure`; `install:dev` | per scoped verification policy |

**Not-tested:** ownerless acceptance in a live runtime; downstream adapter mapping of the corrected failure-path statuses (separate consumer work, cf. #5526).

## Review record

- Plan: `plans/gajae-code/2026-09-12-retained-skill-results.md` (internal), SHA-256 `c97fdb39e322c14ddd44856c4d787c01cde37c5f38fc70501f71d1167d468a7d`.
- Exact base `b80f3ca04930d5901910853f1aa00faf763f4ec8` (dev), exact head `5bb6ab6e21c8b46764c8189dd58a3bea73114a01`, canonical `base...head` diff digest `90efab10ec814da44f2adb4340132a07abde68c8ef87e5549d1cacc7021b2dbb`.
- Harness: Claude Code with Claude Fable 5.1 for planning, implementation, three independent read-only reviews (correctness/concurrency; quality; contract completeness) and this delivery. Effective model settings are self-reported by each session.
- Review rounds: one wave, three reviewers, all APPROVE; 0 critical / 0 high / 0 medium confirmed; no repair round.
- **Notes / accepted debt (low, no repair):**
  - Feedback disposition: snowykr’s ownerless string-content finding is a false positive for supported producers. All three production bindings delegate to metadata-only `AgentSession.invokeSkill`; a real producer probe confirmed object returns. Base/head ownerless frames match. Fresh host/reconciliation tests: 125 pass, package check exit 0. No code repair; maintainer review state remains unchanged.
  - Test narrows a result with a cast to assert `content` is absent; `not.toHaveProperty("content")` would avoid the cast.
  - The why-comment in `bus/index.ts` is seven lines where the plan asked for two; content is load-bearing, length is a taste call.
  - `promptOwned` is `requesterConnectionId !== undefined` while `recordPromptAccepted` skips registration for any falsy id; an empty-string connection id has no known transport path and the same exposure exists for prompts on base.
  - Ownerless acceptance has no behavioral oracle in base or candidate; accepted by the plan as Not-tested.
- Linked: fixes #5539; related #3957 / #4101 (unified results, closed), #5104 (merged, tail authority), #5526 (open, ACP consumer-side recovery), #4743 (adapted tests).
- State: open, **unmerged**; no self-approval. Independent maintainer review requested.

## Risk classification

<!-- Classify honestly; exactly one box must be checked — the exact-head gate fails closed on zero or multiple. The checked class selects the merge path (issue #4703). -->

- [ ] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [x] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

Classified `regression-risk` because the change alters terminal ownership of durable SDK skill results and corrects a failure-path status value; the public schema is unchanged and the diff is nine lines of product code.

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:2af3eeb02674d4ffcfa6f0b59fe19acff5901aa80466e5207fdf0a7809e43b02 reviewer:human reviewer-id:probepark evidence:exact-head-571db6d-APPROVED-by-probepark(write)-https://github.com/Yeachan-Heo/gajae-code/pull/5540#pullrequestreview-5231814863;second-independent-exact-head-APPROVED-by-snowykr(write)-pullrequestreview-5232010827;digest-recomputed-local-ace8c7c...571db6d=2af3eeb0;prior-needs-human-was-stale-reviews-api-binds-both-approvals-to-current-head
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes (package-level `bun --cwd=packages/coding-agent run check` exit 0; root `bun run check` not run under scoped policy)
- [x] Tested locally
- [x] Changelog fragment added under `packages/<pkg>/changelog.d/` (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken

🤖 Generated with [Claude Code](https://claude.com/claude-code)





